### PR TITLE
Improve portability of beatmap helpers and serialization functions

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -158,8 +158,6 @@ data.addBasicEvents(...events);
 > const wrapped = Beatmap.createOne(data); // returns `Beatmap`
 > data.addColorNotes({ time: 0 }); // now works!
 > ```
->
-> In addition, all helper methods should work with both wrapper attribute and wrapper class forms.
 
 ### Cloning
 

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -57,10 +57,9 @@ and difficulty file.
 ```ts
 const info = readInfoFileSync(); // not required
 
-// undefined version, return base wrapper class
+// undefined version, return base wrapper attribute
 // can be either version 1, 2, 3 or 4
 // pass it to isV4 or similar function for type predicate
-// or use `instanceof` operator
 const data = readDifficultyFileSync('HardStandard.dat');
 
 // explicit version, return (and convert to) difficulty version
@@ -81,7 +80,7 @@ await writeDifficultyFile(data2, {
 }); // advanced use
 ```
 
-Difficulty filename is saved directly in beatmap class, as with info, lightshow, and any other
+Difficulty filename is saved directly in beatmap attribute, as with info, lightshow, and any other
 writable object, and can be changed.
 
 ```ts
@@ -108,9 +107,10 @@ globals.directory = './YOUR/MAP/FOLDER/PATH/';
 
 ## Beatmap Object
 
-All beatmap object is a class object as opposed to regular JSON object. This mean most array and
-object will only accept class object. This enables extensive method and functionality to be used
-directly from class object. Custom data is always available and require no checking if exist.
+All beatmap objects have class implementations as an alternative to using the regular JSON
+attributes. While not required to use the engine or its associated helpers, they allow various
+methods to be called directly from the class object as opposed to a standalone function. Custom data
+is always available and require no checking if exist.
 
 ### Creation
 
@@ -142,6 +142,24 @@ into an array. This creates a new object instead of reusing existing object.
 data.addBasicEvents({ time: 2, type: 1, value: 3 }, {});
 data.addBasicEvents(...events);
 ```
+
+> [!WARNING]
+>
+> All loader/saver functions and schema containers will return serializable attributes by default as
+> opposed to the full wrapper class implementation.
+>
+> If you'd prefer to use the class implementations, you'll need to wrap the result with the
+> corresponding class constructor or the static `createOne` method.
+>
+> ```ts
+> const data = loadDifficulty({ _version: '2.6.0' }); // returns `IWrapBeatmapAttribute`
+> data.addColorNotes({ time: 0 }); // will error, since methods doesn't exist on attribute form
+>
+> const wrapped = Beatmap.createOne(data); // returns `Beatmap`
+> data.addColorNotes({ time: 0 }); // now works!
+> ```
+>
+> In addition, all helper methods should work with both wrapper attribute and wrapper class forms.
 
 ### Cloning
 
@@ -306,8 +324,8 @@ behaviour (such as performance), but overall it is very easy to make this mistak
 understood what you are doing, you can ignore this.
 
 ```ts
-const lightshow = readDifficultyFileSync('Lightshow.dat', 3);
-const map = readDifficultyFileSync('ExpertStandard.dat', 3);
+const lightshow = new Beatmap(readDifficultyFileSync('Lightshow.dat', 3));
+const map = new Beatmap(readDifficultyFileSync('ExpertStandard.dat', 3));
 
 // DON'T - 1
 map.basicEvents = lightshow.basicEvents;

--- a/src/beatmap/converter/lightGradient.ts
+++ b/src/beatmap/converter/lightGradient.ts
@@ -1,6 +1,5 @@
 import { logger } from '../../logger.ts';
 import type { IChromaLightGradient } from '../../types/beatmap/v2/custom/chroma.ts';
-import type { IWrapBasicEventAttribute } from '../../types/beatmap/wrapper/basicEvent.ts';
 import type { IWrapBeatmapAttributeSubset } from '../../types/beatmap/wrapper/beatmap.ts';
 import type { Easings } from '../../types/easings.ts';
 import { lerpColor } from '../../utils/colors.ts';
@@ -36,11 +35,11 @@ export function chromaLightGradientToVanillaGradient<
    );
 
    const events = data.lightshow.basicEvents;
-   const newEvents: IWrapBasicEventAttribute[] = [];
+   const newEvents: T['lightshow']['basicEvents'] = [];
    for (let curr = 0, len = events.length; curr < len; curr++) {
       const ev = events[curr];
       if (!isLightEventType(ev.type)) {
-         newEvents.push(ev);
+         newEvents.push({ ...ev, floatValue: 1 });
          continue;
       }
       if (isLightGradient(ev.customData._lightGradient)) {
@@ -65,7 +64,7 @@ export function chromaLightGradientToVanillaGradient<
                   'easeLinear'
             ];
             let hasOff = false;
-            let previousEvent: IWrapBasicEventAttribute = ev;
+            let previousEvent: T['lightshow']['basicEvents'][number] = ev;
             for (const eig of eventInGradient) {
                if (
                   !hasOff &&

--- a/src/beatmap/converter/lightGradient.ts
+++ b/src/beatmap/converter/lightGradient.ts
@@ -1,12 +1,12 @@
 import { logger } from '../../logger.ts';
-import { EasingsFn } from '../../utils/easings.ts';
-import { lerpColor } from '../../utils/colors.ts';
-import { normalize } from '../../utils/math.ts';
-import type { IWrapBeatmap } from '../../types/beatmap/wrapper/beatmap.ts';
 import type { IChromaLightGradient } from '../../types/beatmap/v2/custom/chroma.ts';
-import type { IWrapBasicEvent } from '../../types/beatmap/wrapper/basicEvent.ts';
+import type { IWrapBasicEventAttribute } from '../../types/beatmap/wrapper/basicEvent.ts';
+import type { IWrapBeatmapAttributeSubset } from '../../types/beatmap/wrapper/beatmap.ts';
 import type { Easings } from '../../types/easings.ts';
-import { BasicEvent } from '../core/basicEvent.ts';
+import { lerpColor } from '../../utils/colors.ts';
+import { EasingsFn } from '../../utils/easings.ts';
+import { normalize } from '../../utils/math.ts';
+import { isLightEventType } from '../helpers/core/basicEvent.ts';
 
 function tag(name: string): string[] {
    return ['convert', name];
@@ -27,19 +27,19 @@ function isLightGradient(obj: unknown): obj is IChromaLightGradient {
  * const newData = convert.V2ogChromaToChroma(oldData);
  * ```
  */
-export function chromaLightGradientToVanillaGradient<T extends IWrapBeatmap>(
-   data: T,
-): T {
+export function chromaLightGradientToVanillaGradient<
+   T extends IWrapBeatmapAttributeSubset<'basicEvents'>,
+>(data: T): T {
    logger.tWarn(
       tag('chromaLightGradientToVanillaGradient'),
       'Converting chroma light gradient is not fully tested and may break certain lightshow effect!',
    );
 
-   const events = data.basicEvents;
-   const newEvents: typeof data.basicEvents = [];
+   const events = data.lightshow.basicEvents;
+   const newEvents: IWrapBasicEventAttribute[] = [];
    for (let curr = 0, len = events.length; curr < len; curr++) {
       const ev = events[curr];
-      if (!ev.isLightEvent()) {
+      if (!isLightEventType(ev.type)) {
          newEvents.push(ev);
          continue;
       }
@@ -65,30 +65,28 @@ export function chromaLightGradientToVanillaGradient<T extends IWrapBeatmap>(
                   'easeLinear'
             ];
             let hasOff = false;
-            let previousEvent: IWrapBasicEvent = ev;
+            let previousEvent: IWrapBasicEventAttribute = ev;
             for (const eig of eventInGradient) {
                if (
                   !hasOff &&
                   eig.time >
                      ev.time + ev.customData._lightGradient._duration - 0.001
                ) {
-                  newEvents.push(
-                     new BasicEvent({
-                        time: ev.time +
-                           ev.customData._lightGradient._duration -
-                           0.001,
-                        type: ev.type,
-                        value: ev.value >= 1 && ev.value <= 4
-                           ? 4
-                           : ev.value >= 5 && ev.value <= 8
-                           ? 8
-                           : 12,
-                        floatValue: 1,
-                        customData: {
-                           _color: ev.customData._lightGradient._endColor,
-                        },
-                     }),
-                  );
+                  newEvents.push({
+                     time: ev.time +
+                        ev.customData._lightGradient._duration -
+                        0.001,
+                     type: ev.type,
+                     value: ev.value >= 1 && ev.value <= 4
+                        ? 4
+                        : ev.value >= 5 && ev.value <= 8
+                        ? 8
+                        : 12,
+                     floatValue: 1,
+                     customData: {
+                        _color: ev.customData._lightGradient._endColor,
+                     },
+                  });
                } else {
                   eig.value = hasOff
                      ? eig.value >= 1 && eig.value <= 4
@@ -114,38 +112,36 @@ export function chromaLightGradientToVanillaGradient<T extends IWrapBeatmap>(
                      'rgba',
                   );
                   if (eig.value === 0) {
-                     eig.removeCustomData('_color');
+                     if (eig.customData['_color']) delete eig.customData['_color'];
                      if (!hasOff) {
-                        newEvents.push(
-                           new BasicEvent({
-                              time: eig.time - 0.001,
-                              type: ev.type,
-                              value: previousEvent.value >= 1 &&
-                                    previousEvent.value <= 4
-                                 ? 4
-                                 : previousEvent.value >= 5 &&
-                                       previousEvent.value <= 8
-                                 ? 8
-                                 : 12,
-                              floatValue: 1,
-                              customData: {
-                                 _color: lerpColor(
-                                    ev.customData._lightGradient._startColor,
-                                    ev.customData._lightGradient._endColor,
-                                    easing(
-                                       normalize(
-                                          eig.time - 0.001,
-                                          ev.time,
-                                          ev.time +
-                                             ev.customData._lightGradient
-                                                ._duration,
-                                       ),
+                        newEvents.push({
+                           time: eig.time - 0.001,
+                           type: ev.type,
+                           value: previousEvent.value >= 1 &&
+                                 previousEvent.value <= 4
+                              ? 4
+                              : previousEvent.value >= 5 &&
+                                    previousEvent.value <= 8
+                              ? 8
+                              : 12,
+                           floatValue: 1,
+                           customData: {
+                              _color: lerpColor(
+                                 ev.customData._lightGradient._startColor,
+                                 ev.customData._lightGradient._endColor,
+                                 easing(
+                                    normalize(
+                                       eig.time - 0.001,
+                                       ev.time,
+                                       ev.time +
+                                          ev.customData._lightGradient
+                                             ._duration,
                                     ),
-                                    'rgba',
                                  ),
-                              },
-                           }),
-                        );
+                                 'rgba',
+                              ),
+                           },
+                        });
                      }
                      hasOff = true;
                   } else {
@@ -154,31 +150,25 @@ export function chromaLightGradientToVanillaGradient<T extends IWrapBeatmap>(
                }
                previousEvent = eig;
             }
-            ev.removeCustomData('_lightGradient');
+            if (ev.customData['_lightGradient']) delete ev.customData['_lightGradient'];
          } else {
             ev.customData._color = ev.customData._lightGradient._startColor;
             ev.customData._easing = ev.customData._lightGradient._easing;
             ev.value = ev.value >= 1 && ev.value <= 4 ? 1 : ev.value >= 5 && ev.value <= 8 ? 5 : 9;
-            newEvents.push(
-               new BasicEvent({
-                  time: ev.time + ev.customData._lightGradient._duration,
-                  type: ev.type,
-                  value: ev.value >= 1 && ev.value <= 4
-                     ? 4
-                     : ev.value >= 5 && ev.value <= 8
-                     ? 8
-                     : 12,
-                  floatValue: 1,
-                  customData: {
-                     _color: ev.customData._lightGradient._endColor,
-                  },
-               }),
-            );
-            ev.removeCustomData('_lightGradient');
+            newEvents.push({
+               time: ev.time + ev.customData._lightGradient._duration,
+               type: ev.type,
+               value: ev.value >= 1 && ev.value <= 4 ? 4 : ev.value >= 5 && ev.value <= 8 ? 8 : 12,
+               floatValue: 1,
+               customData: {
+                  _color: ev.customData._lightGradient._endColor,
+               },
+            });
+            if (ev.customData['_lightGradient']) delete ev.customData['_lightGradient'];
          }
       }
       newEvents.push(ev);
    }
-   data.basicEvents = newEvents;
+   data.lightshow.basicEvents = newEvents;
    return data;
 }

--- a/src/beatmap/converter/oldChroma.ts
+++ b/src/beatmap/converter/oldChroma.ts
@@ -1,9 +1,9 @@
 import { logger } from '../../logger.ts';
+import type { EnvironmentAllName } from '../../types/beatmap/shared/environment.ts';
+import type { IWrapBasicEventAttribute } from '../../types/beatmap/wrapper/basicEvent.ts';
+import type { IWrapBeatmapAttributeSubset } from '../../types/beatmap/wrapper/beatmap.ts';
 import type { ColorArray } from '../../types/colors.ts';
 import { ColorScheme, EnvironmentSchemeName } from '../shared/colorScheme.ts';
-import type { EnvironmentAllName } from '../../types/beatmap/shared/environment.ts';
-import type { IWrapBeatmap } from '../../types/beatmap/wrapper/beatmap.ts';
-import type { IWrapBasicEvent } from '../../types/beatmap/wrapper/basicEvent.ts';
 
 function tag(name: string): string[] {
    return ['convert', name];
@@ -15,16 +15,15 @@ function tag(name: string): string[] {
  * const newData = convert.ogChromaToV2Chroma(oldData);
  * ```
  */
-export function ogChromaToV2Chroma<T extends IWrapBeatmap>(
-   data: T,
-   environment: EnvironmentAllName = 'DefaultEnvironment',
-): T {
+export function ogChromaToV2Chroma<
+   T extends IWrapBeatmapAttributeSubset<'basicEvents'>,
+>(data: T, environment: EnvironmentAllName = 'DefaultEnvironment'): T {
    logger.tInfo(
       tag('ogChromaToV2Chroma'),
       'Converting old Chroma event value to Chroma event customData',
    );
-   const events: IWrapBasicEvent[] = data.basicEvents;
-   const newEvents: IWrapBasicEvent[] = [];
+   const events: IWrapBasicEventAttribute[] = data.lightshow.basicEvents;
+   const newEvents: IWrapBasicEventAttribute[] = [];
    const colorScheme = ColorScheme[EnvironmentSchemeName[environment]];
    const defaultLeftLight: ColorArray = [
       colorScheme._envColorLeft!.r,
@@ -75,7 +74,7 @@ export function ogChromaToV2Chroma<T extends IWrapBeatmap>(
          }
       }
    }
-   data.basicEvents = newEvents;
+   data.lightshow.basicEvents = newEvents;
 
    return data;
 }

--- a/src/beatmap/converter/oldChroma.ts
+++ b/src/beatmap/converter/oldChroma.ts
@@ -1,6 +1,5 @@
 import { logger } from '../../logger.ts';
 import type { EnvironmentAllName } from '../../types/beatmap/shared/environment.ts';
-import type { IWrapBasicEventAttribute } from '../../types/beatmap/wrapper/basicEvent.ts';
 import type { IWrapBeatmapAttributeSubset } from '../../types/beatmap/wrapper/beatmap.ts';
 import type { ColorArray } from '../../types/colors.ts';
 import { ColorScheme, EnvironmentSchemeName } from '../shared/colorScheme.ts';
@@ -16,14 +15,14 @@ function tag(name: string): string[] {
  * ```
  */
 export function ogChromaToV2Chroma<
-   T extends IWrapBeatmapAttributeSubset<'basicEvents'>,
+   T extends IWrapBeatmapAttributeSubset<'basicEvents', 'type' | 'value' | 'customData'>,
 >(data: T, environment: EnvironmentAllName = 'DefaultEnvironment'): T {
    logger.tInfo(
       tag('ogChromaToV2Chroma'),
       'Converting old Chroma event value to Chroma event customData',
    );
-   const events: IWrapBasicEventAttribute[] = data.lightshow.basicEvents;
-   const newEvents: IWrapBasicEventAttribute[] = [];
+   const events: T['lightshow']['basicEvents'] = data.lightshow.basicEvents;
+   const newEvents: T['lightshow']['basicEvents'] = [];
    const colorScheme = ColorScheme[EnvironmentSchemeName[environment]];
    const defaultLeftLight: ColorArray = [
       colorScheme._envColorLeft!.r,

--- a/src/beatmap/converter/toV1/info.ts
+++ b/src/beatmap/converter/toV1/info.ts
@@ -1,6 +1,6 @@
 import { logger } from '../../../logger.ts';
 import type { EnvironmentName } from '../../../types/beatmap/shared/environment.ts';
-import type { IWrapInfo } from '../../../types/beatmap/wrapper/info.ts';
+import type { IWrapInfoAttribute } from '../../../types/beatmap/wrapper/info.ts';
 import { is360Environment } from '../../helpers/environment.ts';
 
 function tag(name: string): string[] {
@@ -15,7 +15,7 @@ function tag(name: string): string[] {
  *
  * **WARNING:** Guess you should know this legacy version does not have modern features.
  */
-export function toV1Info<T extends IWrapInfo>(
+export function toV1Info<T extends IWrapInfoAttribute>(
    data: T,
    fromVersion = data.version,
 ): T {

--- a/src/beatmap/converter/toV2/audioData.ts
+++ b/src/beatmap/converter/toV2/audioData.ts
@@ -1,5 +1,5 @@
 import { logger } from '../../../logger.ts';
-import type { IWrapAudioData } from '../../../types/beatmap/wrapper/audioData.ts';
+import type { IWrapAudioDataAttribute } from '../../../types/beatmap/wrapper/audioData.ts';
 
 function tag(name: string): string[] {
    return ['convert', 'toV2Audio', name];
@@ -13,7 +13,10 @@ function tag(name: string): string[] {
  *
  * **WARNING:** Chain and other new stuff will be gone!
  */
-export function toV2AudioData<T extends IWrapAudioData>(data: T, fromVersion = data.version): T {
+export function toV2AudioData<T extends IWrapAudioDataAttribute>(
+   data: T,
+   fromVersion = data.version,
+): T {
    logger.tWarn(tag('main'), 'Converting to beatmap v2 may lose certain data!');
 
    switch (fromVersion) {

--- a/src/beatmap/converter/toV2/info.ts
+++ b/src/beatmap/converter/toV2/info.ts
@@ -3,7 +3,7 @@ import type {
    Environment360Name,
    EnvironmentName,
 } from '../../../types/beatmap/shared/environment.ts';
-import type { IWrapInfo } from '../../../types/beatmap/wrapper/info.ts';
+import type { IWrapInfoAttribute } from '../../../types/beatmap/wrapper/info.ts';
 import { is360Environment } from '../../helpers/environment.ts';
 
 function tag(name: string): string[] {
@@ -18,7 +18,7 @@ function tag(name: string): string[] {
  *
  * **WARNING:** Chain and other new stuff will be gone!
  */
-export function toV2Info<T extends IWrapInfo>(
+export function toV2Info<T extends IWrapInfoAttribute>(
    data: T,
    fromVersion = data.version,
 ): T {

--- a/src/beatmap/converter/toV4/audioData.ts
+++ b/src/beatmap/converter/toV4/audioData.ts
@@ -1,5 +1,5 @@
 import { logger } from '../../../logger.ts';
-import type { IWrapAudioData } from '../../../types/beatmap/wrapper/audioData.ts';
+import type { IWrapAudioDataAttribute } from '../../../types/beatmap/wrapper/audioData.ts';
 
 function tag(name: string): string[] {
    return ['convert', 'toV4Audio', name];
@@ -13,7 +13,10 @@ function tag(name: string): string[] {
  *
  * **WARNING:** Custom data may be lost on conversion, as well as other incompatible attributes.
  */
-export function toV4AudioData<T extends IWrapAudioData>(data: T, fromVersion = data.version): T {
+export function toV4AudioData<T extends IWrapAudioDataAttribute>(
+   data: T,
+   fromVersion = data.version,
+): T {
    logger.tWarn(tag('main'), 'Converting to beatmap v4 may lose certain data!');
 
    switch (fromVersion) {

--- a/src/beatmap/converter/toV4/beatmap.ts
+++ b/src/beatmap/converter/toV4/beatmap.ts
@@ -1,6 +1,5 @@
 import { logger } from '../../../logger.ts';
-import type { IWrapBeatmap } from '../../../types/beatmap/wrapper/beatmap.ts';
-import { BaseSlider } from '../../core/abstract/baseSlider.ts';
+import type { IWrapBeatmapAttribute } from '../../../types/beatmap/wrapper/beatmap.ts';
 import { sortObjectFn } from '../../helpers/sort.ts';
 import { ExecutionTime } from '../../shared/constants.ts';
 import { toV3Beatmap } from '../toV3/beatmap.ts';
@@ -17,7 +16,7 @@ function tag(name: string): string[] {
  *
  * **WARNING:** Custom data may be lost on conversion, as well as other incompatible attributes.
  */
-export function toV4Beatmap<T extends IWrapBeatmap>(
+export function toV4Beatmap<T extends IWrapBeatmapAttribute>(
    data: T,
    fromVersion = data.version,
 ): T {
@@ -29,18 +28,18 @@ export function toV4Beatmap<T extends IWrapBeatmap>(
    data.version = 4;
 
    const objects = [
-      data.arcs,
-      data.bombNotes,
-      data.chains,
-      data.colorNotes,
-      data.obstacles,
-      data.waypoints,
+      data.difficulty.arcs,
+      data.difficulty.bombNotes,
+      data.difficulty.chains,
+      data.difficulty.colorNotes,
+      data.difficulty.obstacles,
+      data.lightshow.waypoints,
    ]
       .flat()
       .sort(sortObjectFn);
 
-   if (data.rotationEvents.length) {
-      const rotations = [...data.rotationEvents]
+   if (data.difficulty.rotationEvents.length) {
+      const rotations = [...data.difficulty.rotationEvents]
          .sort((a, b) => a.executionTime - b.executionTime)
          .sort(sortObjectFn);
 
@@ -64,7 +63,7 @@ export function toV4Beatmap<T extends IWrapBeatmap>(
             evt.executionTime === ExecutionTime.EARLY
          ) {
             obj.laneRotation = Math.round(calculatedRotations % 360);
-            if (obj instanceof BaseSlider) {
+            if ('tailLaneRotation' in obj) {
                obj.tailLaneRotation = obj.laneRotation;
             }
             continue;
@@ -77,19 +76,19 @@ export function toV4Beatmap<T extends IWrapBeatmap>(
          }
          if (!evt) break;
          obj.laneRotation = Math.round(calculatedRotations % 360);
-         if (obj instanceof BaseSlider) {
+         if ('tailLaneRotation' in obj) {
             obj.tailLaneRotation = obj.laneRotation;
          }
       }
 
-      data.rotationEvents = [];
+      data.difficulty.rotationEvents = [];
    }
 
    for (let i = 0; i < objects.length; i++) {
       const obj = objects[i];
       if (typeof obj.customData.worldRotation === 'number') {
          obj.laneRotation = Math.round(obj.customData.worldRotation);
-         if (obj instanceof BaseSlider) {
+         if ('tailLaneRotation' in obj) {
             obj.tailLaneRotation = obj.customData.worldRotation;
          }
          delete obj.customData.worldRotation;

--- a/src/beatmap/converter/toV4/info.ts
+++ b/src/beatmap/converter/toV4/info.ts
@@ -1,5 +1,5 @@
 import { logger } from '../../../logger.ts';
-import type { IWrapInfo } from '../../../types/beatmap/wrapper/info.ts';
+import type { IWrapInfoAttribute } from '../../../types/beatmap/wrapper/info.ts';
 
 function tag(name: string): string[] {
    return ['convert', 'toV4Info', name];
@@ -13,7 +13,7 @@ function tag(name: string): string[] {
  *
  * **WARNING:** Custom data may be lost on conversion, as well as other incompatible attributes.
  */
-export function toV4Info<T extends IWrapInfo>(
+export function toV4Info<T extends IWrapInfoAttribute>(
    data: T,
    fromVersion = data.version,
 ): T {

--- a/src/beatmap/core/abstract/baseSlider.ts
+++ b/src/beatmap/core/abstract/baseSlider.ts
@@ -1,8 +1,11 @@
-import { LINE_COUNT } from '../../shared/constants.ts';
-import type { IWrapBaseSlider } from '../../../types/beatmap/wrapper/baseSlider.ts';
-import { BaseNote } from './baseNote.ts';
-import type { Vector2 } from '../../../types/vector.ts';
 import type { GetPositionFn, MirrorFn } from '../../../types/beatmap/shared/functions.ts';
+import type { IWrapBaseSlider } from '../../../types/beatmap/wrapper/baseSlider.ts';
+import type { Vector2 } from '../../../types/vector.ts';
+import { vectorAdd } from '../../../utils/vector.ts';
+import { isInverseSlider } from '../../helpers/core/baseSlider.ts';
+import { mirrorCoordinate, resolveGridPosition } from '../../helpers/core/gridObject.ts';
+import { LINE_COUNT } from '../../shared/constants.ts';
+import { BaseNote } from './baseNote.ts';
 
 /**
  * Base slider beatmap object.
@@ -34,15 +37,16 @@ export abstract class BaseSlider extends BaseNote implements IWrapBaseSlider {
 
    override mirror(flipColor = true, fn?: MirrorFn<this>): this {
       fn?.(this);
-      this.tailPosX = LINE_COUNT - 1 - this.tailPosX;
+      this.tailPosX = mirrorCoordinate(this.tailPosX, LINE_COUNT);
       return super.mirror(flipColor);
    }
 
    getTailPosition(fn?: GetPositionFn<this>): Vector2 {
-      return fn?.(this) ?? [this.tailPosX - 2, this.tailPosY];
+      return fn?.(this) ??
+         vectorAdd(resolveGridPosition({ posX: this.tailPosX, posY: this.tailPosY }), [-2]);
    }
 
    isInverse(): boolean {
-      return this.time > this.tailTime;
+      return isInverseSlider(this);
    }
 }

--- a/src/beatmap/core/arc.ts
+++ b/src/beatmap/core/arc.ts
@@ -1,31 +1,38 @@
 import type { GetAngleFn, MirrorFn } from '../../types/beatmap/shared/functions.ts';
 import type { IWrapArc, IWrapArcAttribute } from '../../types/beatmap/wrapper/arc.ts';
+import type { DeepPartial } from '../../types/utils.ts';
 import { deepCopy } from '../../utils/misc.ts';
 import { mirrorArcMidAnchor } from '../helpers/core/arc.ts';
 import { mirrorNoteDirectionHorizontally, resolveNoteAngle } from '../helpers/core/baseNote.ts';
 import { BaseSlider } from './abstract/baseSlider.ts';
 
+export function createArc(
+   data: DeepPartial<IWrapArcAttribute> = {},
+): IWrapArcAttribute {
+   return {
+      time: data.time ?? 0,
+      posX: data.posX ?? 0,
+      posY: data.posY ?? 0,
+      color: data.color ?? 0,
+      direction: data.direction ?? 0,
+      lengthMultiplier: data.lengthMultiplier ?? 0,
+      tailTime: data.tailTime ?? 0,
+      tailPosX: data.tailPosX ?? 0,
+      tailPosY: data.tailPosY ?? 0,
+      tailDirection: data.tailDirection ?? 0,
+      tailLengthMultiplier: data.tailLengthMultiplier ?? 0,
+      midAnchor: data.midAnchor ?? 0,
+      laneRotation: data.laneRotation ?? 0,
+      tailLaneRotation: data.tailLaneRotation ?? 0,
+      customData: deepCopy(data.customData ?? {}),
+   };
+}
+
 /**
  * Core beatmap arc.
  */
 export class Arc extends BaseSlider implements IWrapArc {
-   static defaultValue: IWrapArcAttribute = {
-      time: 0,
-      posX: 0,
-      posY: 0,
-      color: 0,
-      direction: 0,
-      lengthMultiplier: 0,
-      tailTime: 0,
-      tailPosX: 0,
-      tailPosY: 0,
-      tailDirection: 0,
-      tailLengthMultiplier: 0,
-      midAnchor: 0,
-      laneRotation: 0,
-      tailLaneRotation: 0,
-      customData: {},
-   };
+   static defaultValue: IWrapArcAttribute = createArc();
 
    static createOne(data: Partial<IWrapArcAttribute> = {}): Arc {
       return new this(data);

--- a/src/beatmap/core/arc.ts
+++ b/src/beatmap/core/arc.ts
@@ -1,8 +1,9 @@
-import { BaseSlider } from './abstract/baseSlider.ts';
-import { NoteDirectionAngle } from '../shared/constants.ts';
+import type { GetAngleFn, MirrorFn } from '../../types/beatmap/shared/functions.ts';
 import type { IWrapArc, IWrapArcAttribute } from '../../types/beatmap/wrapper/arc.ts';
 import { deepCopy } from '../../utils/misc.ts';
-import type { GetAngleFn, MirrorFn } from '../../types/beatmap/shared/functions.ts';
+import { mirrorArcMidAnchor } from '../helpers/core/arc.ts';
+import { mirrorNoteDirectionHorizontally, resolveNoteAngle } from '../helpers/core/baseNote.ts';
+import { BaseSlider } from './abstract/baseSlider.ts';
 
 /**
  * Core beatmap arc.
@@ -90,37 +91,12 @@ export class Arc extends BaseSlider implements IWrapArc {
 
    override mirror(flipColor = true, fn?: MirrorFn<this>): this {
       fn?.(this);
-      switch (this.tailDirection) {
-         case 2:
-            this.tailDirection = 3;
-            break;
-         case 3:
-            this.tailDirection = 2;
-            break;
-         case 6:
-            this.tailDirection = 7;
-            break;
-         case 7:
-            this.tailDirection = 6;
-            break;
-         case 4:
-            this.tailDirection = 5;
-            break;
-         case 5:
-            this.tailDirection = 4;
-            break;
-      }
-      if (this.midAnchor) {
-         this.midAnchor = this.midAnchor === 1 ? 2 : 1;
-      }
+      this.tailDirection = mirrorNoteDirectionHorizontally(this.direction);
+      this.midAnchor = mirrorArcMidAnchor(this.midAnchor);
       return super.mirror(flipColor);
    }
 
    getTailAngle(fn?: GetAngleFn<this>): number {
-      return (
-         fn?.(this) ||
-         NoteDirectionAngle[this.tailDirection as keyof typeof NoteDirectionAngle] ||
-         0
-      );
+      return fn?.(this) || resolveNoteAngle(this.tailDirection);
    }
 }

--- a/src/beatmap/core/audioData.ts
+++ b/src/beatmap/core/audioData.ts
@@ -6,9 +6,33 @@ import type {
    IWrapAudioDataLUFS,
 } from '../../types/beatmap/wrapper/audioData.ts';
 import type { IWrapBPMEventAttribute } from '../../types/beatmap/wrapper/bpmEvent.ts';
-import type { DeepPartialIgnore, LooseAutocomplete } from '../../types/utils.ts';
+import type { DeepPartial, DeepPartialIgnore, LooseAutocomplete } from '../../types/utils.ts';
 import { deepCopy } from '../../utils/misc.ts';
 import { BaseItem } from './abstract/baseItem.ts';
+
+export function createAudioData(
+   data: DeepPartial<IWrapAudioDataAttribute> = {},
+): IWrapAudioDataAttribute {
+   return {
+      version: data.version ?? -1,
+      filename: data.filename ?? 'AudioData.dat',
+      audioChecksum: data.audioChecksum ?? '',
+      sampleCount: data.sampleCount ?? 44100,
+      frequency: data.frequency ?? 0,
+      bpmData: data.bpmData?.map((e) => ({
+         startSampleIndex: e.startSampleIndex ?? 0,
+         endSampleIndex: e.endSampleIndex ?? 0,
+         startBeat: e.startBeat ?? 0,
+         endBeat: e.endBeat ?? 0,
+      })) ?? [],
+      lufsData: data.lufsData?.map((e) => ({
+         startSampleIndex: e.startSampleIndex ?? 0,
+         endSampleIndex: e.endSampleIndex ?? 0,
+         lufs: e.lufs ?? 0,
+      })) ?? [],
+      customData: deepCopy({ ...data.customData }),
+   };
+}
 
 /**
  * Core beatmap audio data.
@@ -16,16 +40,7 @@ import { BaseItem } from './abstract/baseItem.ts';
  * This object is writable into file.
  */
 export class AudioData extends BaseItem implements IWrapAudioData {
-   static defaultValue: IWrapAudioDataAttribute = {
-      version: -1,
-      filename: 'AudioData.dat',
-      audioChecksum: '',
-      sampleCount: 44100,
-      frequency: 0,
-      bpmData: [],
-      lufsData: [],
-      customData: {},
-   };
+   static defaultValue: IWrapAudioDataAttribute = createAudioData();
 
    static createOne(data: Partial<IWrapAudioDataAttribute> = {}): AudioData {
       return new this(data);

--- a/src/beatmap/core/basicEvent.ts
+++ b/src/beatmap/core/basicEvent.ts
@@ -3,6 +3,7 @@ import type {
    IWrapBasicEvent,
    IWrapBasicEventAttribute,
 } from '../../types/beatmap/wrapper/basicEvent.ts';
+import type { DeepPartial } from '../../types/utils.ts';
 import { deepCopy } from '../../utils/misc.ts';
 import {
    isBlueEventValue,
@@ -28,17 +29,23 @@ import {
 } from '../helpers/core/basicEvent.ts';
 import { BaseObject } from './abstract/baseObject.ts';
 
+export function createBasicEvent(
+   data: DeepPartial<IWrapBasicEventAttribute> = {},
+): IWrapBasicEventAttribute {
+   return {
+      time: data.time ?? 0,
+      type: data.type ?? 0,
+      value: data.value ?? 0,
+      floatValue: data.floatValue ?? 0,
+      customData: deepCopy({ ...data.customData }),
+   };
+}
+
 /**
  * Core beatmap basic event.
  */
 export class BasicEvent extends BaseObject implements IWrapBasicEvent {
-   static defaultValue: Required<IWrapBasicEventAttribute> = {
-      time: 0,
-      type: 0,
-      value: 0,
-      floatValue: 0,
-      customData: {},
-   };
+   static defaultValue = createBasicEvent();
 
    static createOne(data: Partial<IWrapBasicEventAttribute> = {}): BasicEvent {
       return new this(data);

--- a/src/beatmap/core/basicEvent.ts
+++ b/src/beatmap/core/basicEvent.ts
@@ -1,11 +1,32 @@
-import { BaseObject } from './abstract/baseObject.ts';
+import type { EnvironmentAllName } from '../../types/beatmap/shared/environment.ts';
 import type {
    IWrapBasicEvent,
    IWrapBasicEventAttribute,
 } from '../../types/beatmap/wrapper/basicEvent.ts';
-import { EventType } from '../shared/constants.ts';
-import { EventLightValue } from '../shared/constants.ts';
 import { deepCopy } from '../../utils/misc.ts';
+import {
+   isBlueEventValue,
+   isBpmChangeEventType,
+   isColorBoostEventType,
+   isExtraEventType,
+   isFadeEventValue,
+   isFlashEventValue,
+   isLaneRotationEventType,
+   isLaserRotationEventType,
+   isLightEventType,
+   isLightingEventType,
+   isNjsChangeEventType,
+   isOffEventValue,
+   isOldChromaEventValue,
+   isOnEventValue,
+   isRedEventValue,
+   isRingEventType,
+   isSpecialEventType,
+   isTransitionEventValue,
+   isValidEventType,
+   isWhiteEventValue,
+} from '../helpers/core/basicEvent.ts';
+import { BaseObject } from './abstract/baseObject.ts';
 
 /**
  * Core beatmap basic event.
@@ -35,11 +56,7 @@ export class BasicEvent extends BaseObject implements IWrapBasicEvent {
    }
 
    isValidType(): boolean {
-      return (
-         (this.type >= 0 && this.type <= 19) ||
-         (this.type >= 40 && this.type <= 43) ||
-         this.type === 100
-      );
+      return isValidEventType(this.type);
    }
 
    override isValid(fn?: (object: this) => boolean, override?: boolean): boolean {
@@ -67,118 +84,61 @@ export class BasicEvent extends BaseObject implements IWrapBasicEvent {
    }
 
    isOff(): boolean {
-      return this.value === EventLightValue.OFF;
+      return isOffEventValue(this.value);
    }
    isOn(): boolean {
-      return (
-         this.value === EventLightValue.BLUE_ON ||
-         this.value === EventLightValue.RED_ON ||
-         this.value === EventLightValue.WHITE_ON
-      );
+      return isOnEventValue(this.value);
    }
    isFlash(): boolean {
-      return (
-         this.value === EventLightValue.BLUE_FLASH ||
-         this.value === EventLightValue.RED_FLASH ||
-         this.value === EventLightValue.WHITE_FLASH
-      );
+      return isFlashEventValue(this.value);
    }
    isFade(): boolean {
-      return (
-         this.value === EventLightValue.BLUE_FADE ||
-         this.value === EventLightValue.RED_FADE ||
-         this.value === EventLightValue.WHITE_FADE
-      );
+      return isFadeEventValue(this.value);
    }
    isTransition(): boolean {
-      return (
-         this.value === EventLightValue.BLUE_TRANSITION ||
-         this.value === EventLightValue.RED_TRANSITION ||
-         this.value === EventLightValue.WHITE_TRANSITION
-      );
+      return isTransitionEventValue(this.value);
    }
    isBlue(): boolean {
-      return (
-         this.value === EventLightValue.BLUE_ON ||
-         this.value === EventLightValue.BLUE_FLASH ||
-         this.value === EventLightValue.BLUE_FADE ||
-         this.value === EventLightValue.BLUE_TRANSITION
-      );
+      return isBlueEventValue(this.value);
    }
    isRed(): boolean {
-      return (
-         this.value === EventLightValue.RED_ON ||
-         this.value === EventLightValue.RED_FLASH ||
-         this.value === EventLightValue.RED_FADE ||
-         this.value === EventLightValue.RED_TRANSITION
-      );
+      return isRedEventValue(this.value);
    }
    isWhite(): boolean {
-      return (
-         this.value === EventLightValue.WHITE_ON ||
-         this.value === EventLightValue.WHITE_FLASH ||
-         this.value === EventLightValue.WHITE_FADE ||
-         this.value === EventLightValue.WHITE_TRANSITION
-      );
+      return isWhiteEventValue(this.value);
    }
 
-   isLightEvent(): boolean {
-      return (
-         this.type === 0 ||
-         this.type === 1 ||
-         this.type === 2 ||
-         this.type === 3 ||
-         this.type === 4 ||
-         this.type === 6 ||
-         this.type === 7 ||
-         this.type === 10 ||
-         this.type === 11
-      );
+   isLightEvent(environment?: EnvironmentAllName): boolean {
+      return isLightEventType(this.type, environment);
    }
    isColorBoost(): boolean {
-      return this.type === EventType.COLOR_BOOST;
+      return isColorBoostEventType(this.type);
    }
-   isRingEvent(): boolean {
-      return this.type === EventType.RING_ROTATION || this.type === EventType.RING_ZOOM;
+   isRingEvent(environment?: EnvironmentAllName): boolean {
+      return isRingEventType(this.type, environment);
    }
-   isLaserRotationEvent(): boolean {
-      return (
-         this.type === EventType.LEFT_LASER_ROTATION || this.type === EventType.RIGHT_LASER_ROTATION
-      );
+   isLaserRotationEvent(environment?: EnvironmentAllName): boolean {
+      return isLaserRotationEventType(this.type, environment);
    }
    isLaneRotationEvent(): boolean {
-      return (
-         this.type === EventType.EARLY_LANE_ROTATION || this.type === EventType.LATE_LANE_ROTATION
-      );
+      return isLaneRotationEventType(this.type);
    }
-   isExtraEvent(): boolean {
-      return (
-         this.type === EventType.UTILITY_EVENT_0 ||
-         this.type === EventType.UTILITY_EVENT_1 ||
-         this.type === EventType.UTILITY_EVENT_2 ||
-         this.type === EventType.UTILITY_EVENT_3
-      );
+   isExtraEvent(environment?: EnvironmentAllName): boolean {
+      return isExtraEventType(this.type, environment);
    }
-   isSpecialEvent(): boolean {
-      return (
-         this.type === EventType.SPECIAL_EVENT_0 ||
-         this.type === EventType.SPECIAL_EVENT_1 ||
-         this.type === EventType.SPECIAL_EVENT_2 ||
-         this.type === EventType.SPECIAL_EVENT_3
-      );
+   isSpecialEvent(environment?: EnvironmentAllName): boolean {
+      return isSpecialEventType(this.type, environment);
    }
    isBpmEvent(): boolean {
-      return this.type === EventType.BPM_CHANGE;
+      return isBpmChangeEventType(this.type);
+   }
+   isNjsEvent(): boolean {
+      return isNjsChangeEventType(this.type);
    }
    isLightingEvent(): boolean {
-      return (
-         this.isLightEvent() ||
-         this.isRingEvent() ||
-         this.isLaserRotationEvent() ||
-         this.isExtraEvent()
-      );
+      return isLightingEventType(this.type);
    }
    isOldChroma(): boolean {
-      return this.value >= 2000000000;
+      return isOldChromaEventValue(this.value);
    }
 }

--- a/src/beatmap/core/basicEventTypesForKeywords.ts
+++ b/src/beatmap/core/basicEventTypesForKeywords.ts
@@ -2,20 +2,27 @@ import type {
    IWrapBasicEventTypesForKeywords,
    IWrapBasicEventTypesForKeywordsAttribute,
 } from '../../types/beatmap/wrapper/basicEventTypesForKeywords.ts';
-import type { DeepPartialIgnore } from '../../types/utils.ts';
+import type { DeepPartial, DeepPartialIgnore } from '../../types/utils.ts';
 import { deepCopy } from '../../utils/misc.ts';
 import { BaseItem } from './abstract/baseItem.ts';
+
+export function createBasicEventTypesForKeywords(
+   data: DeepPartial<IWrapBasicEventTypesForKeywordsAttribute> = {},
+): IWrapBasicEventTypesForKeywordsAttribute {
+   return {
+      keyword: data.keyword ?? '',
+      events: data.events ?? [],
+      customData: deepCopy({ ...data.customData }),
+   };
+}
 
 /**
  * Core beatmap basic event types for keywords.
  */
 export class BasicEventTypesForKeywords extends BaseItem
    implements IWrapBasicEventTypesForKeywords {
-   static defaultValue: IWrapBasicEventTypesForKeywordsAttribute = {
-      keyword: '',
-      events: [],
-      customData: {},
-   };
+   static defaultValue: IWrapBasicEventTypesForKeywordsAttribute =
+      createBasicEventTypesForKeywords();
 
    static createOne(
       data: Partial<IWrapBasicEventTypesForKeywordsAttribute> = {},

--- a/src/beatmap/core/beatmap.ts
+++ b/src/beatmap/core/beatmap.ts
@@ -1,8 +1,14 @@
 import type {
+   GenericBeatmapFilename,
+   GenericLightshowFilename,
+} from '../../types/beatmap/shared/filename.ts';
+import type { IWrapArc, IWrapArcAttribute } from '../../types/beatmap/wrapper/arc.ts';
+import type {
    IWrapBasicEvent,
    IWrapBasicEventAttribute,
 } from '../../types/beatmap/wrapper/basicEvent.ts';
 import type { IWrapBasicEventTypesWithKeywords } from '../../types/beatmap/wrapper/basicEventTypesWithKeywords.ts';
+import type { IWrapBeatmap, IWrapBeatmapAttribute } from '../../types/beatmap/wrapper/beatmap.ts';
 import type {
    IWrapBombNote,
    IWrapBombNoteAttribute,
@@ -20,6 +26,11 @@ import type {
    IWrapColorNote,
    IWrapColorNoteAttribute,
 } from '../../types/beatmap/wrapper/colorNote.ts';
+import type { IWrapDifficulty } from '../../types/beatmap/wrapper/difficulty.ts';
+import type {
+   IWrapFxEventBoxGroup,
+   IWrapFxEventBoxGroupAttribute,
+} from '../../types/beatmap/wrapper/fxEventBoxGroup.ts';
 import type {
    IWrapLightColorEventBoxGroup,
    IWrapLightColorEventBoxGroupAttribute,
@@ -28,10 +39,12 @@ import type {
    IWrapLightRotationEventBoxGroup,
    IWrapLightRotationEventBoxGroupAttribute,
 } from '../../types/beatmap/wrapper/lightRotationEventBoxGroup.ts';
+import type { IWrapLightshow } from '../../types/beatmap/wrapper/lightshow.ts';
 import type {
    IWrapLightTranslationEventBoxGroup,
    IWrapLightTranslationEventBoxGroupAttribute,
 } from '../../types/beatmap/wrapper/lightTranslationEventBoxGroup.ts';
+import type { IWrapNJSEvent } from '../../types/beatmap/wrapper/njsEvent.ts';
 import type {
    IWrapObstacle,
    IWrapObstacleAttribute,
@@ -40,27 +53,14 @@ import type {
    IWrapRotationEvent,
    IWrapRotationEventAttribute,
 } from '../../types/beatmap/wrapper/rotationEvent.ts';
-import type { IWrapArc, IWrapArcAttribute } from '../../types/beatmap/wrapper/arc.ts';
 import type {
    IWrapWaypoint,
    IWrapWaypointAttribute,
 } from '../../types/beatmap/wrapper/waypoint.ts';
-import type { DeepPartialIgnore, LooseAutocomplete } from '../../types/utils.ts';
+import type { DeepPartial, DeepPartialIgnore, LooseAutocomplete } from '../../types/utils.ts';
 import { BaseItem } from './abstract/baseItem.ts';
-import type { IWrapBeatmap, IWrapBeatmapAttribute } from '../../types/beatmap/wrapper/beatmap.ts';
-import type {
-   IWrapFxEventBoxGroup,
-   IWrapFxEventBoxGroupAttribute,
-} from '../../types/beatmap/wrapper/fxEventBoxGroup.ts';
-import type { IWrapDifficulty } from '../../types/beatmap/wrapper/difficulty.ts';
-import type { IWrapLightshow } from '../../types/beatmap/wrapper/lightshow.ts';
 import { Difficulty } from './difficulty.ts';
 import { Lightshow } from './lightshow.ts';
-import type {
-   GenericBeatmapFilename,
-   GenericLightshowFilename,
-} from '../../types/beatmap/shared/filename.ts';
-import type { IWrapNJSEvent } from '../../types/beatmap/wrapper/njsEvent.ts';
 
 /**
  * Core beatmap container.
@@ -105,7 +105,7 @@ export class Beatmap extends BaseItem implements IWrapBeatmap {
       },
    };
 
-   static createOne(data: Partial<IWrapBeatmapAttribute> = {}): Beatmap {
+   static createOne(data: DeepPartial<IWrapBeatmapAttribute> = {}): Beatmap {
       return new this(data);
    }
    static create(...data: DeepPartialIgnore<IWrapBeatmapAttribute, 'customData'>[]): Beatmap[] {

--- a/src/beatmap/core/beatmap.ts
+++ b/src/beatmap/core/beatmap.ts
@@ -58,9 +58,23 @@ import type {
    IWrapWaypointAttribute,
 } from '../../types/beatmap/wrapper/waypoint.ts';
 import type { DeepPartial, DeepPartialIgnore, LooseAutocomplete } from '../../types/utils.ts';
+import { deepCopy } from '../../utils/misc.ts';
 import { BaseItem } from './abstract/baseItem.ts';
-import { Difficulty } from './difficulty.ts';
-import { Lightshow } from './lightshow.ts';
+import { createDifficulty, Difficulty } from './difficulty.ts';
+import { createLightshow, Lightshow } from './lightshow.ts';
+
+export function createBeatmap(
+   data: DeepPartial<IWrapBeatmapAttribute> = {},
+): IWrapBeatmapAttribute {
+   return {
+      version: data.version ?? -1,
+      filename: data.filename ?? 'Unnamed.beatmap.dat',
+      lightshowFilename: data.lightshowFilename ?? 'Unnamed.lightshow.dat',
+      difficulty: createDifficulty(data.difficulty),
+      lightshow: createLightshow(data.lightshow),
+      customData: deepCopy({ ...data.customData }),
+   };
+}
 
 /**
  * Core beatmap container.
@@ -74,36 +88,7 @@ import { Lightshow } from './lightshow.ts';
  * This object exists solely for arbitrary data.
  */
 export class Beatmap extends BaseItem implements IWrapBeatmap {
-   static defaultValue: IWrapBeatmapAttribute = {
-      version: -1,
-      filename: 'Unnamed.beatmap.dat',
-      lightshowFilename: 'Unnamed.lightshow.dat',
-      customData: {},
-
-      difficulty: {
-         bpmEvents: [],
-         rotationEvents: [],
-         colorNotes: [],
-         bombNotes: [],
-         obstacles: [],
-         arcs: [],
-         chains: [],
-         njsEvents: [],
-         customData: {},
-      },
-      lightshow: {
-         waypoints: [],
-         basicEvents: [],
-         colorBoostEvents: [],
-         lightColorEventBoxGroups: [],
-         lightRotationEventBoxGroups: [],
-         lightTranslationEventBoxGroups: [],
-         fxEventBoxGroups: [],
-         basicEventTypesWithKeywords: { list: [] },
-         useNormalEventsAsCompatibleEvents: false,
-         customData: {},
-      },
-   };
+   static defaultValue: IWrapBeatmapAttribute = createBeatmap();
 
    static createOne(data: DeepPartial<IWrapBeatmapAttribute> = {}): Beatmap {
       return new this(data);

--- a/src/beatmap/core/bombNote.ts
+++ b/src/beatmap/core/bombNote.ts
@@ -2,22 +2,29 @@ import type {
    IWrapBombNote,
    IWrapBombNoteAttribute,
 } from '../../types/beatmap/wrapper/bombNote.ts';
+import type { DeepPartial } from '../../types/utils.ts';
 import { deepCopy } from '../../utils/misc.ts';
 import { BaseNote } from './abstract/baseNote.ts';
+
+export function createBombNote(
+   data: DeepPartial<IWrapBombNoteAttribute> = {},
+): IWrapBombNoteAttribute {
+   return {
+      time: data.time ?? 0,
+      posX: data.posX ?? 0,
+      posY: data.posY ?? 0,
+      color: -1,
+      direction: data.direction ?? 0,
+      laneRotation: data.laneRotation ?? 0,
+      customData: deepCopy({ ...data.customData }),
+   };
+}
 
 /**
  * Core beatmap bomb note.
  */
 export class BombNote extends BaseNote implements IWrapBombNote {
-   static defaultValue: IWrapBombNoteAttribute = {
-      time: 0,
-      posX: 0,
-      posY: 0,
-      color: -1,
-      direction: 0,
-      laneRotation: 0,
-      customData: {},
-   };
+   static defaultValue: IWrapBombNoteAttribute = createBombNote();
 
    static createOne(data: Partial<IWrapBombNoteAttribute> = {}): BombNote {
       return new this(data);

--- a/src/beatmap/core/bpmEvent.ts
+++ b/src/beatmap/core/bpmEvent.ts
@@ -1,19 +1,26 @@
-import { BaseObject } from './abstract/baseObject.ts';
 import type {
    IWrapBPMEvent,
    IWrapBPMEventAttribute,
 } from '../../types/beatmap/wrapper/bpmEvent.ts';
+import type { DeepPartial } from '../../types/utils.ts';
 import { deepCopy } from '../../utils/misc.ts';
+import { BaseObject } from './abstract/baseObject.ts';
+
+export function createBPMEvent(
+   data: DeepPartial<IWrapBPMEventAttribute> = {},
+): IWrapBPMEventAttribute {
+   return {
+      time: data.time ?? 0,
+      bpm: data.bpm ?? 0,
+      customData: deepCopy({ ...data.customData }),
+   };
+}
 
 /**
  * Core beatmap BPM event.
  */
 export class BPMEvent extends BaseObject implements IWrapBPMEvent {
-   static defaultValue: IWrapBPMEventAttribute = {
-      time: 0,
-      bpm: 0,
-      customData: {},
-   };
+   static defaultValue: IWrapBPMEventAttribute = createBPMEvent();
 
    static createOne(data: Partial<IWrapBPMEventAttribute> = {}): BPMEvent {
       return new this(data);

--- a/src/beatmap/core/chain.ts
+++ b/src/beatmap/core/chain.ts
@@ -1,26 +1,33 @@
-import { BaseSlider } from './abstract/baseSlider.ts';
 import type { IWrapChain, IWrapChainAttribute } from '../../types/beatmap/wrapper/chain.ts';
+import type { DeepPartial } from '../../types/utils.ts';
 import { deepCopy } from '../../utils/misc.ts';
+import { BaseSlider } from './abstract/baseSlider.ts';
+
+export function createChain(
+   data: DeepPartial<IWrapChainAttribute> = {},
+): IWrapChainAttribute {
+   return {
+      time: data.time ?? 0,
+      posX: data.posX ?? 0,
+      posY: data.posY ?? 0,
+      color: data.color ?? 0,
+      direction: data.direction ?? 0,
+      laneRotation: data.laneRotation ?? 0,
+      tailTime: data.tailTime ?? 0,
+      tailPosX: data.tailPosX ?? 0,
+      tailPosY: data.tailPosY ?? 0,
+      tailLaneRotation: data.tailLaneRotation ?? 0,
+      sliceCount: data.sliceCount ?? 0,
+      squish: data.squish ?? 0,
+      customData: deepCopy({ ...data.customData }),
+   };
+}
 
 /**
  * Core beatmap chain.
  */
 export class Chain extends BaseSlider implements IWrapChain {
-   static defaultValue: IWrapChainAttribute = {
-      time: 0,
-      posX: 0,
-      posY: 0,
-      color: 0,
-      direction: 0,
-      laneRotation: 0,
-      tailTime: 0,
-      tailPosX: 0,
-      tailPosY: 0,
-      tailLaneRotation: 0,
-      sliceCount: 0,
-      squish: 0,
-      customData: {},
-   };
+   static defaultValue: IWrapChainAttribute = createChain();
 
    static createOne(data: Partial<IWrapChainAttribute> = {}): Chain {
       return new this(data);

--- a/src/beatmap/core/colorBoostEvent.ts
+++ b/src/beatmap/core/colorBoostEvent.ts
@@ -1,19 +1,26 @@
-import { BaseObject } from './abstract/baseObject.ts';
 import type {
    IWrapColorBoostEvent,
    IWrapColorBoostEventAttribute,
 } from '../../types/beatmap/wrapper/colorBoostEvent.ts';
+import type { DeepPartial } from '../../types/utils.ts';
 import { deepCopy } from '../../utils/misc.ts';
+import { BaseObject } from './abstract/baseObject.ts';
+
+export function createColorBoostEvent(
+   data: DeepPartial<IWrapColorBoostEventAttribute> = {},
+): IWrapColorBoostEventAttribute {
+   return {
+      time: data.time ?? 0,
+      toggle: data.toggle ?? false,
+      customData: deepCopy({ ...data.customData }),
+   };
+}
 
 /**
  * Core beatmap color boost event.
  */
 export class ColorBoostEvent extends BaseObject implements IWrapColorBoostEvent {
-   static defaultValue: IWrapColorBoostEventAttribute = {
-      time: 0,
-      toggle: false,
-      customData: {},
-   };
+   static defaultValue: IWrapColorBoostEventAttribute = createColorBoostEvent();
 
    static createOne(data: Partial<IWrapColorBoostEventAttribute> = {}): ColorBoostEvent {
       return new this(data);

--- a/src/beatmap/core/colorNote.ts
+++ b/src/beatmap/core/colorNote.ts
@@ -3,24 +3,31 @@ import type {
    IWrapColorNote,
    IWrapColorNoteAttribute,
 } from '../../types/beatmap/wrapper/colorNote.ts';
+import type { DeepPartial } from '../../types/utils.ts';
 import { deepCopy } from '../../utils/misc.ts';
 import { resolveNoteAngle } from '../helpers/core/baseNote.ts';
 import { BaseNote } from './abstract/baseNote.ts';
+
+export function createColorNote(
+   data: DeepPartial<IWrapColorNoteAttribute> = {},
+): IWrapColorNoteAttribute {
+   return {
+      time: data.time ?? 0,
+      posX: data.posX ?? 0,
+      posY: data.posY ?? 0,
+      color: data.color ?? 0,
+      direction: data.direction ?? 0,
+      angleOffset: data.angleOffset ?? 0,
+      laneRotation: data.laneRotation ?? 0,
+      customData: deepCopy({ ...data.customData }),
+   };
+}
 
 /**
  * Core beatmap color note.
  */
 export class ColorNote extends BaseNote implements IWrapColorNote {
-   static defaultValue: IWrapColorNoteAttribute = {
-      time: 0,
-      posX: 0,
-      posY: 0,
-      color: 0,
-      direction: 0,
-      angleOffset: 0,
-      laneRotation: 0,
-      customData: {},
-   };
+   static defaultValue: IWrapColorNoteAttribute = createColorNote();
 
    static createOne(data: Partial<IWrapColorNoteAttribute> = {}): ColorNote {
       return new this(data);

--- a/src/beatmap/core/colorNote.ts
+++ b/src/beatmap/core/colorNote.ts
@@ -1,11 +1,11 @@
-import { NoteDirectionAngle } from '../shared/constants.ts';
+import type { GetAngleFn, MirrorFn } from '../../types/beatmap/shared/functions.ts';
 import type {
    IWrapColorNote,
    IWrapColorNoteAttribute,
 } from '../../types/beatmap/wrapper/colorNote.ts';
-import { BaseNote } from './abstract/baseNote.ts';
 import { deepCopy } from '../../utils/misc.ts';
-import type { GetAngleFn, MirrorFn } from '../../types/beatmap/shared/functions.ts';
+import { resolveNoteAngle } from '../helpers/core/baseNote.ts';
+import { BaseNote } from './abstract/baseNote.ts';
 
 /**
  * Core beatmap color note.
@@ -63,10 +63,6 @@ export class ColorNote extends BaseNote implements IWrapColorNote {
    }
 
    override getAngle(fn?: GetAngleFn<this>): number {
-      return (
-         fn?.(this) ??
-            (NoteDirectionAngle[this.direction as keyof typeof NoteDirectionAngle] || 0) +
-               this.angleOffset
-      );
+      return fn?.(this) ?? resolveNoteAngle(this.direction) + this.angleOffset;
    }
 }

--- a/src/beatmap/core/difficulty.ts
+++ b/src/beatmap/core/difficulty.ts
@@ -1,3 +1,4 @@
+import type { IWrapArc, IWrapArcAttribute } from '../../types/beatmap/wrapper/arc.ts';
 import type {
    IWrapBombNote,
    IWrapBombNoteAttribute,
@@ -12,6 +13,14 @@ import type {
    IWrapColorNoteAttribute,
 } from '../../types/beatmap/wrapper/colorNote.ts';
 import type {
+   IWrapDifficulty,
+   IWrapDifficultyAttribute,
+} from '../../types/beatmap/wrapper/difficulty.ts';
+import type {
+   IWrapNJSEvent,
+   IWrapNJSEventAttribute,
+} from '../../types/beatmap/wrapper/njsEvent.ts';
+import type {
    IWrapObstacle,
    IWrapObstacleAttribute,
 } from '../../types/beatmap/wrapper/obstacle.ts';
@@ -19,43 +28,40 @@ import type {
    IWrapRotationEvent,
    IWrapRotationEventAttribute,
 } from '../../types/beatmap/wrapper/rotationEvent.ts';
-import type { IWrapArc, IWrapArcAttribute } from '../../types/beatmap/wrapper/arc.ts';
-import type { DeepPartialIgnore } from '../../types/utils.ts';
-import { BaseItem } from './abstract/baseItem.ts';
-import type {
-   IWrapDifficulty,
-   IWrapDifficultyAttribute,
-} from '../../types/beatmap/wrapper/difficulty.ts';
-import { sortNoteFn, sortObjectFn } from '../helpers/sort.ts';
-import { BPMEvent } from './bpmEvent.ts';
-import { RotationEvent } from './rotationEvent.ts';
-import { ColorNote } from './colorNote.ts';
-import { BombNote } from './bombNote.ts';
-import { Obstacle } from './obstacle.ts';
-import { Arc } from './arc.ts';
-import { Chain } from './chain.ts';
+import type { DeepPartial, DeepPartialIgnore } from '../../types/utils.ts';
 import { deepCopy } from '../../utils/misc.ts';
-import type {
-   IWrapNJSEvent,
-   IWrapNJSEventAttribute,
-} from '../../types/beatmap/wrapper/njsEvent.ts';
-import { NJSEvent } from './njsEvent.ts';
+import { sortNoteFn, sortObjectFn } from '../helpers/sort.ts';
+import { BaseItem } from './abstract/baseItem.ts';
+import { Arc, createArc } from './arc.ts';
+import { BombNote, createBombNote } from './bombNote.ts';
+import { BPMEvent, createBPMEvent } from './bpmEvent.ts';
+import { Chain, createChain } from './chain.ts';
+import { ColorNote, createColorNote } from './colorNote.ts';
+import { createNJSEvent, NJSEvent } from './njsEvent.ts';
+import { createObstacle, Obstacle } from './obstacle.ts';
+import { createRotationEvent, RotationEvent } from './rotationEvent.ts';
+
+export function createDifficulty(
+   data: DeepPartial<IWrapDifficultyAttribute> = {},
+): IWrapDifficultyAttribute {
+   return {
+      bpmEvents: data.bpmEvents?.map(createBPMEvent) ?? [],
+      rotationEvents: data.rotationEvents?.map(createRotationEvent) ?? [],
+      colorNotes: data.colorNotes?.map(createColorNote) ?? [],
+      bombNotes: data.bombNotes?.map(createBombNote) ?? [],
+      obstacles: data.obstacles?.map(createObstacle) ?? [],
+      arcs: data.arcs?.map(createArc) ?? [],
+      chains: data.chains?.map(createChain) ?? [],
+      njsEvents: data.njsEvents?.map(createNJSEvent) ?? [],
+      customData: deepCopy({ ...data.customData }),
+   };
+}
 
 /**
  * Core beatmap difficulty.
  */
 export class Difficulty extends BaseItem implements IWrapDifficulty {
-   static defaultValue: IWrapDifficultyAttribute = {
-      bpmEvents: [],
-      rotationEvents: [],
-      colorNotes: [],
-      bombNotes: [],
-      obstacles: [],
-      arcs: [],
-      chains: [],
-      njsEvents: [],
-      customData: {},
-   };
+   static defaultValue: IWrapDifficultyAttribute = createDifficulty();
 
    static createOne(data: Partial<IWrapDifficultyAttribute> = {}): Difficulty {
       return new this(data);

--- a/src/beatmap/core/fxEventBox.ts
+++ b/src/beatmap/core/fxEventBox.ts
@@ -3,38 +3,33 @@ import type {
    IWrapFxEventBoxAttribute,
 } from '../../types/beatmap/wrapper/fxEventBox.ts';
 import type { IWrapFxEventFloat } from '../../types/beatmap/wrapper/fxEventFloat.ts';
-import type { DeepPartialIgnore } from '../../types/utils.ts';
+import type { DeepPartial, DeepPartialIgnore } from '../../types/utils.ts';
 import { deepCopy } from '../../utils/misc.ts';
 import { EventBox } from './abstract/eventBox.ts';
-import { FxEventFloat } from './fxEventFloat.ts';
-import { IndexFilter } from './indexFilter.ts';
+import { createFxEventFloat, FxEventFloat } from './fxEventFloat.ts';
+import { createIndexFilter, IndexFilter } from './indexFilter.ts';
+
+export function createFxEventBox(
+   data: DeepPartial<IWrapFxEventBoxAttribute> = {},
+): IWrapFxEventBoxAttribute {
+   return {
+      filter: createIndexFilter(data.filter),
+      beatDistribution: data.beatDistribution ?? 0,
+      beatDistributionType: data.beatDistributionType ?? 1,
+      fxDistribution: data.fxDistribution ?? 0,
+      fxDistributionType: data.fxDistributionType ?? 1,
+      affectFirst: data.affectFirst ?? 0,
+      easing: data.easing ?? 0,
+      events: data.events?.map(createFxEventFloat) ?? [],
+      customData: deepCopy({ ...data.customData }),
+   };
+}
 
 /**
  * Core beatmap FX event box.
  */
 export class FxEventBox extends EventBox implements IWrapFxEventBox {
-   static defaultValue: IWrapFxEventBoxAttribute = {
-      filter: {
-         type: 1,
-         p0: 0,
-         p1: 0,
-         reverse: 0,
-         chunks: 0,
-         random: 0,
-         seed: 0,
-         limit: 0,
-         limitAffectsType: 0,
-         customData: {},
-      },
-      beatDistribution: 0,
-      beatDistributionType: 1,
-      fxDistribution: 0,
-      fxDistributionType: 1,
-      affectFirst: 0,
-      easing: 0,
-      events: [],
-      customData: {},
-   };
+   static defaultValue: IWrapFxEventBoxAttribute = createFxEventBox();
 
    static createOne(data: Partial<IWrapFxEventBoxAttribute> = {}): FxEventBox {
       return new this(data);

--- a/src/beatmap/core/fxEventBoxGroup.ts
+++ b/src/beatmap/core/fxEventBoxGroup.ts
@@ -1,26 +1,32 @@
-import { EventBoxGroup } from './abstract/eventBoxGroup.ts';
+import type { IWrapFxEventBox } from '../../types/beatmap/wrapper/fxEventBox.ts';
 import type {
    IWrapFxEventBoxGroup,
    IWrapFxEventBoxGroupAttribute,
 } from '../../types/beatmap/wrapper/fxEventBoxGroup.ts';
-import type { IWrapFxEventBox } from '../../types/beatmap/wrapper/fxEventBox.ts';
-import type { DeepPartialIgnore } from '../../types/utils.ts';
-import { FxEventBox } from './fxEventBox.ts';
+import type { DeepPartial, DeepPartialIgnore } from '../../types/utils.ts';
 import { deepCopy } from '../../utils/misc.ts';
+import { EventBoxGroup } from './abstract/eventBoxGroup.ts';
+import { createFxEventBox, FxEventBox } from './fxEventBox.ts';
+
+export function createFxEventBoxGroup(
+   data: DeepPartial<IWrapFxEventBoxGroupAttribute> = {},
+): IWrapFxEventBoxGroupAttribute {
+   return {
+      time: data.time ?? 0,
+      id: data.id ?? 0,
+      boxes: data.boxes?.map(createFxEventBox) ?? [],
+      customData: deepCopy({ ...data.customData }),
+   };
+}
 
 /**
  * Core beatmap FX event box group.
  */
 export class FxEventBoxGroup extends EventBoxGroup implements IWrapFxEventBoxGroup {
-   static defaultValue: IWrapFxEventBoxGroupAttribute = {
-      time: 0,
-      id: 0,
-      boxes: [],
-      customData: {},
-   };
+   static defaultValue: IWrapFxEventBoxGroupAttribute = createFxEventBoxGroup();
 
    static createOne(
-      data: DeepPartialIgnore<IWrapFxEventBoxGroupAttribute, 'customData'> = {},
+      data: Partial<IWrapFxEventBoxGroupAttribute> = {},
    ): FxEventBoxGroup {
       return new this(data);
    }

--- a/src/beatmap/core/fxEventFloat.ts
+++ b/src/beatmap/core/fxEventFloat.ts
@@ -2,20 +2,27 @@ import type {
    IWrapFxEventFloat,
    IWrapFxEventFloatAttribute,
 } from '../../types/beatmap/wrapper/fxEventFloat.ts';
+import type { DeepPartial } from '../../types/utils.ts';
 import { deepCopy } from '../../utils/misc.ts';
 import { BaseObject } from './abstract/baseObject.ts';
+
+export function createFxEventFloat(
+   data: DeepPartial<IWrapFxEventFloatAttribute> = {},
+): IWrapFxEventFloatAttribute {
+   return {
+      time: data.time ?? 0,
+      easing: data.easing ?? 0,
+      previous: data.previous ?? 0,
+      value: data.value ?? 0,
+      customData: deepCopy({ ...data.customData }),
+   };
+}
 
 /**
  * Core beatmap FX event float.
  */
 export class FxEventFloat extends BaseObject implements IWrapFxEventFloat {
-   static defaultValue: IWrapFxEventFloatAttribute = {
-      time: 0,
-      easing: 0,
-      previous: 0,
-      value: 0,
-      customData: {},
-   };
+   static defaultValue: IWrapFxEventFloatAttribute = createFxEventFloat();
 
    static createOne(data: Partial<IWrapFxEventFloatAttribute> = {}): FxEventFloat {
       return new this(data);

--- a/src/beatmap/core/fxEventInt.ts
+++ b/src/beatmap/core/fxEventInt.ts
@@ -5,16 +5,20 @@ import type {
 import { deepCopy } from '../../utils/misc.ts';
 import { BaseObject } from './abstract/baseObject.ts';
 
+export function createFxEventInt(data: Partial<IWrapFxEventIntAttribute> = {}) {
+   return {
+      time: data.time ?? 0,
+      previous: data.previous ?? 0,
+      value: data.value ?? 0,
+      customData: deepCopy({ ...data.customData }),
+   };
+}
+
 /**
  * Core beatmap FX event int.
  */
 export class FxEventInt extends BaseObject implements IWrapFxEventInt {
-   static defaultValue: IWrapFxEventIntAttribute = {
-      time: 0,
-      previous: 0,
-      value: 0,
-      customData: {},
-   };
+   static defaultValue: IWrapFxEventIntAttribute = createFxEventInt();
 
    static createOne(data: Partial<IWrapFxEventIntAttribute> = {}): FxEventInt {
       return new this(data);

--- a/src/beatmap/core/indexFilter.ts
+++ b/src/beatmap/core/indexFilter.ts
@@ -1,27 +1,32 @@
+import { LimitAlsoAffectsType, RandomType } from '../../types/beatmap/shared/constants.ts';
 import type {
    IWrapIndexFilter,
    IWrapIndexFilterAttribute,
 } from '../../types/beatmap/wrapper/indexFilter.ts';
-import { LimitAlsoAffectsType, RandomType } from '../../types/beatmap/shared/constants.ts';
-import { BaseItem } from './abstract/baseItem.ts';
+import type { DeepPartial } from '../../types/utils.ts';
 import { deepCopy } from '../../utils/misc.ts';
+import { BaseItem } from './abstract/baseItem.ts';
+
+export function createIndexFilter(data: DeepPartial<IWrapIndexFilterAttribute> = {}) {
+   return {
+      type: data.type ?? 1,
+      p0: data.p0 ?? 0,
+      p1: data.p1 ?? 0,
+      reverse: data.reverse ?? 0,
+      chunks: data.chunks ?? 0,
+      random: data.random ?? 0,
+      seed: data.seed ?? 0,
+      limit: data.limit ?? 0,
+      limitAffectsType: data.limitAffectsType ?? 0,
+      customData: deepCopy({ ...data.customData }),
+   };
+}
 
 /**
  * Core beatmap index filter.
  */
 export class IndexFilter extends BaseItem implements IWrapIndexFilter {
-   static defaultValue: IWrapIndexFilterAttribute = {
-      type: 1,
-      p0: 0,
-      p1: 0,
-      reverse: 0,
-      chunks: 0,
-      random: 0,
-      seed: 0,
-      limit: 0,
-      limitAffectsType: 0,
-      customData: {},
-   };
+   static defaultValue: IWrapIndexFilterAttribute = createIndexFilter();
 
    static createOne(
       data: Partial<IWrapIndexFilterAttribute> = {},

--- a/src/beatmap/core/info.ts
+++ b/src/beatmap/core/info.ts
@@ -13,12 +13,111 @@ import type {
    IWrapInfoColorScheme,
    IWrapInfoSong,
 } from '../../types/beatmap/wrapper/info.ts';
-import type { DeepPartialIgnore, LooseAutocomplete } from '../../types/utils.ts';
+import type { DeepPartial, DeepPartialIgnore, LooseAutocomplete } from '../../types/utils.ts';
 import { deepCopy } from '../../utils/misc.ts';
 import { CharacteristicOrder } from '../shared/characteristic.ts';
 import { DifficultyRanking } from '../shared/difficulty.ts';
 import { BaseItem } from './abstract/baseItem.ts';
-import { InfoBeatmap } from './infoBeatmap.ts';
+import { createInfoBeatmap, InfoBeatmap } from './infoBeatmap.ts';
+
+export function createInfo(data: DeepPartial<IWrapInfoAttribute> = {}): IWrapInfoAttribute {
+   return {
+      version: data.version ?? -1,
+      filename: data.filename ?? 'Info.dat',
+      song: {
+         title: data.song?.title ?? 'Untitled',
+         subTitle: data.song?.subTitle ?? '',
+         author: data.song?.author ?? 'NoAuthor',
+      },
+      audio: {
+         filename: data.audio?.filename ?? 'song.ogg',
+         duration: data.audio?.duration ?? 0,
+         audioDataFilename: data.audio?.audioDataFilename ?? 'AudioData.dat',
+         bpm: data.audio?.bpm ?? 120,
+         lufs: data.audio?.lufs ?? 0,
+         previewStartTime: data.audio?.previewStartTime ?? 0,
+         previewDuration: data.audio?.previewDuration ?? 0,
+         audioOffset: data.audio?.audioOffset ?? 0,
+         shuffle: data.audio?.shuffle ?? 0,
+         shufflePeriod: data.audio?.shufflePeriod ?? 0.5,
+      },
+      songPreviewFilename: data.songPreviewFilename ?? 'song.ogg',
+      coverImageFilename: data.coverImageFilename ?? 'cover.jpg',
+      environmentBase: {
+         normal: data.environmentBase?.normal ?? null,
+         allDirections: data.environmentBase?.allDirections ?? null,
+      },
+      environmentNames: data.environmentNames ?? [],
+      colorSchemes: data.colorSchemes?.map((e) => {
+         const cs: IWrapInfoColorScheme = {
+            name: e!.name ?? '',
+            overrideLights: e!.overrideLights ?? false,
+            overrideNotes: e!.overrideNotes ?? false,
+            saberLeftColor: {
+               r: e!.saberLeftColor?.r ?? 0,
+               g: e!.saberLeftColor?.g ?? 0,
+               b: e!.saberLeftColor?.b ?? 0,
+               a: e!.saberLeftColor?.a ?? 0,
+            },
+            saberRightColor: {
+               r: e!.saberRightColor?.r ?? 0,
+               g: e!.saberRightColor?.g ?? 0,
+               b: e!.saberRightColor?.b ?? 0,
+               a: e!.saberRightColor?.a ?? 0,
+            },
+            environment0Color: {
+               r: e!.environment0Color?.r ?? 0,
+               g: e!.environment0Color?.g ?? 0,
+               b: e!.environment0Color?.b ?? 0,
+               a: e!.environment0Color?.a ?? 0,
+            },
+            environment1Color: {
+               r: e!.environment1Color?.r ?? 0,
+               g: e!.environment1Color?.g ?? 0,
+               b: e!.environment1Color?.b ?? 0,
+               a: e!.environment1Color?.a ?? 0,
+            },
+            environment0ColorBoost: {
+               r: e!.environment0ColorBoost?.r ?? 0,
+               g: e!.environment0ColorBoost?.g ?? 0,
+               b: e!.environment0ColorBoost?.b ?? 0,
+               a: e!.environment0ColorBoost?.a ?? 0,
+            },
+            environment1ColorBoost: {
+               r: e!.environment1ColorBoost?.r ?? 0,
+               g: e!.environment1ColorBoost?.g ?? 0,
+               b: e!.environment1ColorBoost?.b ?? 0,
+               a: e!.environment1ColorBoost?.a ?? 0,
+            },
+            obstaclesColor: {
+               r: e!.obstaclesColor?.r ?? 0,
+               g: e!.obstaclesColor?.g ?? 0,
+               b: e!.obstaclesColor?.b ?? 0,
+               a: e!.obstaclesColor?.a ?? 0,
+            },
+         };
+         if (e!.environmentWColor) {
+            cs.environmentWColor = {
+               r: e!.environmentWColor?.r ?? 0,
+               g: e!.environmentWColor?.g ?? 0,
+               b: e!.environmentWColor?.b ?? 0,
+               a: e!.environmentWColor?.a ?? 0,
+            };
+         }
+         if (e!.environmentWColorBoost) {
+            cs.environmentWColorBoost = {
+               r: e!.environmentWColorBoost?.r ?? 0,
+               g: e!.environmentWColorBoost?.g ?? 0,
+               b: e!.environmentWColorBoost?.b ?? 0,
+               a: e!.environmentWColorBoost?.a ?? 0,
+            };
+         }
+         return cs;
+      }) ?? [],
+      difficulties: data.difficulties?.map(createInfoBeatmap) ?? [],
+      customData: deepCopy({ ...data.customData }),
+   };
+}
 
 /**
  * Core beatmap info.
@@ -26,37 +125,7 @@ import { InfoBeatmap } from './infoBeatmap.ts';
  * This object is writable into file.
  */
 export class Info extends BaseItem implements IWrapInfo {
-   static defaultValue: IWrapInfoAttribute = {
-      version: -1,
-      filename: 'Info.dat',
-      song: {
-         title: 'Untitled',
-         subTitle: '',
-         author: 'NoAuthor',
-      },
-      audio: {
-         filename: '',
-         duration: 0,
-         audioDataFilename: '',
-         bpm: 0,
-         lufs: 0,
-         previewStartTime: 0,
-         previewDuration: 0,
-         audioOffset: 0,
-         shuffle: 0,
-         shufflePeriod: 0.5,
-      },
-      songPreviewFilename: '',
-      coverImageFilename: '',
-      environmentBase: {
-         normal: null,
-         allDirections: null,
-      },
-      environmentNames: [],
-      colorSchemes: [],
-      difficulties: [],
-      customData: {},
-   };
+   static defaultValue: IWrapInfoAttribute = createInfo();
 
    static createOne(data: Partial<IWrapInfoAttribute> = {}): Info {
       return new this(data);

--- a/src/beatmap/core/infoBeatmap.ts
+++ b/src/beatmap/core/infoBeatmap.ts
@@ -9,29 +9,35 @@ import type {
    IWrapInfoBeatmap,
    IWrapInfoBeatmapAttribute,
 } from '../../types/beatmap/wrapper/info.ts';
-import type { DeepPartialIgnore, LooseAutocomplete } from '../../types/utils.ts';
+import type { DeepPartial, DeepPartialIgnore, LooseAutocomplete } from '../../types/utils.ts';
 import { deepCopy } from '../../utils/misc.ts';
 import { BaseItem } from './abstract/baseItem.ts';
+
+export function createInfoBeatmap(
+   data: DeepPartial<IWrapInfoBeatmapAttribute> = {},
+): IWrapInfoBeatmapAttribute {
+   return {
+      characteristic: data.characteristic ?? 'Standard',
+      difficulty: data.difficulty ?? 'Easy',
+      filename: data.filename ?? 'Unnamed.beatmap.dat',
+      lightshowFilename: data.lightshowFilename ?? 'Unnamed.lightshow.dat',
+      authors: {
+         mappers: data.authors?.mappers ?? [],
+         lighters: data.authors?.lighters ?? [],
+      },
+      njs: data.njs ?? 0,
+      njsOffset: data.njsOffset ?? 0,
+      colorSchemeId: data.colorSchemeId ?? -1,
+      environmentId: data.environmentId ?? 0,
+      customData: deepCopy({ ...data.customData }),
+   };
+}
 
 /**
  * Core beatmap info beatmap.
  */
 export class InfoBeatmap extends BaseItem implements IWrapInfoBeatmap {
-   static defaultValue: IWrapInfoBeatmapAttribute = {
-      characteristic: 'Standard',
-      difficulty: 'Easy',
-      filename: 'Unnamed.beatmap.dat',
-      lightshowFilename: 'Unnamed.lightshow.dat',
-      authors: {
-         mappers: [],
-         lighters: [],
-      },
-      njs: 10,
-      njsOffset: 0,
-      colorSchemeId: -1,
-      environmentId: 0,
-      customData: {},
-   };
+   static defaultValue: IWrapInfoBeatmapAttribute = createInfoBeatmap();
 
    static createOne(data: Partial<IWrapInfoBeatmapAttribute> = {}): InfoBeatmap {
       return new this(data);

--- a/src/beatmap/core/lightColorEvent.ts
+++ b/src/beatmap/core/lightColorEvent.ts
@@ -2,24 +2,29 @@ import type {
    IWrapLightColorEvent,
    IWrapLightColorEventAttribute,
 } from '../../types/beatmap/wrapper/lightColorEvent.ts';
+import type { DeepPartial } from '../../types/utils.ts';
 import { deepCopy } from '../../utils/misc.ts';
 import { BaseObject } from './abstract/baseObject.ts';
+
+export function createLightColorEvent(data: DeepPartial<IWrapLightColorEventAttribute> = {}) {
+   return {
+      time: data.time ?? 0,
+      previous: data.previous ?? 0,
+      color: data.color ?? 0,
+      frequency: data.frequency ?? 0,
+      brightness: data.brightness ?? 0,
+      strobeBrightness: data.strobeBrightness ?? 0,
+      strobeFade: data.strobeFade ?? 0,
+      easing: data.easing ?? 0,
+      customData: deepCopy({ ...data.customData }),
+   };
+}
 
 /**
  * Core beatmap light color event.
  */
 export class LightColorEvent extends BaseObject implements IWrapLightColorEvent {
-   static defaultValue: IWrapLightColorEventAttribute = {
-      time: 0,
-      previous: 0,
-      color: 0,
-      frequency: 0,
-      brightness: 0,
-      strobeBrightness: 0,
-      strobeFade: 0,
-      easing: 0,
-      customData: {},
-   };
+   static defaultValue: IWrapLightColorEventAttribute = createLightColorEvent();
 
    static createOne(data: Partial<IWrapLightColorEventAttribute> = {}): LightColorEvent {
       return new this(data);

--- a/src/beatmap/core/lightColorEventBox.ts
+++ b/src/beatmap/core/lightColorEventBox.ts
@@ -3,38 +3,33 @@ import type {
    IWrapLightColorEventBox,
    IWrapLightColorEventBoxAttribute,
 } from '../../types/beatmap/wrapper/lightColorEventBox.ts';
-import type { DeepPartialIgnore } from '../../types/utils.ts';
+import type { DeepPartial, DeepPartialIgnore } from '../../types/utils.ts';
 import { deepCopy } from '../../utils/misc.ts';
 import { EventBox } from './abstract/eventBox.ts';
-import { IndexFilter } from './indexFilter.ts';
-import { LightColorEvent } from './lightColorEvent.ts';
+import { createIndexFilter, IndexFilter } from './indexFilter.ts';
+import { createLightColorEvent, LightColorEvent } from './lightColorEvent.ts';
+
+export function createLightColorEventBox(
+   data: DeepPartial<IWrapLightColorEventBoxAttribute> = {},
+): IWrapLightColorEventBoxAttribute {
+   return {
+      filter: createIndexFilter(data.filter),
+      beatDistribution: data.beatDistribution ?? 0,
+      beatDistributionType: data.beatDistributionType ?? 1,
+      brightnessDistribution: data.brightnessDistribution ?? 0,
+      brightnessDistributionType: data.brightnessDistributionType ?? 1,
+      affectFirst: data.affectFirst ?? 0,
+      easing: data.easing ?? 0,
+      events: data.events?.map((o) => createLightColorEvent(o)) ?? [],
+      customData: deepCopy({ ...data.customData }),
+   };
+}
 
 /**
  * Core beatmap light color event box.
  */
 export class LightColorEventBox extends EventBox implements IWrapLightColorEventBox {
-   static defaultValue: IWrapLightColorEventBoxAttribute = {
-      filter: {
-         type: 1,
-         p0: 0,
-         p1: 0,
-         reverse: 0,
-         chunks: 0,
-         random: 0,
-         seed: 0,
-         limit: 0,
-         limitAffectsType: 0,
-         customData: {},
-      },
-      beatDistribution: 0,
-      beatDistributionType: 1,
-      brightnessDistribution: 0,
-      brightnessDistributionType: 1,
-      affectFirst: 0,
-      easing: 0,
-      events: [],
-      customData: {},
-   };
+   static defaultValue: IWrapLightColorEventBoxAttribute = createLightColorEventBox();
 
    static createOne(data: Partial<IWrapLightColorEventBoxAttribute> = {}): LightColorEventBox {
       return new this(data);

--- a/src/beatmap/core/lightColorEventBoxGroup.ts
+++ b/src/beatmap/core/lightColorEventBoxGroup.ts
@@ -3,21 +3,27 @@ import type {
    IWrapLightColorEventBoxGroup,
    IWrapLightColorEventBoxGroupAttribute,
 } from '../../types/beatmap/wrapper/lightColorEventBoxGroup.ts';
-import type { DeepPartialIgnore } from '../../types/utils.ts';
+import type { DeepPartial, DeepPartialIgnore } from '../../types/utils.ts';
 import { deepCopy } from '../../utils/misc.ts';
 import { EventBoxGroup } from './abstract/eventBoxGroup.ts';
-import { LightColorEventBox } from './lightColorEventBox.ts';
+import { createLightColorEventBox, LightColorEventBox } from './lightColorEventBox.ts';
+
+export function createLightColorEventBoxGroup(
+   data: DeepPartial<IWrapLightColorEventBoxGroupAttribute> = {},
+): IWrapLightColorEventBoxGroupAttribute {
+   return {
+      time: data.time ?? 0,
+      id: data.id ?? 0,
+      boxes: data.boxes?.map((e) => createLightColorEventBox(e)) ?? [],
+      customData: deepCopy({ ...data.customData }),
+   };
+}
 
 /**
  * Core beatmap light color event box group.
  */
 export class LightColorEventBoxGroup extends EventBoxGroup implements IWrapLightColorEventBoxGroup {
-   static defaultValue: IWrapLightColorEventBoxGroupAttribute = {
-      time: 0,
-      id: 0,
-      boxes: [],
-      customData: {},
-   };
+   static defaultValue: IWrapLightColorEventBoxGroupAttribute = createLightColorEventBoxGroup();
 
    static createOne(
       data: Partial<IWrapLightColorEventBoxGroupAttribute> = {},

--- a/src/beatmap/core/lightRotationEvent.ts
+++ b/src/beatmap/core/lightRotationEvent.ts
@@ -2,22 +2,29 @@ import type {
    IWrapLightRotationEvent,
    IWrapLightRotationEventAttribute,
 } from '../../types/beatmap/wrapper/lightRotationEvent.ts';
+import type { DeepPartial } from '../../types/utils.ts';
 import { deepCopy } from '../../utils/misc.ts';
 import { BaseObject } from './abstract/baseObject.ts';
+
+export function createLightRotationEvent(
+   data: DeepPartial<IWrapLightRotationEventAttribute> = {},
+): IWrapLightRotationEventAttribute {
+   return {
+      time: data.time ?? 0,
+      easing: data.easing ?? 0,
+      loop: data.loop ?? 0,
+      direction: data.direction ?? 0,
+      previous: data.previous ?? 0,
+      rotation: data.rotation ?? 0,
+      customData: deepCopy({ ...data.customData }),
+   };
+}
 
 /**
  * Core beatmap light rotation event.
  */
 export class LightRotationEvent extends BaseObject implements IWrapLightRotationEvent {
-   static defaultValue: IWrapLightRotationEventAttribute = {
-      time: 0,
-      easing: 0,
-      loop: 0,
-      direction: 0,
-      previous: 0,
-      rotation: 0,
-      customData: {},
-   };
+   static defaultValue: IWrapLightRotationEventAttribute = createLightRotationEvent();
 
    static createOne(data: Partial<IWrapLightRotationEventAttribute> = {}): LightRotationEvent {
       return new this(data);

--- a/src/beatmap/core/lightRotationEventBox.ts
+++ b/src/beatmap/core/lightRotationEventBox.ts
@@ -3,40 +3,35 @@ import type {
    IWrapLightRotationEventBox,
    IWrapLightRotationEventBoxAttribute,
 } from '../../types/beatmap/wrapper/lightRotationEventBox.ts';
-import type { DeepPartialIgnore } from '../../types/utils.ts';
+import type { DeepPartial, DeepPartialIgnore } from '../../types/utils.ts';
 import { deepCopy } from '../../utils/misc.ts';
 import { EventBox } from './abstract/eventBox.ts';
-import { IndexFilter } from './indexFilter.ts';
-import { LightRotationEvent } from './lightRotationEvent.ts';
+import { createIndexFilter, IndexFilter } from './indexFilter.ts';
+import { createLightRotationEvent, LightRotationEvent } from './lightRotationEvent.ts';
+
+export function createLightRotationEventBox(
+   data: DeepPartial<IWrapLightRotationEventBoxAttribute> = {},
+): IWrapLightRotationEventBoxAttribute {
+   return {
+      filter: createIndexFilter(data.filter),
+      axis: data.axis ?? 0,
+      flip: data.flip ?? 0,
+      beatDistribution: data.beatDistribution ?? 0,
+      beatDistributionType: data.beatDistributionType ?? 1,
+      rotationDistribution: data.rotationDistribution ?? 0,
+      rotationDistributionType: data.rotationDistributionType ?? 1,
+      affectFirst: data.affectFirst ?? 0,
+      easing: data.easing ?? 0,
+      events: data.events?.map((o) => createLightRotationEvent(o)) ?? [],
+      customData: deepCopy({ ...data.customData }),
+   };
+}
 
 /**
  * Core beatmap light rotation event box.
  */
 export class LightRotationEventBox extends EventBox implements IWrapLightRotationEventBox {
-   static defaultValue: IWrapLightRotationEventBoxAttribute = {
-      filter: {
-         type: 1,
-         p0: 0,
-         p1: 0,
-         reverse: 0,
-         chunks: 0,
-         random: 0,
-         seed: 0,
-         limit: 0,
-         limitAffectsType: 0,
-         customData: {},
-      },
-      axis: 0,
-      flip: 0,
-      beatDistribution: 0,
-      beatDistributionType: 1,
-      rotationDistribution: 0,
-      rotationDistributionType: 1,
-      affectFirst: 0,
-      easing: 0,
-      events: [],
-      customData: {},
-   };
+   static defaultValue: IWrapLightRotationEventBoxAttribute = createLightRotationEventBox();
 
    static createOne(
       data: Partial<IWrapLightRotationEventBoxAttribute> = {},

--- a/src/beatmap/core/lightRotationEventBoxGroup.ts
+++ b/src/beatmap/core/lightRotationEventBoxGroup.ts
@@ -1,24 +1,31 @@
-import { EventBoxGroup } from './abstract/eventBoxGroup.ts';
+import type { IWrapLightRotationEventBox } from '../../types/beatmap/wrapper/lightRotationEventBox.ts';
 import type {
    IWrapLightRotationEventBoxGroup,
    IWrapLightRotationEventBoxGroupAttribute,
 } from '../../types/beatmap/wrapper/lightRotationEventBoxGroup.ts';
-import type { IWrapLightRotationEventBox } from '../../types/beatmap/wrapper/lightRotationEventBox.ts';
-import type { DeepPartialIgnore } from '../../types/utils.ts';
-import { LightRotationEventBox } from './lightRotationEventBox.ts';
+import type { DeepPartial, DeepPartialIgnore } from '../../types/utils.ts';
 import { deepCopy } from '../../utils/misc.ts';
+import { EventBoxGroup } from './abstract/eventBoxGroup.ts';
+import { createLightRotationEventBox, LightRotationEventBox } from './lightRotationEventBox.ts';
+
+export function createLightRotationEventBoxGroup(
+   data: DeepPartial<IWrapLightRotationEventBoxGroupAttribute> = {},
+): IWrapLightRotationEventBoxGroupAttribute {
+   return {
+      time: data.time ?? 0,
+      id: data.id ?? 0,
+      boxes: data.boxes?.map((e) => createLightRotationEventBox(e)) ?? [],
+      customData: deepCopy({ ...data.customData }),
+   };
+}
 
 /**
  * Core beatmap light rotation event box group.
  */
 export class LightRotationEventBoxGroup extends EventBoxGroup
    implements IWrapLightRotationEventBoxGroup {
-   static defaultValue: IWrapLightRotationEventBoxGroupAttribute = {
-      time: 0,
-      id: 0,
-      boxes: [],
-      customData: {},
-   };
+   static defaultValue: IWrapLightRotationEventBoxGroupAttribute =
+      createLightRotationEventBoxGroup();
 
    static createOne(
       data: Partial<IWrapLightRotationEventBoxGroupAttribute> = {},

--- a/src/beatmap/core/lightTranslationEvent.ts
+++ b/src/beatmap/core/lightTranslationEvent.ts
@@ -5,17 +5,23 @@ import type {
 import { deepCopy } from '../../utils/misc.ts';
 import { BaseObject } from './abstract/baseObject.ts';
 
+export function createLightTranslationEvent(
+   data: Partial<IWrapLightTranslationEventAttribute> = {},
+): IWrapLightTranslationEventAttribute {
+   return {
+      time: data.time ?? 0,
+      easing: data.easing ?? 0,
+      previous: data.previous ?? 0,
+      translation: data.translation ?? 0,
+      customData: deepCopy({ ...data.customData }),
+   };
+}
+
 /**
  * Core beatmap light translation event.
  */
 export class LightTranslationEvent extends BaseObject implements IWrapLightTranslationEvent {
-   static defaultValue: IWrapLightTranslationEventAttribute = {
-      time: 0,
-      easing: 0,
-      previous: 0,
-      translation: 0,
-      customData: {},
-   };
+   static defaultValue: IWrapLightTranslationEventAttribute = createLightTranslationEvent();
 
    static createOne(
       data: Partial<IWrapLightTranslationEventAttribute> = {},

--- a/src/beatmap/core/lightTranslationEventBox.ts
+++ b/src/beatmap/core/lightTranslationEventBox.ts
@@ -3,40 +3,35 @@ import type {
    IWrapLightTranslationEventBox,
    IWrapLightTranslationEventBoxAttribute,
 } from '../../types/beatmap/wrapper/lightTranslationEventBox.ts';
-import type { DeepPartialIgnore } from '../../types/utils.ts';
+import type { DeepPartial, DeepPartialIgnore } from '../../types/utils.ts';
 import { deepCopy } from '../../utils/misc.ts';
 import { EventBox } from './abstract/eventBox.ts';
-import { IndexFilter } from './indexFilter.ts';
-import { LightTranslationEvent } from './lightTranslationEvent.ts';
+import { createIndexFilter, IndexFilter } from './indexFilter.ts';
+import { createLightTranslationEvent, LightTranslationEvent } from './lightTranslationEvent.ts';
+
+export function createLightTranslationEventBox(
+   data: DeepPartial<IWrapLightTranslationEventBoxAttribute> = {},
+): IWrapLightTranslationEventBoxAttribute {
+   return {
+      filter: createIndexFilter(data.filter),
+      axis: data.axis ?? 0,
+      flip: data.flip ?? 0,
+      beatDistribution: data.beatDistribution ?? 0,
+      beatDistributionType: data.beatDistributionType ?? 1,
+      gapDistribution: data.gapDistribution ?? 0,
+      gapDistributionType: data.gapDistributionType ?? 1,
+      affectFirst: data.affectFirst ?? 0,
+      easing: data.easing ?? 0,
+      events: data.events?.map((o) => createLightTranslationEvent(o)) ?? [],
+      customData: deepCopy({ ...data.customData }),
+   };
+}
 
 /**
  * Core beatmap light translation event box.
  */
 export class LightTranslationEventBox extends EventBox implements IWrapLightTranslationEventBox {
-   static defaultValue: IWrapLightTranslationEventBoxAttribute = {
-      filter: {
-         type: 1,
-         p0: 0,
-         p1: 0,
-         reverse: 0,
-         chunks: 0,
-         random: 0,
-         seed: 0,
-         limit: 0,
-         limitAffectsType: 0,
-         customData: {},
-      },
-      axis: 0,
-      flip: 0,
-      beatDistribution: 0,
-      beatDistributionType: 1,
-      gapDistribution: 0,
-      gapDistributionType: 1,
-      affectFirst: 0,
-      easing: 0,
-      events: [],
-      customData: {},
-   };
+   static defaultValue: IWrapLightTranslationEventBoxAttribute = createLightTranslationEventBox();
 
    static createOne(
       data: Partial<IWrapLightTranslationEventBoxAttribute> = {},

--- a/src/beatmap/core/lightTranslationEventBoxGroup.ts
+++ b/src/beatmap/core/lightTranslationEventBoxGroup.ts
@@ -1,24 +1,34 @@
-import { EventBoxGroup } from './abstract/eventBoxGroup.ts';
+import type { IWrapLightTranslationEventBox } from '../../types/beatmap/wrapper/lightTranslationEventBox.ts';
 import type {
    IWrapLightTranslationEventBoxGroup,
    IWrapLightTranslationEventBoxGroupAttribute,
 } from '../../types/beatmap/wrapper/lightTranslationEventBoxGroup.ts';
-import type { IWrapLightTranslationEventBox } from '../../types/beatmap/wrapper/lightTranslationEventBox.ts';
-import type { DeepPartialIgnore } from '../../types/utils.ts';
-import { LightTranslationEventBox } from './lightTranslationEventBox.ts';
+import type { DeepPartial, DeepPartialIgnore } from '../../types/utils.ts';
 import { deepCopy } from '../../utils/misc.ts';
+import { EventBoxGroup } from './abstract/eventBoxGroup.ts';
+import {
+   createLightTranslationEventBox,
+   LightTranslationEventBox,
+} from './lightTranslationEventBox.ts';
+
+export function createLightTranslationEventBoxGroup(
+   data: DeepPartial<IWrapLightTranslationEventBoxGroupAttribute> = {},
+): IWrapLightTranslationEventBoxGroupAttribute {
+   return {
+      time: data.time ?? 0,
+      id: data.id ?? 0,
+      boxes: data.boxes?.map((e) => createLightTranslationEventBox(e)) ?? [],
+      customData: deepCopy({ ...data.customData }),
+   };
+}
 
 /**
  * Core beatmap light translation event box group.
  */
 export class LightTranslationEventBoxGroup extends EventBoxGroup
    implements IWrapLightTranslationEventBoxGroup {
-   static defaultValue: IWrapLightTranslationEventBoxGroupAttribute = {
-      time: 0,
-      id: 0,
-      boxes: [],
-      customData: {},
-   };
+   static defaultValue: IWrapLightTranslationEventBoxGroupAttribute =
+      createLightTranslationEventBoxGroup();
 
    static createOne(
       data: Partial<IWrapLightTranslationEventBoxGroupAttribute> = {},

--- a/src/beatmap/core/lightshow.ts
+++ b/src/beatmap/core/lightshow.ts
@@ -8,6 +8,10 @@ import type {
    IWrapColorBoostEventAttribute,
 } from '../../types/beatmap/wrapper/colorBoostEvent.ts';
 import type {
+   IWrapFxEventBoxGroup,
+   IWrapFxEventBoxGroupAttribute,
+} from '../../types/beatmap/wrapper/fxEventBoxGroup.ts';
+import type {
    IWrapLightColorEventBoxGroup,
    IWrapLightColorEventBoxGroupAttribute,
 } from '../../types/beatmap/wrapper/lightColorEventBoxGroup.ts';
@@ -16,6 +20,10 @@ import type {
    IWrapLightRotationEventBoxGroupAttribute,
 } from '../../types/beatmap/wrapper/lightRotationEventBoxGroup.ts';
 import type {
+   IWrapLightshow,
+   IWrapLightshowAttribute,
+} from '../../types/beatmap/wrapper/lightshow.ts';
+import type {
    IWrapLightTranslationEventBoxGroup,
    IWrapLightTranslationEventBoxGroupAttribute,
 } from '../../types/beatmap/wrapper/lightTranslationEventBoxGroup.ts';
@@ -23,43 +31,59 @@ import type {
    IWrapWaypoint,
    IWrapWaypointAttribute,
 } from '../../types/beatmap/wrapper/waypoint.ts';
-import type { DeepPartialIgnore } from '../../types/utils.ts';
-import { BaseItem } from './abstract/baseItem.ts';
-import type {
-   IWrapLightshow,
-   IWrapLightshowAttribute,
-} from '../../types/beatmap/wrapper/lightshow.ts';
-import type {
-   IWrapFxEventBoxGroup,
-   IWrapFxEventBoxGroupAttribute,
-} from '../../types/beatmap/wrapper/fxEventBoxGroup.ts';
-import { sortObjectFn } from '../helpers/sort.ts';
-import { Waypoint } from './waypoint.ts';
-import { BasicEvent } from './basicEvent.ts';
-import { ColorBoostEvent } from './colorBoostEvent.ts';
-import { LightColorEventBoxGroup } from './lightColorEventBoxGroup.ts';
-import { LightRotationEventBoxGroup } from './lightRotationEventBoxGroup.ts';
-import { LightTranslationEventBoxGroup } from './lightTranslationEventBoxGroup.ts';
-import { FxEventBoxGroup } from './fxEventBoxGroup.ts';
-import { BasicEventTypesForKeywords } from './basicEventTypesForKeywords.ts';
+import type { DeepPartial, DeepPartialIgnore } from '../../types/utils.ts';
 import { deepCopy } from '../../utils/misc.ts';
+import { sortObjectFn } from '../helpers/sort.ts';
+import { BaseItem } from './abstract/baseItem.ts';
+import { BasicEvent, createBasicEvent } from './basicEvent.ts';
+import {
+   BasicEventTypesForKeywords,
+   createBasicEventTypesForKeywords,
+} from './basicEventTypesForKeywords.ts';
+import { ColorBoostEvent, createColorBoostEvent } from './colorBoostEvent.ts';
+import { createFxEventBoxGroup, FxEventBoxGroup } from './fxEventBoxGroup.ts';
+import {
+   createLightColorEventBoxGroup,
+   LightColorEventBoxGroup,
+} from './lightColorEventBoxGroup.ts';
+import {
+   createLightRotationEventBoxGroup,
+   LightRotationEventBoxGroup,
+} from './lightRotationEventBoxGroup.ts';
+import {
+   createLightTranslationEventBoxGroup,
+   LightTranslationEventBoxGroup,
+} from './lightTranslationEventBoxGroup.ts';
+import { createWaypoint, Waypoint } from './waypoint.ts';
+
+export function createLightshow(
+   data: DeepPartial<IWrapLightshowAttribute> = {},
+): IWrapLightshowAttribute {
+   return {
+      waypoints: data.waypoints?.map(createWaypoint) ?? [],
+      basicEvents: data.basicEvents?.map(createBasicEvent) ?? [],
+      colorBoostEvents: data.colorBoostEvents?.map(createColorBoostEvent) ?? [],
+      lightColorEventBoxGroups: data.lightColorEventBoxGroups?.map(createLightColorEventBoxGroup) ??
+         [],
+      lightRotationEventBoxGroups:
+         data.lightRotationEventBoxGroups?.map(createLightRotationEventBoxGroup) ?? [],
+      lightTranslationEventBoxGroups:
+         data.lightTranslationEventBoxGroups?.map(createLightTranslationEventBoxGroup) ?? [],
+      fxEventBoxGroups: data.fxEventBoxGroups?.map(createFxEventBoxGroup) ?? [],
+      basicEventTypesWithKeywords: {
+         list: (data.basicEventTypesWithKeywords?.list)?.map(createBasicEventTypesForKeywords) ??
+            [],
+      },
+      useNormalEventsAsCompatibleEvents: !!data.useNormalEventsAsCompatibleEvents,
+      customData: deepCopy({ ...data.customData }),
+   };
+}
 
 /**
  * Core beatmap lightshow.
  */
 export class Lightshow extends BaseItem implements IWrapLightshow {
-   static defaultValue: IWrapLightshowAttribute = {
-      waypoints: [],
-      basicEvents: [],
-      colorBoostEvents: [],
-      lightColorEventBoxGroups: [],
-      lightRotationEventBoxGroups: [],
-      lightTranslationEventBoxGroups: [],
-      fxEventBoxGroups: [],
-      basicEventTypesWithKeywords: { list: [] },
-      useNormalEventsAsCompatibleEvents: false,
-      customData: {},
-   };
+   static defaultValue: IWrapLightshowAttribute = createLightshow();
 
    static createOne(data: Partial<IWrapLightshowAttribute> = {}): Lightshow {
       return new this(data);

--- a/src/beatmap/core/njsEvent.ts
+++ b/src/beatmap/core/njsEvent.ts
@@ -1,21 +1,28 @@
-import { BaseObject } from './abstract/baseObject.ts';
 import type {
    IWrapNJSEvent,
    IWrapNJSEventAttribute,
 } from '../../types/beatmap/wrapper/njsEvent.ts';
+import type { DeepPartial } from '../../types/utils.ts';
 import { deepCopy } from '../../utils/misc.ts';
+import { BaseObject } from './abstract/baseObject.ts';
+
+export function createNJSEvent(
+   data: DeepPartial<IWrapNJSEventAttribute> = {},
+): IWrapNJSEventAttribute {
+   return {
+      time: data.time ?? 0,
+      value: data.value ?? 0,
+      previous: data.previous ?? 0,
+      easing: data.easing ?? 0,
+      customData: deepCopy({ ...data.customData }),
+   };
+}
 
 /**
  * Core beatmap NJS event.
  */
 export class NJSEvent extends BaseObject implements IWrapNJSEvent {
-   static defaultValue: IWrapNJSEventAttribute = {
-      time: 0,
-      value: 0,
-      previous: 0,
-      easing: 0,
-      customData: {},
-   };
+   static defaultValue: IWrapNJSEventAttribute = createNJSEvent();
 
    static createOne(data: Partial<IWrapNJSEventAttribute> = {}): NJSEvent {
       return new this(data);

--- a/src/beatmap/core/obstacle.ts
+++ b/src/beatmap/core/obstacle.ts
@@ -5,6 +5,13 @@ import type {
 } from '../../types/beatmap/wrapper/obstacle.ts';
 import type { Vector2 } from '../../types/vector.ts';
 import { deepCopy } from '../../utils/misc.ts';
+import { vectorAdd } from '../../utils/vector.ts';
+import { mirrorCoordinate, resolveGridPosition } from '../helpers/core/gridObject.ts';
+import {
+   isInteractiveObstacle,
+   isNegativeValueObstacle,
+   isZeroValueObstacle,
+} from '../helpers/core/obstacle.ts';
 import { LINE_COUNT } from '../shared/constants.ts';
 import { GridObject } from './abstract/gridObject.ts';
 
@@ -66,29 +73,24 @@ export class Obstacle extends GridObject implements IWrapObstacle {
 
    override mirror(_flipAlt?: boolean, fn?: MirrorFn<this>): this {
       fn?.(this);
-      this.posX = LINE_COUNT - 1 - (this.posX + this.width - 1);
+      this.posX = mirrorCoordinate(this.posX + this.width - 1, LINE_COUNT);
       return this;
    }
 
    override getPosition(fn?: GetPositionFn<this>): Vector2 {
-      return fn?.(this) ?? [this.posX - 2, this.posY - 0.5];
+      return fn?.(this) ?? vectorAdd(resolveGridPosition(this), [-2, -0.5]);
    }
 
    // FIXME: there are a lot more other variables
    isInteractive(): boolean {
-      return (
-         (this.posX < 0 && this.width > 1 - this.posX) ||
-         (this.posX === 0 && this.width > 1) ||
-         this.posX === 1 ||
-         this.posX === 2
-      );
+      return isInteractiveObstacle(this);
    }
 
    hasZero(): boolean {
-      return this.duration === 0 || this.width === 0 || this.height === 0;
+      return isZeroValueObstacle(this);
    }
 
    hasNegative(): boolean {
-      return this.posY < 0 || this.duration < 0 || this.width < 0 || this.height < 0;
+      return isNegativeValueObstacle(this);
    }
 }

--- a/src/beatmap/core/obstacle.ts
+++ b/src/beatmap/core/obstacle.ts
@@ -3,6 +3,7 @@ import type {
    IWrapObstacle,
    IWrapObstacleAttribute,
 } from '../../types/beatmap/wrapper/obstacle.ts';
+import type { DeepPartial } from '../../types/utils.ts';
 import type { Vector2 } from '../../types/vector.ts';
 import { deepCopy } from '../../utils/misc.ts';
 import { vectorAdd } from '../../utils/vector.ts';
@@ -15,20 +16,26 @@ import {
 import { LINE_COUNT } from '../shared/constants.ts';
 import { GridObject } from './abstract/gridObject.ts';
 
+export function createObstacle(
+   data: DeepPartial<IWrapObstacleAttribute> = {},
+): IWrapObstacleAttribute {
+   return {
+      time: data.time ?? 0,
+      posX: data.posX ?? 0,
+      posY: data.posY ?? 0,
+      width: data.width ?? 0,
+      height: data.height ?? 0,
+      duration: data.duration ?? 0,
+      laneRotation: data.laneRotation ?? 0,
+      customData: deepCopy({ ...data.customData }),
+   };
+}
+
 /**
  * Core beatmap obstacle.
  */
 export class Obstacle extends GridObject implements IWrapObstacle {
-   static defaultValue: IWrapObstacleAttribute = {
-      time: 0,
-      posX: 0,
-      posY: 0,
-      width: 0,
-      height: 0,
-      duration: 0,
-      laneRotation: 0,
-      customData: {},
-   };
+   static defaultValue: IWrapObstacleAttribute = createObstacle();
 
    static createOne(data: Partial<IWrapObstacleAttribute> = {}): Obstacle {
       return new this(data);

--- a/src/beatmap/core/rotationEvent.ts
+++ b/src/beatmap/core/rotationEvent.ts
@@ -1,20 +1,27 @@
-import { BaseObject } from './abstract/baseObject.ts';
 import type {
    IWrapRotationEvent,
    IWrapRotationEventAttribute,
 } from '../../types/beatmap/wrapper/rotationEvent.ts';
+import type { DeepPartial } from '../../types/utils.ts';
 import { deepCopy } from '../../utils/misc.ts';
+import { BaseObject } from './abstract/baseObject.ts';
+
+export function createRotationEvent(
+   data: DeepPartial<IWrapRotationEventAttribute> = {},
+): IWrapRotationEventAttribute {
+   return {
+      time: data.time ?? 0,
+      executionTime: data.executionTime ?? 0,
+      rotation: data.rotation ?? 0,
+      customData: deepCopy({ ...data.customData }),
+   };
+}
 
 /**
  * Core beatmap rotation event.
  */
 export class RotationEvent extends BaseObject implements IWrapRotationEvent {
-   static defaultValue: IWrapRotationEventAttribute = {
-      time: 0,
-      executionTime: 0,
-      rotation: 0,
-      customData: {},
-   };
+   static defaultValue: IWrapRotationEventAttribute = createRotationEvent();
 
    static createOne(data: Partial<IWrapRotationEventAttribute> = {}): RotationEvent {
       return new this(data);

--- a/src/beatmap/core/waypoint.ts
+++ b/src/beatmap/core/waypoint.ts
@@ -1,11 +1,12 @@
-import { LINE_COUNT } from '../shared/constants.ts';
+import type { MirrorFn } from '../../types/beatmap/shared/functions.ts';
 import type {
    IWrapWaypoint,
    IWrapWaypointAttribute,
 } from '../../types/beatmap/wrapper/waypoint.ts';
-import { GridObject } from './abstract/gridObject.ts';
 import { deepCopy } from '../../utils/misc.ts';
-import type { MirrorFn } from '../../types/beatmap/shared/functions.ts';
+import { mirrorCoordinate } from '../helpers/core/gridObject.ts';
+import { LINE_COUNT } from '../shared/constants.ts';
+import { GridObject } from './abstract/gridObject.ts';
 
 /**
  * Core beatmap waypoint.
@@ -45,7 +46,7 @@ export class Waypoint extends GridObject implements IWrapWaypoint {
 
    override mirror(_flipAlt?: boolean, fn?: MirrorFn<this>): this {
       fn?.(this);
-      this.posX = LINE_COUNT - 1 - this.posX;
+      this.posX = mirrorCoordinate(this.posX, LINE_COUNT);
       switch (this.direction) {
          case 2:
             this.direction = 3;

--- a/src/beatmap/core/waypoint.ts
+++ b/src/beatmap/core/waypoint.ts
@@ -3,23 +3,30 @@ import type {
    IWrapWaypoint,
    IWrapWaypointAttribute,
 } from '../../types/beatmap/wrapper/waypoint.ts';
+import type { DeepPartial } from '../../types/utils.ts';
 import { deepCopy } from '../../utils/misc.ts';
 import { mirrorCoordinate } from '../helpers/core/gridObject.ts';
 import { LINE_COUNT } from '../shared/constants.ts';
 import { GridObject } from './abstract/gridObject.ts';
 
+export function createWaypoint(
+   data: DeepPartial<IWrapWaypointAttribute> = {},
+): IWrapWaypointAttribute {
+   return {
+      time: data.time ?? 0,
+      posX: data.posX ?? 0,
+      posY: data.posY ?? 0,
+      direction: data.direction ?? 0,
+      laneRotation: data.laneRotation ?? 0,
+      customData: deepCopy({ ...data.customData }),
+   };
+}
+
 /**
  * Core beatmap waypoint.
  */
 export class Waypoint extends GridObject implements IWrapWaypoint {
-   static defaultValue: IWrapWaypointAttribute = {
-      time: 0,
-      posX: 0,
-      posY: 0,
-      direction: 0,
-      laneRotation: 0,
-      customData: {},
-   };
+   static defaultValue: IWrapWaypointAttribute = createWaypoint();
 
    static createOne(data: Partial<IWrapWaypointAttribute> = {}): Waypoint {
       return new this(data);

--- a/src/beatmap/helpers/beatmap.ts
+++ b/src/beatmap/helpers/beatmap.ts
@@ -1,19 +1,23 @@
-import type { IWrapBeatmap } from '../../types/beatmap/wrapper/beatmap.ts';
+import type { IWrapBeatmapAttributeSubset } from '../../types/beatmap/wrapper/beatmap.ts';
+import { isInteractiveObstacle } from './core/obstacle.ts';
 import { sortNoteFn } from './sort.ts';
 import type { TimeProcessor } from './timeProcessor.ts';
 
 /** Calculates the number of notes per second. */
-export function calculateNps(beatmap: IWrapBeatmap, duration: number): number {
+export function calculateNps<
+   T extends IWrapBeatmapAttributeSubset<'colorNotes'>,
+>(
+   beatmap: T,
+   duration: number,
+): number {
    const notes = beatmap.difficulty.colorNotes;
    return duration ? notes.length / duration : 0;
 }
 
 /** Calculates the peak number of notes per second given beat count. */
-export function calculateNpsPeak(
-   beatmap: IWrapBeatmap,
-   beatCount: number,
-   timeProcessor: TimeProcessor,
-): number {
+export function calculateNpsPeak<
+   T extends IWrapBeatmapAttributeSubset<'colorNotes'>,
+>(beatmap: T, beatCount: number, timeProcessor: TimeProcessor): number {
    let peakNPS = 0;
    let currentSectionStart = 0;
    const notes = beatmap.difficulty.colorNotes;
@@ -36,7 +40,9 @@ export function calculateNpsPeak(
  *
  * Color notes, bomb notes, chains and obstacles in middle lane are considered interactive object.
  */
-export function getFirstInteractiveTime(beatmap: IWrapBeatmap): number {
+export function getFirstInteractiveTime<
+   T extends IWrapBeatmapAttributeSubset<'colorNotes' | 'bombNotes' | 'obstacles' | 'chains'>,
+>(beatmap: T): number {
    const notes = [
       ...beatmap.difficulty.colorNotes,
       ...beatmap.difficulty.bombNotes,
@@ -55,7 +61,9 @@ export function getFirstInteractiveTime(beatmap: IWrapBeatmap): number {
  *
  * Color notes, bomb notes, chains and obstacles in middle lane are considered interactive object.
  */
-export function getLastInteractiveTime(beatmap: IWrapBeatmap): number {
+export function getLastInteractiveTime<
+   T extends IWrapBeatmapAttributeSubset<'colorNotes' | 'bombNotes' | 'obstacles' | 'chains'>,
+>(beatmap: T): number {
    const notes = [
       ...beatmap.difficulty.colorNotes,
       ...beatmap.difficulty.bombNotes,
@@ -72,10 +80,12 @@ export function getLastInteractiveTime(beatmap: IWrapBeatmap): number {
 /**
  * Get the first obstacle interactive time.
  */
-export function findFirstInteractiveObstacleTime(beatmap: IWrapBeatmap): number {
-   for (let i = 0, len = beatmap.obstacles.length; i < len; i++) {
-      if (beatmap.obstacles[i].isInteractive()) {
-         return beatmap.obstacles[i].time;
+export function findFirstInteractiveObstacleTime<
+   T extends IWrapBeatmapAttributeSubset<'obstacles'>,
+>(beatmap: T): number {
+   for (let i = 0, len = beatmap.difficulty.obstacles.length; i < len; i++) {
+      if (isInteractiveObstacle(beatmap.difficulty.obstacles[i])) {
+         return beatmap.difficulty.obstacles[i].time;
       }
    }
    return Number.MAX_VALUE;
@@ -84,10 +94,12 @@ export function findFirstInteractiveObstacleTime(beatmap: IWrapBeatmap): number 
 /**
  * Get the last obstacle interactive time.
  */
-export function findLastInteractiveObstacleTime(beatmap: IWrapBeatmap): number {
+export function findLastInteractiveObstacleTime<
+   T extends IWrapBeatmapAttributeSubset<'obstacles'>,
+>(beatmap: T): number {
    let obstacleEnd = 0;
    for (let i = beatmap.difficulty.obstacles.length - 1; i >= 0; i--) {
-      if (beatmap.difficulty.obstacles[i].isInteractive()) {
+      if (isInteractiveObstacle(beatmap.difficulty.obstacles[i])) {
          obstacleEnd = Math.max(
             obstacleEnd,
             beatmap.difficulty.obstacles[i].time + beatmap.difficulty.obstacles[i].duration,

--- a/src/beatmap/helpers/beatmap.ts
+++ b/src/beatmap/helpers/beatmap.ts
@@ -1,3 +1,4 @@
+import type { ISwingAnalysisBeatmapAttribute } from '../../extensions/swing/types/swing.ts';
 import type { IWrapBeatmapAttributeSubset } from '../../types/beatmap/wrapper/beatmap.ts';
 import { isInteractiveObstacle } from './core/obstacle.ts';
 import { sortNoteFn } from './sort.ts';
@@ -5,18 +6,15 @@ import type { TimeProcessor } from './timeProcessor.ts';
 
 /** Calculates the number of notes per second. */
 export function calculateNps<
-   T extends IWrapBeatmapAttributeSubset<'colorNotes'>,
->(
-   beatmap: T,
-   duration: number,
-): number {
+   T extends IWrapBeatmapAttributeSubset<'colorNotes', never>,
+>(beatmap: T, duration: number): number {
    const notes = beatmap.difficulty.colorNotes;
    return duration ? notes.length / duration : 0;
 }
 
 /** Calculates the peak number of notes per second given beat count. */
 export function calculateNpsPeak<
-   T extends IWrapBeatmapAttributeSubset<'colorNotes'>,
+   T extends IWrapBeatmapAttributeSubset<'colorNotes', 'time'>,
 >(beatmap: T, beatCount: number, timeProcessor: TimeProcessor): number {
    let peakNPS = 0;
    let currentSectionStart = 0;
@@ -41,7 +39,7 @@ export function calculateNpsPeak<
  * Color notes, bomb notes, chains and obstacles in middle lane are considered interactive object.
  */
 export function getFirstInteractiveTime<
-   T extends IWrapBeatmapAttributeSubset<'colorNotes' | 'bombNotes' | 'obstacles' | 'chains'>,
+   T extends ISwingAnalysisBeatmapAttribute,
 >(beatmap: T): number {
    const notes = [
       ...beatmap.difficulty.colorNotes,
@@ -62,7 +60,7 @@ export function getFirstInteractiveTime<
  * Color notes, bomb notes, chains and obstacles in middle lane are considered interactive object.
  */
 export function getLastInteractiveTime<
-   T extends IWrapBeatmapAttributeSubset<'colorNotes' | 'bombNotes' | 'obstacles' | 'chains'>,
+   T extends ISwingAnalysisBeatmapAttribute,
 >(beatmap: T): number {
    const notes = [
       ...beatmap.difficulty.colorNotes,
@@ -81,7 +79,7 @@ export function getLastInteractiveTime<
  * Get the first obstacle interactive time.
  */
 export function findFirstInteractiveObstacleTime<
-   T extends IWrapBeatmapAttributeSubset<'obstacles'>,
+   T extends IWrapBeatmapAttributeSubset<'obstacles', 'time' | 'posX' | 'width'>,
 >(beatmap: T): number {
    for (let i = 0, len = beatmap.difficulty.obstacles.length; i < len; i++) {
       if (isInteractiveObstacle(beatmap.difficulty.obstacles[i])) {
@@ -95,7 +93,7 @@ export function findFirstInteractiveObstacleTime<
  * Get the last obstacle interactive time.
  */
 export function findLastInteractiveObstacleTime<
-   T extends IWrapBeatmapAttributeSubset<'obstacles'>,
+   T extends IWrapBeatmapAttributeSubset<'obstacles', 'time' | 'posX' | 'duration' | 'width'>,
 >(beatmap: T): number {
    let obstacleEnd = 0;
    for (let i = beatmap.difficulty.obstacles.length - 1; i >= 0; i--) {

--- a/src/beatmap/helpers/core/arc.ts
+++ b/src/beatmap/helpers/core/arc.ts
@@ -1,0 +1,7 @@
+import { cycle } from '../../../utils/misc.ts';
+import { SliderMidAnchorMode } from '../../shared/constants.ts';
+
+/** Mirror note color. */
+export function mirrorArcMidAnchor(midAnchor: SliderMidAnchorMode) {
+   return cycle([SliderMidAnchorMode.CLOCKWISE, SliderMidAnchorMode.COUNTER_CLOCKWISE], midAnchor);
+}

--- a/src/beatmap/helpers/core/baseNote.ts
+++ b/src/beatmap/helpers/core/baseNote.ts
@@ -12,7 +12,7 @@ export function isRedNoteColor(color: NoteColor) {
 }
 /** Check if note color is not set (-1). */
 export function isUnsetNoteColor(color: NoteColor) {
-   return color === NoteColor.BLUE;
+   return color === NoteColor.NONE;
 }
 
 /** Compare two notes and return if they would form a double. */

--- a/src/beatmap/helpers/core/baseNote.ts
+++ b/src/beatmap/helpers/core/baseNote.ts
@@ -1,0 +1,78 @@
+import { NoteColor, NoteDirection, NoteDirectionAngle } from '../../../beatmap/shared/constants.ts';
+import type { IWrapBaseNoteAttribute } from '../../../types/beatmap/wrapper/baseNote.ts';
+import { cycle } from '../../../utils/misc.ts';
+
+/** Check if note color is red. */
+export function isBlueNoteColor(color: NoteColor) {
+   return color === NoteColor.RED;
+}
+/** Check if note color is blue. */
+export function isRedNoteColor(color: NoteColor) {
+   return color === NoteColor.BLUE;
+}
+/** Check if note color is not set (-1). */
+export function isUnsetNoteColor(color: NoteColor) {
+   return color === NoteColor.BLUE;
+}
+
+/** Compare two notes and return if they would form a double. */
+export function isDouble<
+   T extends Pick<IWrapBaseNoteAttribute, 'time' | 'color'>,
+>(object: T, compareTo: T, tolerance = 0.01) {
+   return (
+      compareTo.time > object.time - tolerance &&
+      compareTo.time < object.time + tolerance &&
+      object.color !== compareTo.color
+   );
+}
+
+/** Get standardised note angle. */
+export function resolveNoteAngle(direction: NoteDirection): number {
+   return NoteDirectionAngle[direction as keyof typeof NoteDirectionAngle] ?? 0;
+}
+
+/** Mirror note color. */
+export function mirrorNoteColor(color: NoteColor) {
+   return cycle([NoteColor.RED, NoteColor.BLUE], color);
+}
+
+/** Mirror note direction horizontally. */
+export function mirrorNoteDirectionHorizontally(direction: NoteDirection) {
+   switch (direction) {
+      case NoteDirection.UP_LEFT:
+      case NoteDirection.LEFT:
+      case NoteDirection.DOWN_LEFT: {
+         return direction + 1;
+      }
+      case NoteDirection.UP_RIGHT:
+      case NoteDirection.RIGHT:
+      case NoteDirection.DOWN_RIGHT: {
+         return direction - 1;
+      }
+      default: {
+         return direction;
+      }
+   }
+}
+/** Mirror note direction vertically. */
+export function mirrorNoteDirectionVertically(direction: NoteDirection) {
+   switch (direction) {
+      case NoteDirection.UP_LEFT:
+      case NoteDirection.UP_RIGHT: {
+         return direction + 2;
+      }
+      case NoteDirection.UP: {
+         return direction + 1;
+      }
+      case NoteDirection.DOWN: {
+         return direction - 1;
+      }
+      case NoteDirection.DOWN_LEFT:
+      case NoteDirection.DOWN_RIGHT: {
+         return direction - 2;
+      }
+      default: {
+         return direction;
+      }
+   }
+}

--- a/src/beatmap/helpers/core/baseSlider.ts
+++ b/src/beatmap/helpers/core/baseSlider.ts
@@ -1,0 +1,8 @@
+import type { IWrapBaseSliderAttribute } from '../../../types/beatmap/wrapper/baseSlider.ts';
+
+/** Checks if the slider is inverted. */
+export function isInverseSlider<
+   T extends Pick<IWrapBaseSliderAttribute, 'time' | 'tailTime'>,
+>(object: T) {
+   return object.time > object.tailTime;
+}

--- a/src/beatmap/helpers/core/basicEvent.ts
+++ b/src/beatmap/helpers/core/basicEvent.ts
@@ -1,0 +1,157 @@
+import type { EnvironmentAllName } from '../../../types/beatmap/shared/environment.ts';
+import { EventLightValue, EventType } from '../../shared/constants.ts';
+
+/** Check if event type is valid. */
+export function isValidEventType(type: EventType): boolean {
+   // todo: replace with enum once schema changes land
+   return (type >= 0 && type <= 19) || (type >= 40 && type <= 43) || type === 100 || type === 1000;
+}
+
+/** Check if event type is a light event. */
+export function isLightEventType(type: EventType, _environment?: EnvironmentAllName): boolean {
+   return (
+      type === EventType.BACK_LASERS ||
+      type === EventType.RING_LIGHTS ||
+      type === EventType.LEFT_LASERS ||
+      type === EventType.RIGHT_LASERS ||
+      type === EventType.CENTER_LIGHTS ||
+      type === EventType.EXTRA_LEFT_LIGHTS ||
+      type === EventType.EXTRA_RIGHT_LIGHTS ||
+      type === EventType.EXTRA_LEFT_LASERS ||
+      type === EventType.EXTRA_RIGHT_LASERS
+   );
+}
+/** Check if event type is a color boost event. */
+export function isColorBoostEventType(type: EventType): boolean {
+   return type === EventType.COLOR_BOOST;
+}
+/** Check if event type is a ring event. */
+export function isRingEventType(type: EventType, _environment?: EnvironmentAllName): boolean {
+   return (
+      type === EventType.RING_ROTATION ||
+      type === EventType.RING_ZOOM
+   );
+}
+/** Check if event type is a laser rotation event. */
+export function isLaserRotationEventType(
+   type: EventType,
+   _environment?: EnvironmentAllName,
+): boolean {
+   return (
+      type === EventType.LEFT_LASER_ROTATION ||
+      type === EventType.RIGHT_LASER_ROTATION
+   );
+}
+/** Check if event type is a lane rotation event. */
+export function isLaneRotationEventType(type: EventType): boolean {
+   return (
+      type === EventType.EARLY_LANE_ROTATION ||
+      type === EventType.LATE_LANE_ROTATION
+   );
+}
+/** Check if event type is an extra event. */
+export function isExtraEventType(type: EventType, _environment?: EnvironmentAllName): boolean {
+   return (
+      type === EventType.UTILITY_EVENT_0 ||
+      type === EventType.UTILITY_EVENT_1 ||
+      type === EventType.UTILITY_EVENT_2 ||
+      type === EventType.UTILITY_EVENT_3
+   );
+}
+/** Check if event type is a special event. */
+export function isSpecialEventType(type: EventType, _environment?: EnvironmentAllName): boolean {
+   return (
+      type === EventType.SPECIAL_EVENT_0 ||
+      type === EventType.SPECIAL_EVENT_1 ||
+      type === EventType.SPECIAL_EVENT_2 ||
+      type === EventType.SPECIAL_EVENT_3
+   );
+}
+/** Check if event type is a BPM change. */
+export function isBpmChangeEventType(type: EventType): boolean {
+   return type === EventType.BPM_CHANGE;
+}
+/** Check if event type is an NJS change. */
+export function isNjsChangeEventType(type: EventType): boolean {
+   return type === EventType.NJS_CHANGE;
+}
+
+/** Not to be confused with isLightEvent, this checks for event that affects the environment/lighting. */
+export function isLightingEventType(type: EventType): boolean {
+   return (
+      isLightEventType(type) ||
+      isRingEventType(type) ||
+      isLaserRotationEventType(type) ||
+      isExtraEventType(type)
+   );
+}
+
+/** Check if light event is an off event. */
+export function isOffEventValue(value: number): boolean {
+   return value === EventLightValue.OFF;
+}
+/** Check if light event is an on event. */
+export function isOnEventValue(value: number): boolean {
+   return (
+      value === EventLightValue.BLUE_ON ||
+      value === EventLightValue.RED_ON ||
+      value === EventLightValue.WHITE_ON
+   );
+}
+/** Check if light event is a flash event. */
+export function isFlashEventValue(value: number): boolean {
+   return (
+      value === EventLightValue.BLUE_FLASH ||
+      value === EventLightValue.RED_FLASH ||
+      value === EventLightValue.WHITE_FLASH
+   );
+}
+/** Check if light event is a fade event. */
+export function isFadeEventValue(value: number): boolean {
+   return (
+      value === EventLightValue.BLUE_FADE ||
+      value === EventLightValue.RED_FADE ||
+      value === EventLightValue.WHITE_FADE
+   );
+}
+/** Check if light event is a transition event. */
+export function isTransitionEventValue(value: number): boolean {
+   return (
+      value === EventLightValue.BLUE_TRANSITION ||
+      value === EventLightValue.RED_TRANSITION ||
+      value === EventLightValue.WHITE_TRANSITION
+   );
+}
+
+/** Check if light event is a blue light. */
+export function isBlueEventValue(value: number): boolean {
+   return (
+      value === EventLightValue.BLUE_ON ||
+      value === EventLightValue.BLUE_FLASH ||
+      value === EventLightValue.BLUE_FADE ||
+      value === EventLightValue.BLUE_TRANSITION
+   );
+}
+/** Check if light event is a red light. */
+export function isRedEventValue(value: number): boolean {
+   return (
+      value === EventLightValue.RED_ON ||
+      value === EventLightValue.RED_FLASH ||
+      value === EventLightValue.RED_FADE ||
+      value === EventLightValue.RED_TRANSITION
+   );
+}
+/** Check if light event is a white light. */
+export function isWhiteEventValue(value: number): boolean {
+   return (
+      value === EventLightValue.WHITE_ON ||
+      value === EventLightValue.WHITE_FLASH ||
+      value === EventLightValue.WHITE_FADE ||
+      value === EventLightValue.WHITE_TRANSITION
+   );
+}
+
+/** Check if event has old Chroma properties. */
+export function isOldChromaEventValue(value: number): boolean {
+   return value >= 2000000000;
+}

--- a/src/beatmap/helpers/core/gridObject.ts
+++ b/src/beatmap/helpers/core/gridObject.ts
@@ -1,0 +1,83 @@
+import type { IWrapGridObjectAttribute } from '../../../types/beatmap/wrapper/gridObject.ts';
+import type { GetPositionFn } from '../../../types/mod.ts';
+import type { Vector2 } from '../../../types/vector.ts';
+import {
+   vectorDistance,
+   vectorIsDiagonal,
+   vectorIsHorizontal,
+   vectorIsVertical,
+} from '../../../utils/vector.ts';
+
+/** Get standardized grid position. */
+export function resolveGridPosition<
+   T extends Pick<IWrapGridObjectAttribute, 'posX' | 'posY'>,
+>(object: T): Vector2 {
+   return [object.posX, object.posY];
+}
+/** Get standardized grid distance. */
+export function resolveGridDistance<
+   T extends Pick<IWrapGridObjectAttribute, 'posX' | 'posY'>,
+>(o1: T, o2: NoInfer<T>, fn?: GetPositionFn<T>): number {
+   const v1 = fn?.(o1) ?? resolveGridPosition(o1);
+   const v2 = fn?.(o2) ?? resolveGridPosition(o2);
+   return vectorDistance(v1, v2);
+}
+
+/** Check if two objects are in horizontal alignment. */
+export function isHorizontal<
+   T extends Pick<IWrapGridObjectAttribute, 'posX' | 'posY'>,
+>(o1: T, o2: NoInfer<T>, epsilon = 0.001, fn?: GetPositionFn<T>) {
+   const v1 = fn?.(o1) ?? resolveGridPosition(o1);
+   const v2 = fn?.(o2) ?? resolveGridPosition(o2);
+   return vectorIsHorizontal(v1, v2, epsilon);
+}
+/** Check if two objects are in vertical alignment. */
+export function isVertical<
+   T extends Pick<IWrapGridObjectAttribute, 'posX' | 'posY'>,
+>(o1: T, o2: NoInfer<T>, epsilon = 0.001, fn?: GetPositionFn<T>) {
+   const v1 = fn?.(o1) ?? resolveGridPosition(o1);
+   const v2 = fn?.(o2) ?? resolveGridPosition(o2);
+   return vectorIsVertical(v1, v2, epsilon);
+}
+/** Check if two objects are in diagonal alignment. */
+export function isDiagonal<
+   T extends Pick<IWrapGridObjectAttribute, 'posX' | 'posY'>,
+>(o1: T, o2: NoInfer<T>, epsilon = 0.001, fn?: GetPositionFn<T>) {
+   const v1 = fn?.(o1) ?? resolveGridPosition(o1);
+   const v2 = fn?.(o2) ?? resolveGridPosition(o2);
+   return vectorIsDiagonal(v1, v2, epsilon);
+}
+/** Check if two objects are inline. */
+export function isInline<
+   T extends Pick<IWrapGridObjectAttribute, 'posX' | 'posY'>,
+>(o1: T, o2: NoInfer<T>, lapping = 0.5, fn?: GetPositionFn<T>) {
+   return resolveGridDistance(o1, o2, fn) <= lapping;
+}
+/** Check if two objects are adjacent. */
+export function isAdjacent<
+   T extends Pick<IWrapGridObjectAttribute, 'posX' | 'posY'>,
+>(o1: T, o2: NoInfer<T>, epsilon = 0.001, fn?: GetPositionFn<T>) {
+   const distance = resolveGridDistance(o1, o2, fn);
+   return distance > (0.5 - epsilon) && distance < (1 + epsilon);
+}
+/** Check if two objects form a "window". */
+export function isWindow<
+   T extends Pick<IWrapGridObjectAttribute, 'posX' | 'posY'>,
+>(o1: T, o2: NoInfer<T>, distance = 1.8, fn?: GetPositionFn<T>) {
+   return resolveGridDistance(o1, o2, fn) > distance;
+}
+/** Check if two objects form a "slanted window". */
+export function isSlantedWindow<
+   T extends Pick<IWrapGridObjectAttribute, 'posX' | 'posY'>,
+>(o1: T, o2: NoInfer<T>, fn?: GetPositionFn<T>) {
+   return (
+      isWindow(o1, o2, 1.8, fn) &&
+      !isDiagonal(o1, o2, 0.001, fn) &&
+      !isHorizontal(o1, o2, 0.001, fn) &&
+      !isVertical(o1, o2, 0.001, fn)
+   );
+}
+
+export function mirrorCoordinate(x: number, axis: number) {
+   return axis - 1 - x;
+}

--- a/src/beatmap/helpers/core/mod.ts
+++ b/src/beatmap/helpers/core/mod.ts
@@ -1,0 +1,6 @@
+export * from './arc.ts';
+export * from './baseNote.ts';
+export * from './baseSlider.ts';
+export * from './basicEvent.ts';
+export * from './gridObject.ts';
+export * from './obstacle.ts';

--- a/src/beatmap/helpers/core/obstacle.ts
+++ b/src/beatmap/helpers/core/obstacle.ts
@@ -1,0 +1,27 @@
+import type { IWrapObstacleAttribute } from '../../../types/beatmap/wrapper/obstacle.ts';
+
+/** Check if obstacle is interactive. */
+export function isInteractiveObstacle<
+   T extends Pick<IWrapObstacleAttribute, 'posX' | 'width'>,
+>(object: T) {
+   // FIXME: there are a lot more other variables
+   return (
+      (object.posX < 0 && object.width > 1 - object.posX) ||
+      (object.posX === 0 && object.width > 1) ||
+      object.posX === 1 ||
+      object.posX === 2
+   );
+}
+
+/** Check if obstacle has zero value. */
+export function isZeroValueObstacle<
+   T extends Pick<IWrapObstacleAttribute, 'duration' | 'width' | 'height'>,
+>(object: T) {
+   return object.duration === 0 || object.width === 0 || object.height === 0;
+}
+/** Check if obstacle has negative value. */
+export function isNegativeValueObstacle<
+   T extends Pick<IWrapObstacleAttribute, 'posY' | 'duration' | 'width' | 'height'>,
+>(object: T) {
+   return object.posY < 0 || object.duration < 0 || object.width < 0 || object.height < 0;
+}

--- a/src/beatmap/helpers/mod.ts
+++ b/src/beatmap/helpers/mod.ts
@@ -1,4 +1,6 @@
+export * from './core/mod.ts';
 export * from './modded/mod.ts';
+
 export * from './beatmap.ts';
 export * from './convert.ts';
 export * from './environment.ts';

--- a/src/beatmap/helpers/modded/angle.ts
+++ b/src/beatmap/helpers/modded/angle.ts
@@ -4,7 +4,7 @@ import type { ICustomDataNote } from '../../../types/beatmap/wrapper/custom/note
  * Get direction angle of Noodle Extensions in beatmap v2.
  */
 export function getNoodleExtensionsAngleV2<
-   T extends { customData: ICustomDataNote },
+   T extends { customData: Pick<ICustomDataNote, '_cutDirection'> },
 >(data: T): number | null {
    if (data.customData._cutDirection) {
       return data.customData._cutDirection > 0

--- a/src/beatmap/helpers/modded/angle.ts
+++ b/src/beatmap/helpers/modded/angle.ts
@@ -1,11 +1,11 @@
-import type { IWrapBaseItemAttribute } from '../../../types/beatmap/wrapper/baseItem.ts';
+import type { ICustomDataNote } from '../../../types/beatmap/wrapper/custom/note.ts';
 
 /**
  * Get direction angle of Noodle Extensions in beatmap v2.
  */
-export function getNoodleExtensionsAngleV2(
-   data: IWrapBaseItemAttribute,
-): number | null {
+export function getNoodleExtensionsAngleV2<
+   T extends { customData: ICustomDataNote },
+>(data: T): number | null {
    if (data.customData._cutDirection) {
       return data.customData._cutDirection > 0
          ? data.customData._cutDirection % 360

--- a/src/beatmap/helpers/modded/has.ts
+++ b/src/beatmap/helpers/modded/has.ts
@@ -1,9 +1,9 @@
 //FIXME: i feel like it's better to just check key instead of type of it
 import type { IWrapArcAttribute } from '../../../types/beatmap/wrapper/arc.ts';
-import type { IWrapBaseItemAttribute } from '../../../types/beatmap/wrapper/baseItem.ts';
-import type { IWrapBaseNoteAttribute } from '../../../types/beatmap/wrapper/baseNote.ts';
+import type { IWrapBasicEventAttribute } from '../../../types/beatmap/wrapper/basicEvent.ts';
 import type { IWrapBombNoteAttribute } from '../../../types/beatmap/wrapper/bombNote.ts';
 import type { IWrapChainAttribute } from '../../../types/beatmap/wrapper/chain.ts';
+import type { IWrapColorNoteAttribute } from '../../../types/beatmap/wrapper/colorNote.ts';
 import type { IWrapObstacleAttribute } from '../../../types/beatmap/wrapper/obstacle.ts';
 import type { IWrapRotationEventAttribute } from '../../../types/beatmap/wrapper/rotationEvent.ts';
 import { RotationValueEventValue } from '../../shared/constants.ts';
@@ -11,7 +11,9 @@ import { RotationValueEventValue } from '../../shared/constants.ts';
 /**
  * Checks if basic event has Chroma in beatmap v2.
  */
-export function hasChromaEventV2(data: IWrapBaseItemAttribute): boolean {
+export function hasChromaEventV2<
+   T extends Pick<IWrapBasicEventAttribute, 'customData'>,
+>(data: T): boolean {
    return (
       Array.isArray(data.customData._color) ||
       typeof data.customData._lightID === 'number' ||
@@ -41,7 +43,9 @@ export function hasChromaEventV2(data: IWrapBaseItemAttribute): boolean {
 /**
  * Checks if note has Chroma in beatmap v2.
  */
-export function hasChromaNoteV2(data: IWrapBaseItemAttribute): boolean {
+export function hasChromaNoteV2<
+   T extends Pick<IWrapColorNoteAttribute | IWrapBombNoteAttribute, 'customData'>,
+>(data: T): boolean {
    return (
       Array.isArray(data.customData._color) ||
       typeof data.customData._disableSpawnEffect === 'boolean'
@@ -51,9 +55,9 @@ export function hasChromaNoteV2(data: IWrapBaseItemAttribute): boolean {
 /**
  * Checks if note has Noodle Extensions in beatmap v2.
  */
-export function hasNoodleExtensionsNoteV2(
-   data: IWrapBaseItemAttribute,
-): boolean {
+export function hasNoodleExtensionsNoteV2<
+   T extends Pick<IWrapColorNoteAttribute | IWrapBombNoteAttribute, 'customData'>,
+>(data: T): boolean {
    return (
       Array.isArray(data.customData._animation) ||
       typeof data.customData._cutDirection === 'number' ||
@@ -73,16 +77,18 @@ export function hasNoodleExtensionsNoteV2(
 /**
  * Checks if obstacle has Chroma in beatmap v2
  */
-export function hasChromaObstacleV2(data: IWrapBaseItemAttribute): boolean {
+export function hasChromaObstacleV2<
+   T extends Pick<IWrapObstacleAttribute, 'customData'>,
+>(data: T): boolean {
    return Array.isArray(data.customData._color);
 }
 
 /**
  * Checks if obstacle has Noodle Extensions in beatmap v2.
  */
-export function hasNoodleExtensionsObstacleV2(
-   data: IWrapBaseItemAttribute,
-): boolean {
+export function hasNoodleExtensionsObstacleV2<
+   T extends Pick<IWrapObstacleAttribute, 'customData'>,
+>(data: T): boolean {
    return (
       Array.isArray(data.customData._animation) ||
       typeof data.customData._fake === 'boolean' ||
@@ -99,9 +105,9 @@ export function hasNoodleExtensionsObstacleV2(
 /**
  * Checks if obstacle has Mapping Extensions in beatmap v2.
  */
-export function hasMappingExtensionsObstacleV2(
-   data: IWrapObstacleAttribute,
-): boolean {
+export function hasMappingExtensionsObstacleV2<
+   T extends Pick<IWrapObstacleAttribute, 'posX' | 'posY' | 'width' | 'height'>,
+>(data: T): boolean {
    return (
       data.posX < 0 ||
       data.posX > 3 ||
@@ -118,25 +124,27 @@ export function hasMappingExtensionsObstacleV2(
 /**
  * Checks if rotation event has Noodle Extensions in beatmap v2.
  */
-export function hasNoodleExtensionsRotationV2(
-   data: IWrapRotationEventAttribute,
-): boolean {
+export function hasNoodleExtensionsRotationV2<
+   T extends Pick<IWrapRotationEventAttribute, 'customData'>,
+>(data: T): boolean {
    return typeof data.customData._rotation === 'number';
 }
 
 /**
  * Checks if rotation event has Mapping Extensions in beatmap v2.
  */
-export function hasMappingExtensionsRotationV2(
-   data: IWrapRotationEventAttribute,
-): boolean {
+export function hasMappingExtensionsRotationV2<
+   T extends Pick<IWrapRotationEventAttribute, 'rotation'>,
+>(data: T): boolean {
    return !RotationValueEventValue[data.rotation];
 }
 
 /**
  * Checks if basic event has Chroma in beatmap v3.
  */
-export function hasChromaEventV3(data: IWrapBaseItemAttribute): boolean {
+export function hasChromaEventV3<
+   T extends Pick<IWrapBasicEventAttribute, 'customData'>,
+>(data: T): boolean {
    return (
       Array.isArray(data.customData.color) ||
       typeof data.customData.lightID === 'number' ||
@@ -158,7 +166,9 @@ export function hasChromaEventV3(data: IWrapBaseItemAttribute): boolean {
 /**
  * Checks if note has Chroma in beatmap v3.
  */
-export function hasChromaNoteV3(data: IWrapBaseItemAttribute): boolean {
+export function hasChromaNoteV3<
+   T extends Pick<IWrapColorNoteAttribute | IWrapBombNoteAttribute, 'customData'>,
+>(data: T): boolean {
    return (
       Array.isArray(data.customData.color) ||
       typeof data.customData.spawnEffect === 'boolean' ||
@@ -169,9 +179,9 @@ export function hasChromaNoteV3(data: IWrapBaseItemAttribute): boolean {
 /**
  * Checks if note has Noodle Extensions in beatmap v3.
  */
-export function hasNoodleExtensionsNoteV3(
-   data: IWrapBaseItemAttribute,
-): boolean {
+export function hasNoodleExtensionsNoteV3<
+   T extends Pick<IWrapColorNoteAttribute | IWrapBombNoteAttribute, 'customData'>,
+>(data: T): boolean {
    return (
       Array.isArray(data.customData.animation) ||
       typeof data.customData.disableNoteGravity === 'boolean' ||
@@ -194,9 +204,9 @@ export function hasNoodleExtensionsNoteV3(
 /**
  * Checks if slider has Noodle Extensions in beatmap v3.
  */
-export function hasNoodleExtensionsSliderV3(
-   data: IWrapBaseItemAttribute,
-): boolean {
+export function hasNoodleExtensionsSliderV3<
+   T extends Pick<IWrapArcAttribute | IWrapChainAttribute, 'customData'>,
+>(data: T): boolean {
    return (
       Array.isArray(data.customData.animation) ||
       typeof data.customData.disableNoteGravity === 'boolean' ||
@@ -220,16 +230,18 @@ export function hasNoodleExtensionsSliderV3(
 /**
  * Checks if obstacle has Chroma in beatmap v3.
  */
-export function hasChromaObstacleV3(data: IWrapBaseItemAttribute): boolean {
+export function hasChromaObstacleV3<
+   T extends Pick<IWrapObstacleAttribute, 'customData'>,
+>(data: T): boolean {
    return Array.isArray(data.customData.color);
 }
 
 /**
  * Checks if obstacle has Noodle Extensions in beatmap v3.
  */
-export function hasNoodleExtensionsObstacleV3(
-   data: IWrapBaseItemAttribute,
-): boolean {
+export function hasNoodleExtensionsObstacleV3<
+   T extends Pick<IWrapObstacleAttribute, 'customData'>,
+>(data: T): boolean {
    return (
       Array.isArray(data.customData.animation) ||
       typeof data.customData.uninteractable === 'boolean' ||
@@ -245,9 +257,9 @@ export function hasNoodleExtensionsObstacleV3(
 /**
  * Checks if obstacle has Mapping Extensions in beatmap v3.
  */
-export function hasMappingExtensionsObstacleV3(
-   data: IWrapObstacleAttribute,
-): boolean {
+export function hasMappingExtensionsObstacleV3<
+   T extends Pick<IWrapObstacleAttribute, 'posX' | 'posY' | 'width' | 'height'>,
+>(data: T): boolean {
    return (
       data.posY < 0 ||
       data.posY > 2 ||
@@ -263,7 +275,9 @@ export function hasMappingExtensionsObstacleV3(
 /**
  * Checks if arc has Mapping Extensions in beatmap v3.
  */
-export function hasMappingExtensionsArc(data: IWrapArcAttribute): boolean {
+export function hasMappingExtensionsArc<
+   T extends Pick<IWrapArcAttribute, 'posX' | 'posY' | 'direction' | 'tailDirection'>,
+>(data: T): boolean {
    return (
       data.posY > 2 ||
       data.posY < 0 ||
@@ -277,16 +291,18 @@ export function hasMappingExtensionsArc(data: IWrapArcAttribute): boolean {
 /**
  * Checks if bomb note has Mapping Extensions in beatmap v3.
  */
-export function hasMappingExtensionsBombNote(
-   data: IWrapBombNoteAttribute,
-): boolean {
+export function hasMappingExtensionsBombNote<
+   T extends Pick<IWrapBombNoteAttribute, 'posX' | 'posY'>,
+>(data: T): boolean {
    return data.posX > 3 || data.posX < 0 || data.posY > 2 || data.posY < 0;
 }
 
 /**
  * Checks if chain has Mapping Extensions in beatmap v3.
  */
-export function hasMappingExtensionsChain(data: IWrapChainAttribute): boolean {
+export function hasMappingExtensionsChain<
+   T extends Pick<IWrapChainAttribute, 'posX' | 'posY' | 'direction'>,
+>(data: T): boolean {
    return (
       data.posY > 2 ||
       data.posY < 0 ||
@@ -299,9 +315,9 @@ export function hasMappingExtensionsChain(data: IWrapChainAttribute): boolean {
 /**
  * Checks if note has Mapping Extensions.
  */
-export function hasMappingExtensionsNote(
-   data: IWrapBaseNoteAttribute,
-): boolean {
+export function hasMappingExtensionsNote<
+   T extends Pick<IWrapColorNoteAttribute, 'posX' | 'posY' | 'direction'>,
+>(data: T): boolean {
    return (
       data.posX > 3 ||
       data.posX < 0 ||

--- a/src/beatmap/helpers/modded/mirror.ts
+++ b/src/beatmap/helpers/modded/mirror.ts
@@ -1,11 +1,14 @@
 import type { Vector3PointDefinition } from '../../../types/beatmap/shared/custom/heck.ts';
-import type { IWrapBaseItemAttribute } from '../../../types/beatmap/wrapper/baseItem.ts';
+import type { ICustomDataNote } from '../../../types/beatmap/wrapper/custom/note.ts';
+import type { ICustomDataSlider } from '../../../types/beatmap/wrapper/custom/slider.ts';
 import { isVector3 } from '../../../utils/vector.ts';
 
 /**
  * Mirrors the object for Noodle Extensions in beatmap v2.
  */
-export function mirrorNoodleExtensionsV2(data: IWrapBaseItemAttribute) {
+export function mirrorNoodleExtensionsV2<
+   T extends { customData: ICustomDataNote | ICustomDataSlider },
+>(data: T) {
    if (data.customData._position) {
       data.customData._position[0] = -1 - data.customData._position[0];
    }
@@ -39,7 +42,9 @@ export function mirrorNoodleExtensionsV2(data: IWrapBaseItemAttribute) {
 /**
  * Mirrors the object for Noodle Extensions in beatmap v3.
  */
-export function mirrorNoodleExtensionsV3(data: IWrapBaseItemAttribute) {
+export function mirrorNoodleExtensionsV3<
+   T extends { customData: ICustomDataNote | ICustomDataSlider },
+>(data: T) {
    if (data.customData.coordinates) {
       data.customData.coordinates[0] = -1 - data.customData.coordinates[0];
    }

--- a/src/beatmap/helpers/modded/mirror.ts
+++ b/src/beatmap/helpers/modded/mirror.ts
@@ -7,7 +7,11 @@ import { isVector3 } from '../../../utils/vector.ts';
  * Mirrors the object for Noodle Extensions in beatmap v2.
  */
 export function mirrorNoodleExtensionsV2<
-   T extends { customData: ICustomDataNote | ICustomDataSlider },
+   T extends {
+      customData:
+         & Pick<ICustomDataNote, '_position' | '_flip' | '_animation'>
+         & Pick<ICustomDataSlider, 'tailCoordinates'>;
+   },
 >(data: T) {
    if (data.customData._position) {
       data.customData._position[0] = -1 - data.customData._position[0];
@@ -26,12 +30,12 @@ export function mirrorNoodleExtensionsV2<
             });
          }
       }
-      if (Array.isArray(data.customData._animation._offsetPosition)) {
-         if (isVector3(data.customData._animation._offsetPosition)) {
-            data.customData._animation._offsetPosition[0] = -data.customData._animation
-               ._offsetPosition[0];
+      if (Array.isArray(data.customData._animation._position)) {
+         if (isVector3(data.customData._animation._position)) {
+            data.customData._animation._position[0] = -data.customData._animation
+               ._position[0];
          } else {
-            data.customData._animation._offsetPosition.forEach((op: Vector3PointDefinition) => {
+            data.customData._animation._position.forEach((op: Vector3PointDefinition) => {
                if (Array.isArray(op)) op[0] = -op[0];
             });
          }
@@ -43,7 +47,11 @@ export function mirrorNoodleExtensionsV2<
  * Mirrors the object for Noodle Extensions in beatmap v3.
  */
 export function mirrorNoodleExtensionsV3<
-   T extends { customData: ICustomDataNote | ICustomDataSlider },
+   T extends {
+      customData:
+         & Pick<ICustomDataNote, 'coordinates' | 'flip' | 'animation'>
+         & Pick<ICustomDataSlider, 'tailCoordinates'>;
+   },
 >(data: T) {
    if (data.customData.coordinates) {
       data.customData.coordinates[0] = -1 - data.customData.coordinates[0];

--- a/src/beatmap/helpers/modded/position.ts
+++ b/src/beatmap/helpers/modded/position.ts
@@ -1,12 +1,13 @@
-import type { IWrapBaseItemAttribute } from '../../../types/beatmap/wrapper/baseItem.ts';
+import type { ICustomDataNote } from '../../../types/beatmap/wrapper/custom/note.ts';
+import type { ICustomDataSlider } from '../../../types/beatmap/wrapper/custom/slider.ts';
 import type { Vector2 } from '../../../types/vector.ts';
 
 /**
  * Get position of Noodle Extensions in beatmap v2.
  */
-export function getNoodleExtensionsPositionV2(
-   data: IWrapBaseItemAttribute,
-): Vector2 | null {
+export function getNoodleExtensionsPositionV2<
+   T extends { customData: ICustomDataNote },
+>(data: T): Vector2 | null {
    return Array.isArray(data.customData._position)
       ? [data.customData._position[0], data.customData._position[1]]
       : null;
@@ -15,9 +16,9 @@ export function getNoodleExtensionsPositionV2(
 /**
  * Get position of Noodle Extensions in beatmap v3.
  */
-export function getNoodleExtensionsPositionV3(
-   data: IWrapBaseItemAttribute,
-): Vector2 | null {
+export function getNoodleExtensionsPositionV3<
+   T extends { customData: ICustomDataNote },
+>(data: T): Vector2 | null {
    return Array.isArray(data.customData.coordinates)
       ? [data.customData.coordinates[0], data.customData.coordinates[1]]
       : null;
@@ -26,9 +27,9 @@ export function getNoodleExtensionsPositionV3(
 /**
  * Get tail position of Noodle Extensions in beatmap v3.
  */
-export function getNoodleExtensionsTailPositionV3(
-   data: IWrapBaseItemAttribute,
-): Vector2 | null {
+export function getNoodleExtensionsTailPositionV3<
+   T extends { customData: ICustomDataSlider },
+>(data: T): Vector2 | null {
    return Array.isArray(data.customData.tailCoordinates)
       ? [data.customData.tailCoordinates[0], data.customData.tailCoordinates[1]]
       : null;

--- a/src/beatmap/helpers/modded/position.ts
+++ b/src/beatmap/helpers/modded/position.ts
@@ -6,7 +6,7 @@ import type { Vector2 } from '../../../types/vector.ts';
  * Get position of Noodle Extensions in beatmap v2.
  */
 export function getNoodleExtensionsPositionV2<
-   T extends { customData: ICustomDataNote },
+   T extends { customData: Pick<ICustomDataNote, '_position'> },
 >(data: T): Vector2 | null {
    return Array.isArray(data.customData._position)
       ? [data.customData._position[0], data.customData._position[1]]
@@ -17,7 +17,7 @@ export function getNoodleExtensionsPositionV2<
  * Get position of Noodle Extensions in beatmap v3.
  */
 export function getNoodleExtensionsPositionV3<
-   T extends { customData: ICustomDataNote },
+   T extends { customData: Pick<ICustomDataNote, 'coordinates'> },
 >(data: T): Vector2 | null {
    return Array.isArray(data.customData.coordinates)
       ? [data.customData.coordinates[0], data.customData.coordinates[1]]
@@ -28,7 +28,7 @@ export function getNoodleExtensionsPositionV3<
  * Get tail position of Noodle Extensions in beatmap v3.
  */
 export function getNoodleExtensionsTailPositionV3<
-   T extends { customData: ICustomDataSlider },
+   T extends { customData: Pick<ICustomDataSlider, 'tailCoordinates'> },
 >(data: T): Vector2 | null {
    return Array.isArray(data.customData.tailCoordinates)
       ? [data.customData.tailCoordinates[0], data.customData.tailCoordinates[1]]

--- a/src/beatmap/helpers/score.ts
+++ b/src/beatmap/helpers/score.ts
@@ -1,7 +1,10 @@
-import type { IWrapArcAttribute } from '../../types/beatmap/wrapper/arc.ts';
 import type { IWrapBeatmapAttributeSubset } from '../../types/beatmap/wrapper/beatmap.ts';
-import type { IWrapChainAttribute } from '../../types/beatmap/wrapper/chain.ts';
 import { lerp, normalize } from '../../utils/math.ts';
+
+type IScoreBeatmapAttributeSubset = IWrapBeatmapAttributeSubset<
+   'colorNotes' | 'arcs' | 'chains',
+   'time' | 'posX' | 'posY' | 'color' | 'tailTime' | 'tailPosX' | 'tailPosY' | 'sliceCount'
+>;
 
 /** Scoring type of note. */
 export const enum ScoreType {
@@ -24,9 +27,7 @@ export const ScoreValue: { readonly [key in ScoreType]: number } = {
 };
 
 /** Calculate max score from beatmap. */
-export function calculateScore<
-   T extends IWrapBeatmapAttributeSubset<'colorNotes' | 'arcs' | 'chains'>,
->(beatmap: T): number {
+export function calculateScore<T extends IScoreBeatmapAttributeSubset>(beatmap: T): number {
    let total = 0;
    let multiplier = 1;
    const elements = generateScoreElement(beatmap);
@@ -39,9 +40,7 @@ export function calculateScore<
    return total;
 }
 
-function generateScoreElement<
-   T extends IWrapBeatmapAttributeSubset<'colorNotes' | 'arcs' | 'chains'>,
->(beatmap: T) {
+function generateScoreElement<T extends IScoreBeatmapAttributeSubset>(beatmap: T) {
    return [
       createNoteElement(beatmap),
       createChainElement(beatmap.difficulty.chains),
@@ -52,12 +51,10 @@ function generateScoreElement<
 
 // for now I only care about arc head/tail and chain head, arc takes priority
 // FIXME: use epsilon dammit
-function createNoteElement<
-   T extends IWrapBeatmapAttributeSubset<'colorNotes' | 'arcs' | 'chains'>,
->(beatmap: T) {
-   const mapArcHead = new Map<number, IWrapArcAttribute[]>();
-   const mapArcTail = new Map<number, IWrapArcAttribute[]>();
-   const mapChainHead = new Map<number, IWrapChainAttribute[]>();
+function createNoteElement<T extends IScoreBeatmapAttributeSubset>(beatmap: T) {
+   const mapArcHead = new Map<number, T['difficulty']['arcs']>();
+   const mapArcTail = new Map<number, T['difficulty']['arcs']>();
+   const mapChainHead = new Map<number, T['difficulty']['chains']>();
 
    for (let i = 0; i < beatmap.difficulty.arcs.length; i++) {
       const arc = beatmap.difficulty.arcs[i];
@@ -122,7 +119,9 @@ function createNoteElement<
    });
 }
 
-function createChainElement<T extends IWrapChainAttribute>(chains: T[]) {
+function createChainElement<
+   T extends IScoreBeatmapAttributeSubset['difficulty']['chains'][number],
+>(chains: T[]) {
    return chains.flatMap((c) => {
       if (c.sliceCount > 1) {
          return Array(c.sliceCount - 1).map((_, i) => {

--- a/src/beatmap/helpers/score.ts
+++ b/src/beatmap/helpers/score.ts
@@ -1,5 +1,5 @@
 import type { IWrapArcAttribute } from '../../types/beatmap/wrapper/arc.ts';
-import type { IWrapBeatmapAttribute } from '../../types/beatmap/wrapper/beatmap.ts';
+import type { IWrapBeatmapAttributeSubset } from '../../types/beatmap/wrapper/beatmap.ts';
 import type { IWrapChainAttribute } from '../../types/beatmap/wrapper/chain.ts';
 import { lerp, normalize } from '../../utils/math.ts';
 
@@ -24,7 +24,9 @@ export const ScoreValue: { readonly [key in ScoreType]: number } = {
 };
 
 /** Calculate max score from beatmap. */
-export function calculateScore(beatmap: IWrapBeatmapAttribute): number {
+export function calculateScore<
+   T extends IWrapBeatmapAttributeSubset<'colorNotes' | 'arcs' | 'chains'>,
+>(beatmap: T): number {
    let total = 0;
    let multiplier = 1;
    const elements = generateScoreElement(beatmap);
@@ -37,7 +39,9 @@ export function calculateScore(beatmap: IWrapBeatmapAttribute): number {
    return total;
 }
 
-function generateScoreElement(beatmap: IWrapBeatmapAttribute) {
+function generateScoreElement<
+   T extends IWrapBeatmapAttributeSubset<'colorNotes' | 'arcs' | 'chains'>,
+>(beatmap: T) {
    return [
       createNoteElement(beatmap),
       createChainElement(beatmap.difficulty.chains),
@@ -48,7 +52,9 @@ function generateScoreElement(beatmap: IWrapBeatmapAttribute) {
 
 // for now I only care about arc head/tail and chain head, arc takes priority
 // FIXME: use epsilon dammit
-function createNoteElement(beatmap: IWrapBeatmapAttribute) {
+function createNoteElement<
+   T extends IWrapBeatmapAttributeSubset<'colorNotes' | 'arcs' | 'chains'>,
+>(beatmap: T) {
    const mapArcHead = new Map<number, IWrapArcAttribute[]>();
    const mapArcTail = new Map<number, IWrapArcAttribute[]>();
    const mapChainHead = new Map<number, IWrapChainAttribute[]>();
@@ -116,7 +122,7 @@ function createNoteElement(beatmap: IWrapBeatmapAttribute) {
    });
 }
 
-function createChainElement(chains: IWrapChainAttribute[]) {
+function createChainElement<T extends IWrapChainAttribute>(chains: T[]) {
    return chains.flatMap((c) => {
       if (c.sliceCount > 1) {
          return Array(c.sliceCount - 1).map((_, i) => {

--- a/src/beatmap/helpers/sort.ts
+++ b/src/beatmap/helpers/sort.ts
@@ -1,7 +1,7 @@
 import type { INote } from '../../types/beatmap/v2/note.ts';
 import type { IBaseObject as IV2BaseObject } from '../../types/beatmap/v2/object.ts';
 import type { IBaseObject as IV3BaseObject } from '../../types/beatmap/v3/baseObject.ts';
-import { IGridObject } from '../../types/beatmap/v3/gridObject.ts';
+import type { IGridObject } from '../../types/beatmap/v3/gridObject.ts';
 import type { IWrapBaseObjectAttribute } from '../../types/beatmap/wrapper/baseObject.ts';
 import type { IWrapGridObjectAttribute } from '../../types/beatmap/wrapper/gridObject.ts';
 import type { Vector2 } from '../../types/vector.ts';

--- a/src/beatmap/helpers/sort.ts
+++ b/src/beatmap/helpers/sort.ts
@@ -1,10 +1,10 @@
 import type { INote } from '../../types/beatmap/v2/note.ts';
 import type { IBaseObject as IV2BaseObject } from '../../types/beatmap/v2/object.ts';
 import type { IBaseObject as IV3BaseObject } from '../../types/beatmap/v3/baseObject.ts';
+import { IGridObject } from '../../types/beatmap/v3/gridObject.ts';
 import type { IWrapBaseObjectAttribute } from '../../types/beatmap/wrapper/baseObject.ts';
-import type { Vector2 } from '../../types/vector.ts';
-import type { IBombNote } from '../../types/beatmap/v3/bombNote.ts';
 import type { IWrapGridObjectAttribute } from '../../types/beatmap/wrapper/gridObject.ts';
+import type { Vector2 } from '../../types/vector.ts';
 
 /**
  * Pass this to wrapper object array `sort` function as an argument.
@@ -13,7 +13,7 @@ import type { IWrapGridObjectAttribute } from '../../types/beatmap/wrapper/gridO
  * data.basicEvents.sort(sortObjectFn);
  * ```
  */
-export function sortObjectFn(a: IWrapBaseObjectAttribute, b: IWrapBaseObjectAttribute): number {
+export function sortObjectFn<T extends Pick<IWrapBaseObjectAttribute, 'time'>>(a: T, b: T): number {
    return a.time - b.time;
 }
 
@@ -24,7 +24,9 @@ export function sortObjectFn(a: IWrapBaseObjectAttribute, b: IWrapBaseObjectAttr
  * data.chains.sort(sortNoteFn);
  * ```
  */
-export function sortNoteFn(a: IWrapGridObjectAttribute, b: IWrapGridObjectAttribute): number {
+export function sortNoteFn<
+   T extends Pick<IWrapGridObjectAttribute, 'time' | 'posX' | 'posY' | 'customData'>,
+>(a: T, b: T): number {
    if (Array.isArray(a.customData.coordinates) && Array.isArray(b.customData.coordinates)) {
       return (
          a.time - b.time ||
@@ -49,7 +51,7 @@ export function sortNoteFn(a: IWrapGridObjectAttribute, b: IWrapGridObjectAttrib
  * data._events.sort(sortV2ObjectFn);
  * ```
  */
-export function sortV2ObjectFn(a: IV2BaseObject, b: IV2BaseObject): number {
+export function sortV2ObjectFn<T extends Pick<IV2BaseObject, '_time'>>(a: T, b: T): number {
    return a._time! - b._time!;
 }
 
@@ -60,7 +62,9 @@ export function sortV2ObjectFn(a: IV2BaseObject, b: IV2BaseObject): number {
  * data._notes.sort(sortV2NoteFn);
  * ```
  */
-export function sortV2NoteFn(a: INote, b: INote): number {
+export function sortV2NoteFn<
+   T extends Pick<INote, '_time' | '_lineIndex' | '_lineLayer' | '_customData'>,
+>(a: T, b: T): number {
    if (Array.isArray(a._customData?._position) && Array.isArray(b._customData?._position)) {
       return (
          a._time! - b._time! ||
@@ -78,7 +82,7 @@ export function sortV2NoteFn(a: INote, b: INote): number {
  * data.basicBeatmapEvents.sort(sortV3ObjectFn);
  * ```
  */
-export function sortV3ObjectFn(a: IV3BaseObject, b: IV3BaseObject): number {
+export function sortV3ObjectFn<T extends Pick<IV3BaseObject, 'b'>>(a: T, b: T): number {
    return a.b! - b.b!;
 }
 
@@ -89,7 +93,9 @@ export function sortV3ObjectFn(a: IV3BaseObject, b: IV3BaseObject): number {
  * data.arcs.sort(sortV3NoteFn);
  * ```
  */
-export function sortV3NoteFn(a: IBombNote, b: IBombNote): number {
+export function sortV3NoteFn<
+   T extends Pick<IGridObject, 'b' | 'x' | 'y' | 'customData'>,
+>(a: T, b: T): number {
    if (Array.isArray(a.customData?.coordinates) && Array.isArray(b.customData?.coordinates)) {
       return (
          a.b! - b.b! ||

--- a/src/beatmap/helpers/version.ts
+++ b/src/beatmap/helpers/version.ts
@@ -1,3 +1,4 @@
+// deno-lint-ignore-file no-explicit-any
 import type { BeatmapFileType } from '../../types/beatmap/shared/schema.ts';
 import type { Version } from '../../types/beatmap/shared/version.ts';
 

--- a/src/beatmap/helpers/version.ts
+++ b/src/beatmap/helpers/version.ts
@@ -20,7 +20,7 @@ export function implicitVersion(type: BeatmapFileType): Version {
 }
 
 /** Get beatmap version from JSON. */
-export function retrieveVersion(json: Record<string, unknown>): Version | null {
+export function retrieveVersion<T extends Record<string, any>>(json: T): Version | null {
    const ver = json._version ?? json.version;
    if (typeof ver !== 'string') {
       return null;

--- a/src/beatmap/loader/_main.ts
+++ b/src/beatmap/loader/_main.ts
@@ -1,13 +1,14 @@
 // deno-lint-ignore-file no-explicit-any
-import type { BeatmapFileType } from '../../types/beatmap/shared/schema.ts';
-import type { IWrapInfo } from '../../types/beatmap/wrapper/info.ts';
-import type { IWrapAudioData } from '../../types/beatmap/wrapper/audioData.ts';
-import type { ILoadOptions } from '../../types/beatmap/options/loader.ts';
-import type { IWrapBeatmap } from '../../types/beatmap/wrapper/beatmap.ts';
 import { logger } from '../../logger.ts';
-import { implicitVersion, retrieveVersion } from '../helpers/version.ts';
-import { Info } from '../core/info.ts';
+import type { ILoadOptions } from '../../types/beatmap/options/loader.ts';
+import type { BeatmapFileType } from '../../types/beatmap/shared/schema.ts';
+import type { IWrapAudioData } from '../../types/beatmap/wrapper/audioData.ts';
+import type { IWrapBeatmap } from '../../types/beatmap/wrapper/beatmap.ts';
+import type { IWrapInfo } from '../../types/beatmap/wrapper/info.ts';
 import { AudioData } from '../core/audioData.ts';
+import { Beatmap } from '../core/beatmap.ts';
+import { Info } from '../core/info.ts';
+import { implicitVersion, retrieveVersion } from '../helpers/version.ts';
 import { audioDataConvertMap, beatmapConvertMap, infoConvertMap } from '../mapping/converter.ts';
 import {
    audioDataSchemaMap,
@@ -16,7 +17,6 @@ import {
    lightshowSchemaMap,
 } from '../mapping/schema.ts';
 import { validateJSON } from '../validator/json.ts';
-import { Beatmap } from '../core/beatmap.ts';
 
 export function tag(name: string): string[] {
    return ['loader', name];
@@ -149,7 +149,9 @@ export function loadBeatmap<T extends Record<string, any>>(
       data = convertMap[targetVer](data, data.version);
    }
 
-   if (opt.sort) data.sort();
+   if (opt.sort && 'sort' in data && typeof data.sort === 'function') {
+      data.sort();
+   }
 
    opt.postprocess.forEach((fn, i) => {
       logger.tInfo(tag('loadBeatmap'), 'Running postprocess function #' + (i + 1));

--- a/src/beatmap/loader/_main.ts
+++ b/src/beatmap/loader/_main.ts
@@ -1,118 +1,65 @@
 // deno-lint-ignore-file no-explicit-any
 import { logger } from '../../logger.ts';
 import type { ILoadOptions } from '../../types/beatmap/options/loader.ts';
+import type { MirrorFn } from '../../types/beatmap/shared/functions.ts';
+import type {
+   InferBeatmapAttribute,
+   InferBeatmapSerial,
+   InferBeatmapVersion,
+} from '../../types/beatmap/shared/infer.ts';
 import type { BeatmapFileType } from '../../types/beatmap/shared/schema.ts';
-import type { IWrapAudioData } from '../../types/beatmap/wrapper/audioData.ts';
-import type { IWrapBeatmap } from '../../types/beatmap/wrapper/beatmap.ts';
-import type { IWrapInfo } from '../../types/beatmap/wrapper/info.ts';
-import { AudioData } from '../core/audioData.ts';
-import { Beatmap } from '../core/beatmap.ts';
-import { Info } from '../core/info.ts';
 import { implicitVersion, retrieveVersion } from '../helpers/version.ts';
-import { audioDataConvertMap, beatmapConvertMap, infoConvertMap } from '../mapping/converter.ts';
-import {
-   audioDataSchemaMap,
-   difficultySchemaMap,
-   infoSchemaMap,
-   lightshowSchemaMap,
-} from '../mapping/schema.ts';
+import { convertBeatmap } from '../mapping/converter.ts';
+import { deserializeBeatmap } from '../mapping/schema.ts';
 import { validateJSON } from '../validator/json.ts';
 
 export function tag(name: string): string[] {
    return ['loader', name];
 }
 
-const defaultOptions: Required<ILoadOptions<any>> = {
+const defaultOptions = {
    forceConvert: true,
    schemaCheck: {},
    sort: true,
    preprocess: [],
    postprocess: [],
-};
+} as const;
 
-export function loadBeatmap<T extends Record<string, any>>(
-   type: BeatmapFileType,
-   json: Record<string, unknown>,
-   targetVer?: number | null,
-   options?: ILoadOptions<T>,
-): T;
-export function loadBeatmap(
-   type: 'info',
-   json: Record<string, unknown>,
-   targetVer?: number | null,
-   options?: ILoadOptions<IWrapInfo>,
-): IWrapInfo;
-export function loadBeatmap(
-   type: 'audioData',
-   json: Record<string, unknown>,
-   targetVer?: number | null,
-   options?: ILoadOptions<IWrapAudioData>,
-): IWrapAudioData;
-export function loadBeatmap(
-   type: 'lightshow',
-   json: Record<string, unknown>,
-   targetVer?: number | null,
-   options?: ILoadOptions<IWrapBeatmap>,
-): IWrapBeatmap;
-export function loadBeatmap(
-   type: 'difficulty',
-   json: Record<string, unknown>,
-   targetVer?: number | null,
-   options?: ILoadOptions<IWrapBeatmap>,
-): IWrapBeatmap;
-export function loadBeatmap<T extends Record<string, any>>(
-   type: BeatmapFileType,
-   json: Record<string, unknown>,
-   targetVer?: number | null,
-   options: ILoadOptions<any> = {},
-): T {
-   const opt: Required<ILoadOptions> = {
-      forceConvert: options.forceConvert ?? defaultOptions.forceConvert,
-      schemaCheck: {
-         ...defaultOptions.schemaCheck,
-         ...options.schemaCheck,
-      },
-      sort: options.sort ?? defaultOptions.sort,
-      preprocess: options.preprocess ?? defaultOptions.preprocess,
-      postprocess: options.postprocess ?? defaultOptions.postprocess,
+export function loadBeatmap<
+   TFileType extends BeatmapFileType,
+   TVersion extends InferBeatmapVersion<TFileType>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<TFileType>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<TFileType, TVersion>,
+>(
+   type: TFileType,
+   json: TSerial,
+   version?: TVersion | null,
+   options: ILoadOptions<TFileType, TVersion, TWrapper, TSerial> = {},
+): TWrapper {
+   const optD = (typeof version !== 'number' ? version : options) ?? options ?? {};
+   const opt: Required<ILoadOptions<TFileType, TVersion, TWrapper, TSerial>> = {
+      forceConvert: optD.forceConvert ?? defaultOptions.forceConvert,
+      schemaCheck: { ...defaultOptions.schemaCheck, ...optD.schemaCheck },
+      sort: optD.sort ?? defaultOptions.sort,
+      preprocess: optD.preprocess ?? defaultOptions.preprocess as any,
+      postprocess: optD.postprocess ?? defaultOptions.postprocess as any,
    };
-   let coreClass;
-   let schemaMap;
-   let convertMap;
-   switch (type) {
-      case 'info':
-         coreClass = Info;
-         schemaMap = infoSchemaMap;
-         convertMap = infoConvertMap;
-         break;
-      case 'audioData':
-         coreClass = AudioData;
-         schemaMap = audioDataSchemaMap;
-         convertMap = audioDataConvertMap;
-         break;
-      case 'difficulty':
-         coreClass = Beatmap;
-         schemaMap = difficultySchemaMap;
-         convertMap = beatmapConvertMap;
-         break;
-      case 'lightshow':
-         coreClass = Beatmap;
-         schemaMap = lightshowSchemaMap;
-         convertMap = beatmapConvertMap;
-         break;
-   }
 
-   opt.preprocess.forEach((fn, i) => {
+   const [pretransformer, ...preprocesses] = opt.preprocess;
+   let serial = pretransformer
+      ? pretransformer(json, version)
+      : json as InferBeatmapSerial<TFileType, TVersion>;
+   preprocesses.forEach((fn, i) => {
       logger.tInfo(tag('loadBeatmap'), 'Running preprocess function #' + (i + 1));
-      json = fn(json);
+      serial = fn(serial);
    });
 
-   const jsonVerStr = retrieveVersion(json)?.at(0);
-   let jsonVer: number;
+   const jsonVerStr = retrieveVersion(serial)?.at(0);
+   let jsonVer: TVersion;
    if (jsonVerStr) {
-      jsonVer = parseInt(jsonVerStr);
+      jsonVer = parseInt(jsonVerStr) as TVersion;
    } else {
-      jsonVer = +implicitVersion(type).at(0)!;
+      jsonVer = +implicitVersion(type).at(0)! as TVersion;
       logger.tWarn(
          tag('loadBeatmap'),
          'Could not identify beatmap version from JSON, assume implicit version',
@@ -120,42 +67,48 @@ export function loadBeatmap<T extends Record<string, any>>(
       );
    }
 
-   let data: any;
-   const schema = schemaMap[jsonVer];
-   if (schema) {
-      if (opt.schemaCheck.enabled) validateJSON(type, json, jsonVer, opt.schemaCheck);
-      data = new coreClass(schema.deserialize(json));
-   } else {
-      throw new Error(
-         `Beatmap version ${jsonVer} is not supported, this may be an error in JSON or is newer than currently supported.`,
-      );
-   }
+   let attribute: InferBeatmapAttribute<TFileType>;
+   if (opt.schemaCheck.enabled) validateJSON(type, serial, jsonVer, opt.schemaCheck);
+   attribute = deserializeBeatmap(type, jsonVer, serial);
 
-   if (targetVer && jsonVer !== targetVer) {
+   if (version && jsonVer !== version) {
       if (!opt.forceConvert) {
          throw new Error(
-            `Beatmap version unmatched, expected ${targetVer} but received ${jsonVer}`,
+            `Beatmap version unmatched, expected ${version} but received ${jsonVer}`,
          );
       }
       logger.tWarn(
          tag('loadBeatmap'),
          'Beatmap version unmatched, expected',
-         targetVer,
+         version,
          'but received',
          jsonVer,
          'for version; Converting to beatmap version',
-         targetVer,
+         version,
       );
-      data = convertMap[targetVer](data, data.version);
+      attribute = convertBeatmap(
+         type,
+         version,
+         attribute,
+         attribute.version as InferBeatmapVersion<TFileType>,
+      );
    }
 
-   if (opt.sort && 'sort' in data && typeof data.sort === 'function') {
-      data.sort();
+   if (opt.sort && 'sort' in attribute && typeof attribute.sort === 'function') {
+      attribute.sort();
    }
 
-   opt.postprocess.forEach((fn, i) => {
+   const [posttransformer, ...postprocesses] = opt.postprocess.toReversed() as [
+      (data: InferBeatmapAttribute<TFileType>, version: TVersion | null) => TWrapper,
+      ...MirrorFn<InferBeatmapAttribute<TFileType>>[],
+   ];
+   postprocesses.forEach((fn, i) => {
       logger.tInfo(tag('loadBeatmap'), 'Running postprocess function #' + (i + 1));
-      data = fn(data);
+      attribute = fn(attribute);
    });
-   return data;
+
+   const wrapper = posttransformer
+      ? posttransformer(attribute, version ?? null)
+      : attribute as TWrapper;
+   return wrapper;
 }

--- a/src/beatmap/loader/audioData.ts
+++ b/src/beatmap/loader/audioData.ts
@@ -1,7 +1,11 @@
 // deno-lint-ignore-file no-explicit-any
 import { logger } from '../../logger.ts';
-import type { IWrapAudioData } from '../../types/beatmap/wrapper/audioData.ts';
 import type { ILoadOptions } from '../../types/beatmap/options/loader.ts';
+import type {
+   InferBeatmapAttribute,
+   InferBeatmapSerial,
+   InferBeatmapVersion,
+} from '../../types/beatmap/shared/infer.ts';
 import { loadBeatmap, tag } from './_main.ts';
 
 /**
@@ -13,20 +17,32 @@ import { loadBeatmap, tag } from './_main.ts';
  *
  * Mismatched beatmap version will be automatically converted, unspecified will leave the version as is but not known.
  */
-export function loadAudioData(
-   json: Record<string, any>,
-   version?: number | null,
-   options?: ILoadOptions<IWrapAudioData>,
-): IWrapAudioData;
-export function loadAudioData(
-   json: Record<string, any>,
-   options?: ILoadOptions<IWrapAudioData>,
-): IWrapAudioData;
-export function loadAudioData(
-   json: Record<string, any>,
-   version?: number | null | ILoadOptions<IWrapAudioData>,
-   options?: ILoadOptions<IWrapAudioData>,
-): IWrapAudioData {
+export function loadAudioData<
+   TVersion extends InferBeatmapVersion<'audioData'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'audioData'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'audioData', TVersion>,
+>(
+   json: TSerial,
+   version?: TVersion | null,
+   options?: ILoadOptions<'audioData', TVersion, TWrapper, TSerial>,
+): TWrapper;
+export function loadAudioData<
+   TVersion extends InferBeatmapVersion<'audioData'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'audioData'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'audioData', TVersion>,
+>(
+   json: TSerial,
+   options?: ILoadOptions<'audioData', TVersion, TWrapper, TSerial>,
+): TWrapper;
+export function loadAudioData<
+   TVersion extends InferBeatmapVersion<'audioData'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'audioData'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'audioData', TVersion>,
+>(
+   json: TSerial,
+   version?: TVersion | null | ILoadOptions<'audioData', TVersion, TWrapper, TSerial>,
+   options?: ILoadOptions<'audioData', TVersion, TWrapper, TSerial>,
+): TWrapper {
    const ver = typeof version === 'number' ? version : null;
    const opt = (typeof version !== 'number' ? version : options) ?? {};
    logger.tInfo(tag('loadAudioData'), 'Loading audio data from JSON');

--- a/src/beatmap/loader/difficulty.ts
+++ b/src/beatmap/loader/difficulty.ts
@@ -1,7 +1,11 @@
 // deno-lint-ignore-file no-explicit-any
 import { logger } from '../../logger.ts';
-import type { IWrapBeatmap } from '../../types/beatmap/wrapper/beatmap.ts';
 import type { ILoadOptions } from '../../types/beatmap/options/loader.ts';
+import type {
+   InferBeatmapAttribute,
+   InferBeatmapSerial,
+   InferBeatmapVersion,
+} from '../../types/beatmap/shared/infer.ts';
 import { loadBeatmap, tag } from './_main.ts';
 
 /**
@@ -13,20 +17,32 @@ import { loadBeatmap, tag } from './_main.ts';
  *
  * Mismatched beatmap version will be automatically converted, unspecified will leave the version as is but not known.
  */
-export function loadDifficulty(
-   json: Record<string, any>,
-   version?: number | null,
-   options?: ILoadOptions<IWrapBeatmap>,
-): IWrapBeatmap;
-export function loadDifficulty(
-   json: Record<string, any>,
-   options?: ILoadOptions<IWrapBeatmap>,
-): IWrapBeatmap;
-export function loadDifficulty(
-   json: Record<string, any>,
-   version?: number | null | ILoadOptions<IWrapBeatmap>,
-   options?: ILoadOptions<IWrapBeatmap>,
-): IWrapBeatmap {
+export function loadDifficulty<
+   TVersion extends InferBeatmapVersion<'difficulty'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'difficulty'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'difficulty', TVersion>,
+>(
+   json: TSerial,
+   version?: TVersion | null,
+   options?: ILoadOptions<'difficulty', TVersion, TWrapper, TSerial>,
+): TWrapper;
+export function loadDifficulty<
+   TVersion extends InferBeatmapVersion<'difficulty'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'difficulty'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'difficulty', TVersion>,
+>(
+   json: TSerial,
+   options?: ILoadOptions<'difficulty', TVersion, TWrapper, TSerial>,
+): TWrapper;
+export function loadDifficulty<
+   TVersion extends InferBeatmapVersion<'difficulty'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'difficulty'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'difficulty', TVersion>,
+>(
+   json: TSerial,
+   version?: TVersion | null | ILoadOptions<'difficulty', TVersion, TWrapper, TSerial>,
+   options?: ILoadOptions<'difficulty', TVersion, TWrapper, TSerial>,
+): TWrapper {
    const ver = typeof version === 'number' ? version : null;
    const opt = (typeof version !== 'number' ? version : options) ?? {};
    logger.tInfo(tag('loadDifficulty'), 'Loading difficulty from JSON');

--- a/src/beatmap/loader/info.ts
+++ b/src/beatmap/loader/info.ts
@@ -1,7 +1,11 @@
 // deno-lint-ignore-file no-explicit-any
 import { logger } from '../../logger.ts';
-import type { IWrapInfo } from '../../types/beatmap/wrapper/info.ts';
 import type { ILoadOptions } from '../../types/beatmap/options/loader.ts';
+import type {
+   InferBeatmapAttribute,
+   InferBeatmapSerial,
+   InferBeatmapVersion,
+} from '../../types/beatmap/shared/infer.ts';
 import { loadBeatmap, tag } from './_main.ts';
 
 /**
@@ -13,17 +17,32 @@ import { loadBeatmap, tag } from './_main.ts';
  *
  * Mismatched beatmap version will be automatically converted, unspecified will leave the version as is but not known.
  */
-export function loadInfo(
-   json: Record<string, any>,
-   version?: number | null,
-   options?: ILoadOptions<IWrapInfo>,
-): IWrapInfo;
-export function loadInfo(json: Record<string, any>, options?: ILoadOptions<IWrapInfo>): IWrapInfo;
-export function loadInfo(
-   json: Record<string, any>,
-   version?: number | null | ILoadOptions<IWrapInfo>,
-   options?: ILoadOptions<IWrapInfo>,
-): IWrapInfo {
+export function loadInfo<
+   TVersion extends InferBeatmapVersion<'info'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'info'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'info', TVersion>,
+>(
+   json: TSerial,
+   version?: TVersion | null,
+   options?: ILoadOptions<'info', TVersion, TWrapper, TSerial>,
+): TWrapper;
+export function loadInfo<
+   TVersion extends InferBeatmapVersion<'info'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'info'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'info', TVersion>,
+>(
+   json: TSerial,
+   options?: ILoadOptions<'info', TVersion, TWrapper, TSerial>,
+): TWrapper;
+export function loadInfo<
+   TVersion extends InferBeatmapVersion<'info'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'info'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'info', TVersion>,
+>(
+   json: TSerial,
+   version?: TVersion | null | ILoadOptions<'info', TVersion, TWrapper, TSerial>,
+   options?: ILoadOptions<'info', TVersion, TWrapper, TSerial>,
+): TWrapper {
    const ver = typeof version === 'number' ? version : null;
    const opt = (typeof version !== 'number' ? version : options) ?? {};
    logger.tInfo(tag('loadInfo'), 'Loading info from JSON');

--- a/src/beatmap/loader/lightshow.ts
+++ b/src/beatmap/loader/lightshow.ts
@@ -1,7 +1,11 @@
 // deno-lint-ignore-file no-explicit-any
 import { logger } from '../../logger.ts';
-import type { IWrapBeatmap } from '../../types/beatmap/wrapper/beatmap.ts';
 import type { ILoadOptions } from '../../types/beatmap/options/loader.ts';
+import type {
+   InferBeatmapAttribute,
+   InferBeatmapSerial,
+   InferBeatmapVersion,
+} from '../../types/beatmap/shared/infer.ts';
 import { loadBeatmap, tag } from './_main.ts';
 
 /**
@@ -13,20 +17,32 @@ import { loadBeatmap, tag } from './_main.ts';
  *
  * Mismatched beatmap version will be automatically converted, unspecified will leave the version as is but not known.
  */
-export function loadLightshow(
-   json: Record<string, any>,
-   version?: number | null,
-   options?: ILoadOptions<IWrapBeatmap>,
-): IWrapBeatmap;
-export function loadLightshow(
-   json: Record<string, any>,
-   options?: ILoadOptions<IWrapBeatmap>,
-): IWrapBeatmap;
-export function loadLightshow(
-   json: Record<string, any>,
-   version?: number | null | ILoadOptions<IWrapBeatmap>,
-   options?: ILoadOptions<IWrapBeatmap>,
-): IWrapBeatmap {
+export function loadLightshow<
+   TVersion extends InferBeatmapVersion<'lightshow'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'lightshow'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'lightshow', TVersion>,
+>(
+   json: TSerial,
+   version?: TVersion | null,
+   options?: ILoadOptions<'lightshow', TVersion, TWrapper, TSerial>,
+): TWrapper;
+export function loadLightshow<
+   TVersion extends InferBeatmapVersion<'lightshow'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'lightshow'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'lightshow', TVersion>,
+>(
+   json: TSerial,
+   options?: ILoadOptions<'lightshow', TVersion, TWrapper, TSerial>,
+): TWrapper;
+export function loadLightshow<
+   TVersion extends InferBeatmapVersion<'lightshow'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'lightshow'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'lightshow', TVersion>,
+>(
+   json: TSerial,
+   version?: TVersion | null | ILoadOptions<'lightshow', TVersion, TWrapper, TSerial>,
+   options?: ILoadOptions<'lightshow', TVersion, TWrapper, TSerial>,
+): TWrapper {
    const ver = typeof version === 'number' ? version : null;
    const opt = (typeof version !== 'number' ? version : options) ?? {};
    logger.tInfo(tag('loadLightshow'), 'Loading lightshow from JSON');

--- a/src/beatmap/mapping/compatibility.ts
+++ b/src/beatmap/mapping/compatibility.ts
@@ -1,52 +1,51 @@
-// deno-lint-ignore-file no-explicit-any
-import { compatInfo as compatV1Info } from '../schema/v1/compat/info.ts';
-import { compatInfo as compatV2Info } from '../schema/v2/compat/info.ts';
-import { compatInfo as compatV4Info } from '../schema/v4/compat/info.ts';
-import { compatAudioData as compatV2AudioData } from '../schema/v2/compat/audioData.ts';
-import { compatAudioData as compatV4AudioData } from '../schema/v4/compat/audioData.ts';
-import { compatDifficulty as compatV1Difficulty } from '../schema/v1/compat/difficulty.ts';
-import { compatDifficulty as compatV2Difficulty } from '../schema/v2/compat/difficulty.ts';
-import { compatDifficulty as compatV3Difficulty } from '../schema/v3/compat/difficulty.ts';
-import { compatDifficulty as compatV4Difficulty } from '../schema/v4/compat/difficulty.ts';
-import { compatLightshow as compatV3Lightshow } from '../schema/v3/compat/lightshow.ts';
-import { compatLightshow as compatV4Lightshow } from '../schema/v4/compat/lightshow.ts';
 import type { ICompatibilityOptions } from '../../types/beatmap/options/compatibility.ts';
+import type {
+   InferBeatmapAttribute,
+   InferBeatmapVersion,
+} from '../../types/beatmap/shared/infer.ts';
+import type { BeatmapFileType } from '../../types/beatmap/shared/schema.ts';
+import { compatDifficulty as compatV1Difficulty } from '../schema/v1/compat/difficulty.ts';
+import { compatInfo as compatV1Info } from '../schema/v1/compat/info.ts';
+import { compatAudioData as compatV2AudioData } from '../schema/v2/compat/audioData.ts';
+import { compatDifficulty as compatV2Difficulty } from '../schema/v2/compat/difficulty.ts';
+import { compatInfo as compatV2Info } from '../schema/v2/compat/info.ts';
+import { compatDifficulty as compatV3Difficulty } from '../schema/v3/compat/difficulty.ts';
+import { compatLightshow as compatV3Lightshow } from '../schema/v3/compat/lightshow.ts';
+import { compatAudioData as compatV4AudioData } from '../schema/v4/compat/audioData.ts';
+import { compatDifficulty as compatV4Difficulty } from '../schema/v4/compat/difficulty.ts';
+import { compatInfo as compatV4Info } from '../schema/v4/compat/info.ts';
+import { compatLightshow as compatV4Lightshow } from '../schema/v4/compat/lightshow.ts';
+
+type CompatibilityMap<T extends BeatmapFileType> = {
+   [TVersion in InferBeatmapVersion<T>]: <TSerial extends InferBeatmapAttribute<T>>(
+      data: TSerial,
+      options: ICompatibilityOptions,
+   ) => void;
+};
 
 /** Compatibility function version map for beatmap info. */
-export const infoCompatibilityMap: Record<
-   number,
-   (data: any, options: ICompatibilityOptions) => void
-> = {
+export const infoCompatibilityMap: CompatibilityMap<'info'> = {
    1: compatV1Info,
    2: compatV2Info,
    4: compatV4Info,
-};
+} as const;
 
 /** Compatibility function version map for beatmap audio data. */
-export const audioDataCompatibilityMap: Record<
-   number,
-   (data: any, options: ICompatibilityOptions) => void
-> = {
+export const audioDataCompatibilityMap: CompatibilityMap<'audioData'> = {
    2: compatV2AudioData,
    4: compatV4AudioData,
-};
+} as const;
 
 /** Compatibility function version map for beatmap difficulty. */
-export const difficultyCompatibilityMap: Record<
-   number,
-   (data: any, options: ICompatibilityOptions) => void
-> = {
+export const difficultyCompatibilityMap: CompatibilityMap<'difficulty'> = {
    1: compatV1Difficulty,
    2: compatV2Difficulty,
    3: compatV3Difficulty,
    4: compatV4Difficulty,
-};
+} as const;
 
 /** Compatibility function version map for beatmap lightshow. */
-export const lightshowCompatibilityMap: Record<
-   number,
-   (data: any, options: ICompatibilityOptions) => void
-> = {
+export const lightshowCompatibilityMap: CompatibilityMap<'lightshow'> = {
    3: compatV3Lightshow,
    4: compatV4Lightshow,
-};
+} as const;

--- a/src/beatmap/mapping/converter.ts
+++ b/src/beatmap/mapping/converter.ts
@@ -1,39 +1,76 @@
-import { toV1Info } from '../converter/toV1/info.ts';
+// deno-lint-ignore-file no-explicit-any
+import type {
+   InferBeatmapAttribute,
+   InferBeatmapVersion,
+} from '../../types/beatmap/shared/infer.ts';
+import type { BeatmapFileType } from '../../types/beatmap/shared/schema.ts';
 import { toV1Beatmap } from '../converter/toV1/beatmap.ts';
-import { toV2Info } from '../converter/toV2/info.ts';
+import { toV1Info } from '../converter/toV1/info.ts';
 import { toV2AudioData } from '../converter/toV2/audioData.ts';
 import { toV2Beatmap } from '../converter/toV2/beatmap.ts';
+import { toV2Info } from '../converter/toV2/info.ts';
 import { toV3Beatmap } from '../converter/toV3/beatmap.ts';
-import { toV4Info } from '../converter/toV4/info.ts';
 import { toV4AudioData } from '../converter/toV4/audioData.ts';
 import { toV4Beatmap } from '../converter/toV4/beatmap.ts';
-import type { IWrapInfo } from '../../types/beatmap/wrapper/info.ts';
-import type { IWrapAudioData } from '../../types/beatmap/wrapper/audioData.ts';
-import type { IWrapBeatmap } from '../../types/beatmap/wrapper/beatmap.ts';
+import { toV4Info } from '../converter/toV4/info.ts';
+
+type ConverterMap<T extends BeatmapFileType> = {
+   [TVersion in InferBeatmapVersion<T>]: <TWrapper extends InferBeatmapAttribute<T>>(
+      data: TWrapper,
+      fromVersion?: number,
+   ) => TWrapper;
+};
 
 /** Conversion function version map for beatmap info. */
-export const infoConvertMap: Record<number, (data: IWrapInfo, sourceVer: number) => IWrapInfo> = {
+export const infoConvertMap: ConverterMap<'info'> = {
    1: toV1Info,
    2: toV2Info,
    4: toV4Info,
 };
 
 /** Conversion function version map for beatmap audio data. */
-export const audioDataConvertMap: Record<
-   number,
-   (data: IWrapAudioData, sourceVer: number) => IWrapAudioData
-> = {
+export const audioDataConvertMap: ConverterMap<'audioData'> = {
    2: toV2AudioData,
    4: toV4AudioData,
 };
 
 /** Conversion function version map for beatmap data. */
-export const beatmapConvertMap: Record<
-   number,
-   (data: IWrapBeatmap, sourceVer: number) => IWrapBeatmap
-> = {
+export const beatmapConvertMap: ConverterMap<'difficulty' | 'lightshow'> = {
    1: toV1Beatmap,
    2: toV2Beatmap,
    3: toV3Beatmap,
    4: toV4Beatmap,
 };
+
+export function convertBeatmap<
+   TFileType extends BeatmapFileType,
+   TVersion extends InferBeatmapVersion<TFileType>,
+   TWrapper extends InferBeatmapAttribute<TFileType>,
+>(
+   type: TFileType,
+   targetVersion: TVersion,
+   data: TWrapper,
+   sourceVersion?: InferBeatmapVersion<TFileType>,
+): TWrapper {
+   switch (type) {
+      case 'info': {
+         const convert = infoConvertMap[targetVersion as InferBeatmapVersion<'info'>];
+         return convert(data as any, sourceVersion) as TWrapper;
+      }
+      case 'audioData': {
+         const convert = audioDataConvertMap[targetVersion as InferBeatmapVersion<'audioData'>];
+         return convert(data as any, sourceVersion) as TWrapper;
+      }
+      case 'difficulty': {
+         const convert = beatmapConvertMap[targetVersion as InferBeatmapVersion<'difficulty'>];
+         return convert(data as any, sourceVersion) as TWrapper;
+      }
+      case 'lightshow': {
+         const convert = beatmapConvertMap[targetVersion as InferBeatmapVersion<'lightshow'>];
+         return convert(data as any, sourceVersion) as TWrapper;
+      }
+      default: {
+         throw new Error('');
+      }
+   }
+}

--- a/src/beatmap/mapping/optimizer.ts
+++ b/src/beatmap/mapping/optimizer.ts
@@ -1,34 +1,65 @@
 // deno-lint-ignore-file no-explicit-any
-import { optimizeInfo as optimizeV1Info } from '../schema/v1/optimize/info.ts';
-import { optimizeInfo as optimizeV2Info } from '../schema/v2/optimize/info.ts';
-import { optimizeInfo as optimizeV4Info } from '../schema/v4/optimize/info.ts';
-import { optimizeDifficulty as optimizeV1Difficulty } from '../schema/v1/optimize/difficulty.ts';
-import { optimizeDifficulty as optimizeV2Difficulty } from '../schema/v2/optimize/difficulty.ts';
-import { optimizeDifficulty as optimizeV3Difficulty } from '../schema/v3/optimize/difficulty.ts';
-import { optimizeDifficulty as optimizeV4Difficulty } from '../schema/v4/optimize/difficulty.ts';
-import { optimizeLightshow as optimizeV3Lightshow } from '../schema/v3/optimize/lightshow.ts';
-import { optimizeLightshow as optimizeV4Lightshow } from '../schema/v4/optimize/lightshow.ts';
 import type { IOptimizeOptions } from '../../types/beatmap/options/optimize.ts';
+import type { InferBeatmapSerial, InferBeatmapVersion } from '../../types/beatmap/shared/infer.ts';
+import type { BeatmapFileType } from '../../types/mod.ts';
+import { optimizeDifficulty as optimizeV1Difficulty } from '../schema/v1/optimize/difficulty.ts';
+import { optimizeInfo as optimizeV1Info } from '../schema/v1/optimize/info.ts';
+import { optimizeDifficulty as optimizeV2Difficulty } from '../schema/v2/optimize/difficulty.ts';
+import { optimizeInfo as optimizeV2Info } from '../schema/v2/optimize/info.ts';
+import { optimizeDifficulty as optimizeV3Difficulty } from '../schema/v3/optimize/difficulty.ts';
+import { optimizeLightshow as optimizeV3Lightshow } from '../schema/v3/optimize/lightshow.ts';
+import { optimizeDifficulty as optimizeV4Difficulty } from '../schema/v4/optimize/difficulty.ts';
+import { optimizeInfo as optimizeV4Info } from '../schema/v4/optimize/info.ts';
+import { optimizeLightshow as optimizeV4Lightshow } from '../schema/v4/optimize/lightshow.ts';
+
+type OptimizeMap<T extends BeatmapFileType> = {
+   [key in InferBeatmapVersion<T>]: (
+      data: InferBeatmapSerial<T, key>,
+      options: IOptimizeOptions,
+   ) => void;
+};
 
 /** Optimize function version map for schema beatmap info. */
-export const infoOptimizeMap: Record<number, (data: any, options: IOptimizeOptions) => void> = {
+export const infoOptimizeMap: OptimizeMap<'info'> = {
    1: optimizeV1Info,
    2: optimizeV2Info,
    4: optimizeV4Info,
 };
 
 /** Optimize function version map for schema beatmap difficulty. */
-export const difficultyOptimizeMap: Record<number, (data: any, options: IOptimizeOptions) => void> =
-   {
-      1: optimizeV1Difficulty,
-      2: optimizeV2Difficulty,
-      3: optimizeV3Difficulty,
-      4: optimizeV4Difficulty,
-   };
+export const difficultyOptimizeMap: OptimizeMap<'difficulty'> = {
+   1: optimizeV1Difficulty,
+   2: optimizeV2Difficulty,
+   3: optimizeV3Difficulty,
+   4: optimizeV4Difficulty,
+} as const;
 
 /** Optimize function version map for schema beatmap lightshow. */
-export const lightshowOptimizeMap: Record<number, (data: any, options: IOptimizeOptions) => void> =
-   {
-      3: optimizeV3Lightshow,
-      4: optimizeV4Lightshow,
-   };
+export const lightshowOptimizeMap: OptimizeMap<'lightshow'> = {
+   3: optimizeV3Lightshow,
+   4: optimizeV4Lightshow,
+};
+
+export function optimizeBeatmap<
+   TFileType extends BeatmapFileType,
+   TVersion extends InferBeatmapVersion<TFileType>,
+   TSerial extends InferBeatmapSerial<TFileType, TVersion>,
+>(type: TFileType, ver: TVersion, data: TSerial, options: IOptimizeOptions): void {
+   switch (type) {
+      case 'info': {
+         const optimize = infoOptimizeMap[ver as InferBeatmapVersion<'info'>];
+         return optimize(data as any, options);
+      }
+      case 'difficulty': {
+         const optimize = difficultyOptimizeMap[ver as InferBeatmapVersion<'difficulty'>];
+         return optimize(data as any, options);
+      }
+      case 'lightshow': {
+         const optimize = lightshowOptimizeMap[ver as InferBeatmapVersion<'lightshow'>];
+         return optimize(data as any, options);
+      }
+      default: {
+         throw new Error('');
+      }
+   }
+}

--- a/src/beatmap/mapping/schema.ts
+++ b/src/beatmap/mapping/schema.ts
@@ -1,34 +1,44 @@
-import { info as V1Info } from '../schema/v1/info.ts';
-import { info as V2Info } from '../schema/v2/info.ts';
-import { info as V4Info } from '../schema/v4/info.ts';
-import { audioData as V2AudioData } from '../schema/v2/audioData.ts';
-import { audioData as V4AudioData } from '../schema/v4/audioData.ts';
+// deno-lint-ignore-file no-explicit-any
+import type {
+   InferBeatmapAttribute,
+   InferBeatmapSerial,
+   InferBeatmapVersion,
+} from '../../types/beatmap/shared/infer.ts';
+import type { BeatmapFileType, ISchemaContainer } from '../../types/beatmap/shared/schema.ts';
 import { difficulty as V1Difficulty } from '../schema/v1/difficulty.ts';
+import { info as V1Info } from '../schema/v1/info.ts';
+import { audioData as V2AudioData } from '../schema/v2/audioData.ts';
 import { difficulty as V2Difficulty } from '../schema/v2/difficulty.ts';
+import { info as V2Info } from '../schema/v2/info.ts';
 import { difficulty as V3Difficulty } from '../schema/v3/difficulty.ts';
-import { difficulty as V4Difficulty } from '../schema/v4/difficulty.ts';
 import { lightshow as V3Lightshow } from '../schema/v3/lightshow.ts';
+import { audioData as V4AudioData } from '../schema/v4/audioData.ts';
+import { difficulty as V4Difficulty } from '../schema/v4/difficulty.ts';
+import { info as V4Info } from '../schema/v4/info.ts';
 import { lightshow as V4Lightshow } from '../schema/v4/lightshow.ts';
-import type { ISchemaContainer } from '../../types/beatmap/shared/schema.ts';
-import type { IWrapInfoAttribute } from '../../types/beatmap/wrapper/info.ts';
-import type { IWrapBeatmapAttribute } from '../../types/beatmap/wrapper/beatmap.ts';
-import type { IWrapAudioDataAttribute } from '../../types/beatmap/wrapper/audioData.ts';
+
+type SchemaMap<T extends BeatmapFileType> = {
+   [key in InferBeatmapVersion<T>]: ISchemaContainer<
+      InferBeatmapAttribute<T>,
+      InferBeatmapSerial<T, key>
+   >;
+};
 
 /** Schema version map for beatmap info. */
-export const infoSchemaMap: Record<number, ISchemaContainer<IWrapInfoAttribute>> = {
+export const infoSchemaMap: SchemaMap<'info'> = {
    1: V1Info,
    2: V2Info,
    4: V4Info,
 };
 
 /** Schema version map for beatmap audio data. */
-export const audioDataSchemaMap: Record<number, ISchemaContainer<IWrapAudioDataAttribute>> = {
+export const audioDataSchemaMap: SchemaMap<'audioData'> = {
    2: V2AudioData,
    4: V4AudioData,
 };
 
 /** Schema version map for beatmap difficulty. */
-export const difficultySchemaMap: Record<number, ISchemaContainer<IWrapBeatmapAttribute>> = {
+export const difficultySchemaMap: SchemaMap<'difficulty'> = {
    1: V1Difficulty,
    2: V2Difficulty,
    3: V3Difficulty,
@@ -36,7 +46,65 @@ export const difficultySchemaMap: Record<number, ISchemaContainer<IWrapBeatmapAt
 };
 
 /** Schema version map for beatmap lightshow. */
-export const lightshowSchemaMap: Record<number, ISchemaContainer<IWrapBeatmapAttribute>> = {
+export const lightshowSchemaMap: SchemaMap<'lightshow'> = {
    3: V3Lightshow,
    4: V4Lightshow,
 };
+
+export function serializeBeatmap<
+   TFileType extends BeatmapFileType,
+   TVersion extends InferBeatmapVersion<TFileType>,
+   TWrapper extends InferBeatmapAttribute<TFileType>,
+   TSerial extends InferBeatmapSerial<TFileType, TVersion>,
+>(type: TFileType, ver: TVersion, data: TWrapper): TSerial {
+   switch (type) {
+      case 'info': {
+         const container = infoSchemaMap[ver as InferBeatmapVersion<'info'>];
+         return container.serialize(data as InferBeatmapAttribute<'info'>) as TSerial;
+      }
+      case 'audioData': {
+         const container = audioDataSchemaMap[ver as InferBeatmapVersion<'audioData'>];
+         return container.serialize(data as InferBeatmapAttribute<'audioData'>) as TSerial;
+      }
+      case 'difficulty': {
+         const container = difficultySchemaMap[ver as InferBeatmapVersion<'difficulty'>];
+         return container.serialize(data as InferBeatmapAttribute<'difficulty'>) as TSerial;
+      }
+      case 'lightshow': {
+         const container = lightshowSchemaMap[ver as InferBeatmapVersion<'lightshow'>];
+         return container.serialize(data as InferBeatmapAttribute<'lightshow'>) as TSerial;
+      }
+      default: {
+         throw new Error('');
+      }
+   }
+}
+
+export function deserializeBeatmap<
+   TFileType extends BeatmapFileType,
+   TVersion extends InferBeatmapVersion<TFileType>,
+   TSerial extends InferBeatmapSerial<TFileType, TVersion>,
+   TWrapper extends InferBeatmapAttribute<TFileType>,
+>(type: TFileType, ver: TVersion, data: TSerial): TWrapper {
+   switch (type) {
+      case 'info': {
+         const container = infoSchemaMap[ver as InferBeatmapVersion<'info'>];
+         return container.deserialize(data as any) as TWrapper;
+      }
+      case 'audioData': {
+         const container = audioDataSchemaMap[ver as InferBeatmapVersion<'audioData'>];
+         return container.deserialize(data as any) as TWrapper;
+      }
+      case 'difficulty': {
+         const container = difficultySchemaMap[ver as InferBeatmapVersion<'difficulty'>];
+         return container.deserialize(data as any) as TWrapper;
+      }
+      case 'lightshow': {
+         const container = lightshowSchemaMap[ver as InferBeatmapVersion<'lightshow'>];
+         return container.deserialize(data as any) as TWrapper;
+      }
+      default: {
+         throw new Error('');
+      }
+   }
+}

--- a/src/beatmap/saver/_main.ts
+++ b/src/beatmap/saver/_main.ts
@@ -1,12 +1,11 @@
 // deno-lint-ignore-file no-explicit-any
 import { logger } from '../../logger.ts';
-import type { BeatmapFileType } from '../../types/beatmap/shared/schema.ts';
 import type { ISaveOptions } from '../../types/beatmap/options/saver.ts';
-import type { IWrapInfo } from '../../types/beatmap/wrapper/info.ts';
+import type { BeatmapFileType } from '../../types/beatmap/shared/schema.ts';
 import type { IWrapAudioData } from '../../types/beatmap/wrapper/audioData.ts';
-import type { IWrapBeatmap } from '../../types/beatmap/wrapper/beatmap.ts';
 import type { IWrapBeatmapFile } from '../../types/beatmap/wrapper/baseFile.ts';
-import { validateJSON } from '../validator/json.ts';
+import type { IWrapBeatmap } from '../../types/beatmap/wrapper/beatmap.ts';
+import type { IWrapInfo } from '../../types/beatmap/wrapper/info.ts';
 import { audioDataConvertMap, beatmapConvertMap, infoConvertMap } from '../mapping/converter.ts';
 import {
    difficultyOptimizeMap,
@@ -20,6 +19,7 @@ import {
    lightshowSchemaMap,
 } from '../mapping/schema.ts';
 import { compatibilityCheck } from '../validator/compatibility.ts';
+import { validateJSON } from '../validator/json.ts';
 
 export function tag(name: string): string[] {
    return ['saver', name];
@@ -167,7 +167,7 @@ export function saveBeatmap<
    //    }
    // }
 
-   if (opt.sort) {
+   if (opt.sort && 'sort' in data && typeof data.sort === 'function') {
       logger.tInfo(tag('saveBeatmap'), 'Sorting beatmap objects');
       data.sort();
    }

--- a/src/beatmap/saver/audioData.ts
+++ b/src/beatmap/saver/audioData.ts
@@ -1,7 +1,11 @@
 // deno-lint-ignore-file no-explicit-any
 import { logger } from '../../logger.ts';
-import type { IWrapAudioData } from '../../types/beatmap/wrapper/audioData.ts';
 import type { ISaveOptions } from '../../types/beatmap/options/saver.ts';
+import type {
+   InferBeatmapAttribute,
+   InferBeatmapSerial,
+   InferBeatmapVersion,
+} from '../../types/beatmap/shared/infer.ts';
 import { saveBeatmap, tag } from './_main.ts';
 
 /**
@@ -13,20 +17,34 @@ import { saveBeatmap, tag } from './_main.ts';
  *
  * Mismatched beatmap version will be automatically converted, unspecified will leave the version as is but not known.
  */
-export function saveAudioData<T extends Record<string, any>>(
-   data: IWrapAudioData,
-   version?: number | null,
-   options?: ISaveOptions<IWrapAudioData>,
-): T;
-export function saveAudioData<T extends Record<string, any>>(
-   data: IWrapAudioData,
-   options?: ISaveOptions<IWrapAudioData>,
-): T;
-export function saveAudioData<T extends Record<string, any>>(
-   data: IWrapAudioData,
-   version?: number | null | ISaveOptions<IWrapAudioData>,
-   options?: ISaveOptions<IWrapAudioData>,
-): T {
+export function saveAudioData<
+   TVersion extends InferBeatmapVersion<'audioData'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'audioData'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'audioData', TVersion>,
+>(
+   data: TWrapper,
+   version?: TVersion | null,
+   options?: ISaveOptions<'audioData', TVersion, TWrapper, TSerial>,
+): TSerial;
+export function saveAudioData<
+   TVersion extends InferBeatmapVersion<'audioData'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'audioData'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'audioData', TVersion>,
+>(
+   data: TWrapper,
+   options?: ISaveOptions<'audioData', TVersion, TWrapper, TSerial>,
+): TSerial;
+export function saveAudioData<
+   TVersion extends InferBeatmapVersion<'audioData'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'audioData'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'audioData', TVersion>,
+>(
+   data: TWrapper,
+   version?: TVersion | null | ISaveOptions<'audioData', TVersion, TWrapper, TSerial>,
+   options?: ISaveOptions<'audioData', TVersion, TWrapper, TSerial>,
+): TSerial {
+   const ver = typeof version === 'number' ? version : null;
+   const opt = (typeof version !== 'number' ? version : options) ?? {};
    logger.tInfo(tag('saveAudioData'), 'Saving audio data to JSON');
-   return saveBeatmap<T>('audioData', data, version, options);
+   return saveBeatmap('audioData', data, ver, opt);
 }

--- a/src/beatmap/saver/difficulty.ts
+++ b/src/beatmap/saver/difficulty.ts
@@ -1,7 +1,11 @@
 // deno-lint-ignore-file no-explicit-any
 import { logger } from '../../logger.ts';
-import type { IWrapBeatmap } from '../../types/beatmap/wrapper/beatmap.ts';
 import type { ISaveOptions } from '../../types/beatmap/options/saver.ts';
+import type {
+   InferBeatmapAttribute,
+   InferBeatmapSerial,
+   InferBeatmapVersion,
+} from '../../types/beatmap/shared/infer.ts';
 import { saveBeatmap, tag } from './_main.ts';
 
 /**
@@ -13,20 +17,37 @@ import { saveBeatmap, tag } from './_main.ts';
  *
  * Mismatched beatmap version will be automatically converted, unspecified will leave the version as is but not known.
  */
-export function saveDifficulty<T extends Record<string, any>>(
-   data: IWrapBeatmap,
-   version?: number | null,
-   options?: ISaveOptions<IWrapBeatmap>,
-): T;
-export function saveDifficulty<T extends Record<string, any>>(
-   data: IWrapBeatmap,
-   options?: ISaveOptions<IWrapBeatmap>,
-): T;
-export function saveDifficulty<T extends Record<string, any>>(
-   data: IWrapBeatmap,
-   version?: number | null | ISaveOptions<IWrapBeatmap>,
-   options?: ISaveOptions<IWrapBeatmap>,
-): T {
+export function saveDifficulty<
+   TVersion extends InferBeatmapVersion<'difficulty'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'difficulty'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'difficulty', TVersion>,
+>(
+   data: TWrapper,
+   version?: TVersion | null,
+   options?: ISaveOptions<'difficulty', TVersion, TWrapper, TSerial>,
+): TSerial;
+export function saveDifficulty<
+   TVersion extends InferBeatmapVersion<'difficulty'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'difficulty'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<
+      'difficulty',
+      TVersion
+   >,
+>(
+   data: TWrapper,
+   options?: ISaveOptions<'difficulty', TVersion, TWrapper, TSerial>,
+): TSerial;
+export function saveDifficulty<
+   TVersion extends InferBeatmapVersion<'difficulty'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'difficulty'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'difficulty', TVersion>,
+>(
+   data: TWrapper,
+   version?: TVersion | null | ISaveOptions<'difficulty', TVersion, TWrapper, TSerial>,
+   options?: ISaveOptions<'difficulty', TVersion, TWrapper, TSerial>,
+): TSerial {
+   const ver = typeof version === 'number' ? version : null;
+   const opt = (typeof version !== 'number' ? version : options) ?? {};
    logger.tInfo(tag('saveDifficulty'), 'Saving difficulty to JSON');
-   return saveBeatmap<T>('difficulty', data, version, options);
+   return saveBeatmap('difficulty', data, ver, opt);
 }

--- a/src/beatmap/saver/info.ts
+++ b/src/beatmap/saver/info.ts
@@ -1,7 +1,11 @@
 // deno-lint-ignore-file no-explicit-any
 import { logger } from '../../logger.ts';
-import type { IWrapInfo } from '../../types/beatmap/wrapper/info.ts';
 import type { ISaveOptions } from '../../types/beatmap/options/saver.ts';
+import type {
+   InferBeatmapAttribute,
+   InferBeatmapSerial,
+   InferBeatmapVersion,
+} from '../../types/beatmap/shared/infer.ts';
 import { saveBeatmap, tag } from './_main.ts';
 
 /**
@@ -13,20 +17,34 @@ import { saveBeatmap, tag } from './_main.ts';
  *
  * Mismatched beatmap version will be automatically converted, unspecified will leave the version as is but not known.
  */
-export function saveInfo<T extends Record<string, any>>(
-   data: IWrapInfo,
-   version?: number | null,
-   options?: ISaveOptions<IWrapInfo>,
-): T;
-export function saveInfo<T extends Record<string, any>>(
-   data: IWrapInfo,
-   options?: ISaveOptions<IWrapInfo>,
-): T;
-export function saveInfo<T extends Record<string, any>>(
-   data: IWrapInfo,
-   version?: number | null | ISaveOptions<IWrapInfo>,
-   options?: ISaveOptions<IWrapInfo>,
-): T {
+export function saveInfo<
+   TVersion extends InferBeatmapVersion<'info'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'info'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'info', TVersion>,
+>(
+   data: TWrapper,
+   version?: TVersion | null,
+   options?: ISaveOptions<'info', TVersion, TWrapper, TSerial>,
+): TSerial;
+export function saveInfo<
+   TVersion extends InferBeatmapVersion<'info'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'info'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'info', TVersion>,
+>(
+   data: TWrapper,
+   options?: ISaveOptions<'info', TVersion, TWrapper, TSerial>,
+): TSerial;
+export function saveInfo<
+   TVersion extends InferBeatmapVersion<'info'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'info'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'info', TVersion>,
+>(
+   data: TWrapper,
+   version?: TVersion | null | ISaveOptions<'info', TVersion, TWrapper, TSerial>,
+   options?: ISaveOptions<'info', TVersion, TWrapper, TSerial>,
+): TSerial {
+   const ver = typeof version === 'number' ? version : null;
+   const opt = (typeof version !== 'number' ? version : options) ?? {};
    logger.tInfo(tag('saveInfo'), 'Saving info to JSON');
-   return saveBeatmap<T>('info', data, version, options);
+   return saveBeatmap('info', data, ver, opt);
 }

--- a/src/beatmap/saver/lightshow.ts
+++ b/src/beatmap/saver/lightshow.ts
@@ -1,7 +1,11 @@
 // deno-lint-ignore-file no-explicit-any
 import { logger } from '../../logger.ts';
-import type { IWrapBeatmap } from '../../types/beatmap/wrapper/beatmap.ts';
 import type { ISaveOptions } from '../../types/beatmap/options/saver.ts';
+import type {
+   InferBeatmapAttribute,
+   InferBeatmapSerial,
+   InferBeatmapVersion,
+} from '../../types/beatmap/shared/infer.ts';
 import { saveBeatmap, tag } from './_main.ts';
 
 /**
@@ -13,20 +17,34 @@ import { saveBeatmap, tag } from './_main.ts';
  *
  * Mismatched beatmap version will be automatically converted, unspecified will leave the version as is but not known.
  */
-export function saveLightshow<T extends Record<string, any>>(
-   data: IWrapBeatmap,
-   version?: number | null,
-   options?: ISaveOptions<IWrapBeatmap>,
-): T;
-export function saveLightshow<T extends Record<string, any>>(
-   data: IWrapBeatmap,
-   options?: ISaveOptions<IWrapBeatmap>,
-): T;
-export function saveLightshow<T extends Record<string, any>>(
-   data: IWrapBeatmap,
-   version?: number | null | ISaveOptions<IWrapBeatmap>,
-   options?: ISaveOptions<IWrapBeatmap>,
-): T {
+export function saveLightshow<
+   TVersion extends InferBeatmapVersion<'lightshow'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'lightshow'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'lightshow', TVersion>,
+>(
+   data: TWrapper,
+   version?: TVersion | null,
+   options?: ISaveOptions<'lightshow', TVersion, TWrapper, TSerial>,
+): TSerial;
+export function saveLightshow<
+   TVersion extends InferBeatmapVersion<'lightshow'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'lightshow'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'lightshow', TVersion>,
+>(
+   data: TWrapper,
+   options?: ISaveOptions<'lightshow', TVersion, TWrapper, TSerial>,
+): TSerial;
+export function saveLightshow<
+   TVersion extends InferBeatmapVersion<'lightshow'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'lightshow'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'lightshow', TVersion>,
+>(
+   data: TWrapper,
+   version?: TVersion | null | ISaveOptions<'lightshow', TVersion, TWrapper, TSerial>,
+   options?: ISaveOptions<'lightshow', TVersion, TWrapper, TSerial>,
+): TSerial {
+   const ver = typeof version === 'number' ? version : null;
+   const opt = (typeof version !== 'number' ? version : options) ?? {};
    logger.tInfo(tag('saveLightshow'), 'Saving lightshow to JSON');
-   return saveBeatmap<T>('lightshow', data, version, options);
+   return saveBeatmap('lightshow', data, ver, opt);
 }

--- a/src/beatmap/schema/v1/basicEvent.ts
+++ b/src/beatmap/schema/v1/basicEvent.ts
@@ -6,19 +6,20 @@ import type { IWrapBasicEventAttribute } from '../../../types/beatmap/wrapper/ba
  * Schema serialization for v1 `Basic Event`.
  */
 export const basicEvent: ISchemaContainer<IWrapBasicEventAttribute, IEvent> = {
-   serialize(data: IWrapBasicEventAttribute): IEvent {
+   serialize(data) {
       return {
          _time: data.time,
          _type: data.type,
          _value: data.value,
       };
    },
-   deserialize(data: Partial<IEvent> = {}): Partial<IWrapBasicEventAttribute> {
+   deserialize(data) {
       return {
-         time: data._time,
-         type: data._type,
-         value: data._value,
+         time: data._time ?? 0,
+         type: data._type ?? 0,
+         value: data._value ?? 0,
          floatValue: 1,
+         customData: {},
       };
    },
 };

--- a/src/beatmap/schema/v1/basicEvent.ts
+++ b/src/beatmap/schema/v1/basicEvent.ts
@@ -1,6 +1,7 @@
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IEvent } from '../../../types/beatmap/v1/event.ts';
 import type { IWrapBasicEventAttribute } from '../../../types/beatmap/wrapper/basicEvent.ts';
+import { createBasicEvent } from '../../core/basicEvent.ts';
 
 /**
  * Schema serialization for v1 `Basic Event`.
@@ -14,12 +15,11 @@ export const basicEvent: ISchemaContainer<IWrapBasicEventAttribute, IEvent> = {
       };
    },
    deserialize(data) {
-      return {
-         time: data._time ?? 0,
-         type: data._type ?? 0,
-         value: data._value ?? 0,
+      return createBasicEvent({
+         time: data._time,
+         type: data._type,
+         value: data._value,
          floatValue: 1,
-         customData: {},
-      };
+      });
    },
 };

--- a/src/beatmap/schema/v1/bombNote.ts
+++ b/src/beatmap/schema/v1/bombNote.ts
@@ -1,6 +1,7 @@
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { INote } from '../../../types/beatmap/v1/note.ts';
 import type { IWrapBombNoteAttribute } from '../../../types/beatmap/wrapper/bombNote.ts';
+import { createBombNote } from '../../core/bombNote.ts';
 
 /**
  * Schema serialization for v1 `Bomb Note`.
@@ -16,14 +17,11 @@ export const bombNote: ISchemaContainer<IWrapBombNoteAttribute, INote> = {
       };
    },
    deserialize(data) {
-      return {
-         time: data._time ?? 0,
-         laneRotation: 0,
-         posX: data._lineIndex ?? 0,
-         posY: data._lineLayer ?? 0,
-         color: -1,
-         direction: data._cutDirection ?? 0,
-         customData: {},
-      };
+      return createBombNote({
+         time: data._time,
+         posX: data._lineIndex,
+         posY: data._lineLayer,
+         direction: data._cutDirection,
+      });
    },
 };

--- a/src/beatmap/schema/v1/bombNote.ts
+++ b/src/beatmap/schema/v1/bombNote.ts
@@ -6,7 +6,7 @@ import type { IWrapBombNoteAttribute } from '../../../types/beatmap/wrapper/bomb
  * Schema serialization for v1 `Bomb Note`.
  */
 export const bombNote: ISchemaContainer<IWrapBombNoteAttribute, INote> = {
-   serialize(data: IWrapBombNoteAttribute): INote {
+   serialize(data) {
       return {
          _time: data.time,
          _lineIndex: data.posX,
@@ -15,12 +15,15 @@ export const bombNote: ISchemaContainer<IWrapBombNoteAttribute, INote> = {
          _cutDirection: data.direction,
       };
    },
-   deserialize(data: Partial<INote> = {}): Partial<IWrapBombNoteAttribute> {
+   deserialize(data) {
       return {
-         time: data._time,
-         posX: data._lineIndex,
-         posY: data._lineLayer,
-         direction: data._cutDirection,
+         time: data._time ?? 0,
+         laneRotation: 0,
+         posX: data._lineIndex ?? 0,
+         posY: data._lineLayer ?? 0,
+         color: -1,
+         direction: data._cutDirection ?? 0,
+         customData: {},
       };
    },
 };

--- a/src/beatmap/schema/v1/bpmEvent.ts
+++ b/src/beatmap/schema/v1/bpmEvent.ts
@@ -6,17 +6,18 @@ import type { IWrapBPMEventAttribute } from '../../../types/beatmap/wrapper/bpmE
  * Schema serialization for v1 `BPM Event`.
  */
 export const bpmEvent: ISchemaContainer<IWrapBPMEventAttribute, IEvent> = {
-   serialize(data: IWrapBPMEventAttribute): IEvent {
+   serialize(data) {
       return {
          _time: data.time,
          _type: 100,
          _value: Math.round(data.bpm),
       };
    },
-   deserialize(data: Partial<IEvent> = {}): Partial<IWrapBPMEventAttribute> {
+   deserialize(data) {
       return {
-         time: data._time,
-         bpm: data._value,
+         time: data._time ?? 0,
+         bpm: data._value ?? 0,
+         customData: {},
       };
    },
 };

--- a/src/beatmap/schema/v1/bpmEvent.ts
+++ b/src/beatmap/schema/v1/bpmEvent.ts
@@ -1,6 +1,7 @@
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IEvent } from '../../../types/beatmap/v1/event.ts';
 import type { IWrapBPMEventAttribute } from '../../../types/beatmap/wrapper/bpmEvent.ts';
+import { createBPMEvent } from '../../core/bpmEvent.ts';
 
 /**
  * Schema serialization for v1 `BPM Event`.
@@ -14,10 +15,9 @@ export const bpmEvent: ISchemaContainer<IWrapBPMEventAttribute, IEvent> = {
       };
    },
    deserialize(data) {
-      return {
-         time: data._time ?? 0,
-         bpm: data._value ?? 0,
-         customData: {},
-      };
+      return createBPMEvent({
+         time: data._time,
+         bpm: data._value,
+      });
    },
 };

--- a/src/beatmap/schema/v1/colorBoostEvent.ts
+++ b/src/beatmap/schema/v1/colorBoostEvent.ts
@@ -1,6 +1,7 @@
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IEvent } from '../../../types/beatmap/v1/event.ts';
 import type { IWrapColorBoostEventAttribute } from '../../../types/beatmap/wrapper/colorBoostEvent.ts';
+import { createColorBoostEvent } from '../../core/colorBoostEvent.ts';
 
 /**
  * Schema serialization for v1 `Color Boost Event`.
@@ -14,10 +15,9 @@ export const colorBoostEvent: ISchemaContainer<IWrapColorBoostEventAttribute, IE
       };
    },
    deserialize(data) {
-      return {
-         time: data._time ?? 0,
+      return createColorBoostEvent({
+         time: data._time,
          toggle: data._value === 1,
-         customData: {},
-      };
+      });
    },
 };

--- a/src/beatmap/schema/v1/colorBoostEvent.ts
+++ b/src/beatmap/schema/v1/colorBoostEvent.ts
@@ -6,17 +6,18 @@ import type { IWrapColorBoostEventAttribute } from '../../../types/beatmap/wrapp
  * Schema serialization for v1 `Color Boost Event`.
  */
 export const colorBoostEvent: ISchemaContainer<IWrapColorBoostEventAttribute, IEvent> = {
-   serialize(data: IWrapColorBoostEventAttribute): IEvent {
+   serialize(data) {
       return {
          _time: data.time,
          _type: 5,
          _value: data.toggle ? 1 : 0,
       };
    },
-   deserialize(data: Partial<IEvent> = {}): Partial<IWrapColorBoostEventAttribute> {
+   deserialize(data) {
       return {
-         time: data._time,
+         time: data._time ?? 0,
          toggle: data._value === 1,
+         customData: {},
       };
    },
 };

--- a/src/beatmap/schema/v1/colorNote.ts
+++ b/src/beatmap/schema/v1/colorNote.ts
@@ -1,6 +1,8 @@
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { INote } from '../../../types/beatmap/v1/note.ts';
 import type { IWrapColorNoteAttribute } from '../../../types/beatmap/wrapper/colorNote.ts';
+import { createColorNote } from '../../core/colorNote.ts';
+import { NoteColor } from '../../shared/constants.ts';
 
 /**
  * Schema serialization for v1 `Color Note`.
@@ -16,15 +18,12 @@ export const colorNote: ISchemaContainer<IWrapColorNoteAttribute, INote> = {
       };
    },
    deserialize(data) {
-      return {
-         time: data._time ?? 0,
-         laneRotation: 0,
-         posX: data._lineIndex ?? 0,
-         posY: data._lineLayer ?? 0,
-         color: data._type as 0 ?? 0,
-         direction: data._cutDirection ?? 0,
-         angleOffset: 0,
-         customData: {},
-      };
+      return createColorNote({
+         time: data._time,
+         posX: data._lineIndex,
+         posY: data._lineLayer,
+         color: [NoteColor.RED, NoteColor.BLUE][data._type ?? 0],
+         direction: data._cutDirection,
+      });
    },
 };

--- a/src/beatmap/schema/v1/colorNote.ts
+++ b/src/beatmap/schema/v1/colorNote.ts
@@ -6,7 +6,7 @@ import type { IWrapColorNoteAttribute } from '../../../types/beatmap/wrapper/col
  * Schema serialization for v1 `Color Note`.
  */
 export const colorNote: ISchemaContainer<IWrapColorNoteAttribute, INote> = {
-   serialize(data: IWrapColorNoteAttribute): INote {
+   serialize(data) {
       return {
          _time: data.time,
          _lineIndex: data.posX,
@@ -15,13 +15,16 @@ export const colorNote: ISchemaContainer<IWrapColorNoteAttribute, INote> = {
          _cutDirection: data.direction,
       };
    },
-   deserialize(data: Partial<INote> = {}): Partial<IWrapColorNoteAttribute> {
+   deserialize(data) {
       return {
-         time: data._time,
-         posX: data._lineIndex,
-         posY: data._lineLayer,
-         color: data._type as 0,
-         direction: data._cutDirection,
+         time: data._time ?? 0,
+         laneRotation: 0,
+         posX: data._lineIndex ?? 0,
+         posY: data._lineLayer ?? 0,
+         color: data._type as 0 ?? 0,
+         direction: data._cutDirection ?? 0,
+         angleOffset: 0,
+         customData: {},
       };
    },
 };

--- a/src/beatmap/schema/v1/compat/difficulty.ts
+++ b/src/beatmap/schema/v1/compat/difficulty.ts
@@ -1,29 +1,29 @@
-import type { IWrapBeatmap } from '../../../../types/beatmap/wrapper/beatmap.ts';
-import type { ICompatibilityOptions } from '../../../../types/beatmap/options/compatibility.ts';
 import { logger } from '../../../../logger.ts';
-import { tag } from './_common.ts';
+import type { ICompatibilityOptions } from '../../../../types/beatmap/options/compatibility.ts';
+import type { IWrapBeatmapAttribute } from '../../../../types/beatmap/wrapper/beatmap.ts';
 import {
    hasMappingExtensionsBombNote,
    hasMappingExtensionsNote,
    hasMappingExtensionsObstacleV2,
    hasMappingExtensionsRotationV2,
 } from '../../../helpers/modded/has.ts';
+import { tag } from './_common.ts';
 
 /**
  * Checks if beatmap data is compatible with v1 `Difficulty` schema.
  */
-export function compatDifficulty(
-   bm: IWrapBeatmap,
+export function compatDifficulty<T extends IWrapBeatmapAttribute>(
+   bm: T,
    options: ICompatibilityOptions,
 ) {
-   const hasIncompat = !!bm.arcs.length ||
-      !!bm.chains.length ||
-      !!bm.waypoints.length ||
-      !!bm.bpmEvents.length ||
-      !!bm.lightColorEventBoxGroups.length ||
-      !!bm.lightRotationEventBoxGroups.length ||
-      !!bm.lightTranslationEventBoxGroups.length ||
-      !!bm.fxEventBoxGroups.length;
+   const hasIncompat = !!bm.difficulty.arcs.length ||
+      !!bm.difficulty.chains.length ||
+      !!bm.lightshow.waypoints.length ||
+      !!bm.difficulty.bpmEvents.length ||
+      !!bm.lightshow.lightColorEventBoxGroups.length ||
+      !!bm.lightshow.lightRotationEventBoxGroups.length ||
+      !!bm.lightshow.lightTranslationEventBoxGroups.length ||
+      !!bm.lightshow.fxEventBoxGroups.length;
 
    if (hasIncompat) {
       if (options.throwOn.incompatibleObject) {
@@ -36,10 +36,10 @@ export function compatDifficulty(
       }
    }
 
-   const hasME = bm.colorNotes.some(hasMappingExtensionsNote) ||
-      bm.bombNotes.some(hasMappingExtensionsBombNote) ||
-      bm.obstacles.some(hasMappingExtensionsObstacleV2) ||
-      bm.rotationEvents.some(hasMappingExtensionsRotationV2);
+   const hasME = bm.difficulty.colorNotes.some(hasMappingExtensionsNote) ||
+      bm.difficulty.bombNotes.some(hasMappingExtensionsBombNote) ||
+      bm.difficulty.obstacles.some(hasMappingExtensionsObstacleV2) ||
+      bm.difficulty.rotationEvents.some(hasMappingExtensionsRotationV2);
 
    if (hasME) {
       if (options.throwOn.mappingExtensions) {

--- a/src/beatmap/schema/v1/compat/info.ts
+++ b/src/beatmap/schema/v1/compat/info.ts
@@ -1,12 +1,12 @@
 import { logger } from '../../../../logger.ts';
 import type { ICompatibilityOptions } from '../../../../types/beatmap/options/compatibility.ts';
-import type { IWrapInfo } from '../../../../types/beatmap/wrapper/info.ts';
+import type { IWrapInfoAttribute } from '../../../../types/beatmap/wrapper/info.ts';
 import { tag } from './_common.ts';
 
 /**
  * Check if beatmap info is compatible with v1 `Info` schema.
  */
-export function compatInfo(info: IWrapInfo, options: ICompatibilityOptions) {
+export function compatInfo<T extends IWrapInfoAttribute>(info: T, options: ICompatibilityOptions) {
    const hasIncompat = info.audio.shufflePeriod !== 0.5 ||
       info.audio.shuffle !== 0 ||
       info.audio.audioOffset !== 0;

--- a/src/beatmap/schema/v1/difficulty.ts
+++ b/src/beatmap/schema/v1/difficulty.ts
@@ -1,59 +1,86 @@
-import type { IDifficulty } from '../../../types/beatmap/v1/difficulty.ts';
-import type { IWrapBeatmapAttribute } from '../../../types/beatmap/wrapper/beatmap.ts';
-import type { DeepPartial } from '../../../types/utils.ts';
-import type { IWrapColorNoteAttribute } from '../../../types/beatmap/wrapper/colorNote.ts';
-import type { IWrapBombNoteAttribute } from '../../../types/beatmap/wrapper/bombNote.ts';
-import type { IWrapBasicEventAttribute } from '../../../types/beatmap/wrapper/basicEvent.ts';
-import type { IWrapBPMEventAttribute } from '../../../types/beatmap/wrapper/bpmEvent.ts';
-import type { IWrapRotationEventAttribute } from '../../../types/beatmap/wrapper/rotationEvent.ts';
-import type { IWrapColorBoostEventAttribute } from '../../../types/beatmap/wrapper/colorBoostEvent.ts';
-import { bombNote } from './bombNote.ts';
-import { colorNote } from './colorNote.ts';
-import { basicEvent } from './basicEvent.ts';
-import { colorBoostEvent } from './colorBoostEvent.ts';
-import { rotationEvent } from './rotationEvent.ts';
-import { bpmEvent } from './bpmEvent.ts';
-import { obstacle } from './obstacle.ts';
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
+import type { IDifficulty } from '../../../types/beatmap/v1/difficulty.ts';
+import type { IWrapBasicEventAttribute } from '../../../types/beatmap/wrapper/basicEvent.ts';
+import type { IWrapBeatmapAttribute } from '../../../types/beatmap/wrapper/beatmap.ts';
+import type { IWrapBombNoteAttribute } from '../../../types/beatmap/wrapper/bombNote.ts';
+import type { IWrapBPMEventAttribute } from '../../../types/beatmap/wrapper/bpmEvent.ts';
+import type { IWrapColorBoostEventAttribute } from '../../../types/beatmap/wrapper/colorBoostEvent.ts';
+import type { IWrapColorNoteAttribute } from '../../../types/beatmap/wrapper/colorNote.ts';
+import type {
+   IWrapInfoAttribute,
+   IWrapInfoBeatmapAttribute,
+} from '../../../types/beatmap/wrapper/info.ts';
+import type { IWrapRotationEventAttribute } from '../../../types/beatmap/wrapper/rotationEvent.ts';
+import { basicEvent } from './basicEvent.ts';
+import { bombNote } from './bombNote.ts';
+import { bpmEvent } from './bpmEvent.ts';
+import { colorBoostEvent } from './colorBoostEvent.ts';
+import { colorNote } from './colorNote.ts';
+import { obstacle } from './obstacle.ts';
+import { rotationEvent } from './rotationEvent.ts';
+
+type DifficultySerializationPolyfills = Partial<
+   & Pick<IWrapInfoAttribute['audio'], 'bpm' | 'shuffle' | 'shufflePeriod'>
+   & Pick<IWrapInfoBeatmapAttribute, 'njs' | 'njsOffset'>
+   & { beatsPerBar: number }
+>;
+type DifficultyDeserializationPolyfills = Pick<
+   IWrapBeatmapAttribute,
+   'filename' | 'lightshowFilename'
+>;
 
 /**
  * Schema serialization for v1 `Difficulty`.
  */
-export const difficulty: ISchemaContainer<IWrapBeatmapAttribute, IDifficulty> = {
-   serialize(data: IWrapBeatmapAttribute): IDifficulty {
+export const difficulty: ISchemaContainer<
+   IWrapBeatmapAttribute,
+   IDifficulty,
+   DifficultySerializationPolyfills,
+   DifficultyDeserializationPolyfills
+> = {
+   serialize(data, options) {
       return {
          _version: '1.5.0',
          // FIXME: none of these shouldve ever existed, why
-         _beatsPerMinute: 120,
-         _beatsPerBar: 4,
-         _shuffle: 0,
-         _shufflePeriod: 0.5,
-         _noteJumpSpeed: 10,
-         _noteJumpStartBeatOffset: 0,
-         //
+         _beatsPerMinute: options?.bpm ?? 120,
+         _beatsPerBar: options?.beatsPerBar ?? 4,
+         _shuffle: options?.shuffle ?? 0,
+         _shufflePeriod: options?.shufflePeriod ?? 0.5,
+         _noteJumpSpeed: options?.njs ?? 0,
+         _noteJumpStartBeatOffset: options?.njsOffset ?? 0,
          _notes: [
-            ...data.difficulty.colorNotes.map(colorNote.serialize),
-            ...data.difficulty.bombNotes.map(bombNote.serialize),
+            ...data.difficulty.colorNotes.map((x) => {
+               return colorNote.serialize(x);
+            }),
+            ...data.difficulty.bombNotes.map((x) => {
+               return bombNote.serialize(x);
+            }),
          ],
-         _obstacles: data.difficulty.obstacles.map(obstacle.serialize),
+         _obstacles: data.difficulty.obstacles.map((x) => {
+            return obstacle.serialize(x);
+         }),
          _events: [
-            ...data.lightshow.basicEvents.map(basicEvent.serialize),
-            ...data.lightshow.colorBoostEvents.map(
-               colorBoostEvent.serialize,
-            ),
-            ...data.difficulty.rotationEvents.map(rotationEvent.serialize),
-            ...data.difficulty.bpmEvents.map(bpmEvent.serialize),
+            ...data.lightshow.basicEvents.map((x) => {
+               return basicEvent.serialize(x);
+            }),
+            ...data.lightshow.colorBoostEvents.map((x) => {
+               return colorBoostEvent.serialize(x);
+            }),
+            ...data.difficulty.rotationEvents.map((x) => {
+               return rotationEvent.serialize(x);
+            }),
+            ...data.difficulty.bpmEvents.map((x) => {
+               return bpmEvent.serialize(x);
+            }),
          ],
          _time: data.difficulty.customData._time,
          _BPMChanges: data.difficulty.customData._bpmChanges,
          _bookmarks: data.difficulty.customData._bookmarks,
       };
    },
-   deserialize(
-      data: DeepPartial<IDifficulty> = {},
-   ): DeepPartial<IWrapBeatmapAttribute> {
-      const colorNotes: Partial<IWrapColorNoteAttribute>[] = [];
-      const bombNotes: Partial<IWrapBombNoteAttribute>[] = [];
+   deserialize(data, options) {
+      const colorNotes: IWrapColorNoteAttribute[] = [];
+      const bombNotes: IWrapBombNoteAttribute[] = [];
       const _notes = data._notes || [];
       for (let i = 0; i < _notes.length; i++) {
          const obj = _notes[i];
@@ -64,10 +91,10 @@ export const difficulty: ISchemaContainer<IWrapBeatmapAttribute, IDifficulty> = 
          }
       }
 
-      const basicEvents: Partial<IWrapBasicEventAttribute>[] = [];
-      const colorBoostEvents: Partial<IWrapColorBoostEventAttribute>[] = [];
-      const rotationEvents: Partial<IWrapRotationEventAttribute>[] = [];
-      const bpmEvents: Partial<IWrapBPMEventAttribute>[] = [];
+      const basicEvents: IWrapBasicEventAttribute[] = [];
+      const colorBoostEvents: IWrapColorBoostEventAttribute[] = [];
+      const rotationEvents: IWrapRotationEventAttribute[] = [];
+      const bpmEvents: IWrapBPMEventAttribute[] = [];
       const _events = data._events || [];
       for (let i = 0; i < _events.length; i++) {
          const obj = _events[i];
@@ -90,12 +117,19 @@ export const difficulty: ISchemaContainer<IWrapBeatmapAttribute, IDifficulty> = 
 
       return {
          version: 1,
+         filename: options?.filename ?? 'EasyStandard.dat',
+         lightshowFilename: options?.lightshowFilename ?? 'EasyLightshow.dat',
          difficulty: {
             colorNotes,
             bombNotes,
-            obstacles: data._obstacles?.map(obstacle.deserialize),
-            bpmEvents,
+            obstacles: data._obstacles?.map((x) => {
+               return obstacle.deserialize(x);
+            }) ?? [],
+            arcs: [],
+            chains: [],
             rotationEvents,
+            bpmEvents,
+            njsEvents: [],
             customData: {
                _bpmChanges: data._BPMChanges,
                _bookmarks: data._bookmarks,
@@ -103,9 +137,18 @@ export const difficulty: ISchemaContainer<IWrapBeatmapAttribute, IDifficulty> = 
             },
          },
          lightshow: {
+            waypoints: [],
             basicEvents,
             colorBoostEvents,
+            lightColorEventBoxGroups: [],
+            lightRotationEventBoxGroups: [],
+            lightTranslationEventBoxGroups: [],
+            fxEventBoxGroups: [],
+            basicEventTypesWithKeywords: { list: [] },
+            useNormalEventsAsCompatibleEvents: true,
+            customData: {},
          },
+         customData: {},
       };
    },
 };

--- a/src/beatmap/schema/v1/difficulty.ts
+++ b/src/beatmap/schema/v1/difficulty.ts
@@ -11,6 +11,9 @@ import type {
    IWrapInfoBeatmapAttribute,
 } from '../../../types/beatmap/wrapper/info.ts';
 import type { IWrapRotationEventAttribute } from '../../../types/beatmap/wrapper/rotationEvent.ts';
+import { createBeatmap } from '../../core/beatmap.ts';
+import { createDifficulty } from '../../core/difficulty.ts';
+import { createLightshow } from '../../core/lightshow.ts';
 import { basicEvent } from './basicEvent.ts';
 import { bombNote } from './bombNote.ts';
 import { bpmEvent } from './bpmEvent.ts';
@@ -19,11 +22,11 @@ import { colorNote } from './colorNote.ts';
 import { obstacle } from './obstacle.ts';
 import { rotationEvent } from './rotationEvent.ts';
 
-type DifficultySerializationPolyfills = Partial<
+type DifficultySerializationPolyfills =
    & Pick<IWrapInfoAttribute['audio'], 'bpm' | 'shuffle' | 'shufflePeriod'>
    & Pick<IWrapInfoBeatmapAttribute, 'njs' | 'njsOffset'>
-   & { beatsPerBar: number }
->;
+   & { beatsPerBar: number };
+
 type DifficultyDeserializationPolyfills = Pick<
    IWrapBeatmapAttribute,
    'filename' | 'lightshowFilename'
@@ -115,40 +118,27 @@ export const difficulty: ISchemaContainer<
          }
       }
 
-      return {
+      return createBeatmap({
          version: 1,
          filename: options?.filename ?? 'EasyStandard.dat',
          lightshowFilename: options?.lightshowFilename ?? 'EasyLightshow.dat',
-         difficulty: {
+         difficulty: createDifficulty({
             colorNotes,
             bombNotes,
-            obstacles: data._obstacles?.map((x) => {
-               return obstacle.deserialize(x);
-            }) ?? [],
-            arcs: [],
-            chains: [],
+            obstacles: data._obstacles?.map((x) => obstacle.deserialize(x)),
             rotationEvents,
             bpmEvents,
-            njsEvents: [],
             customData: {
                _bpmChanges: data._BPMChanges,
                _bookmarks: data._bookmarks,
                _time: data._time,
             },
-         },
-         lightshow: {
-            waypoints: [],
+         }),
+         lightshow: createLightshow({
             basicEvents,
             colorBoostEvents,
-            lightColorEventBoxGroups: [],
-            lightRotationEventBoxGroups: [],
-            lightTranslationEventBoxGroups: [],
-            fxEventBoxGroups: [],
-            basicEventTypesWithKeywords: { list: [] },
             useNormalEventsAsCompatibleEvents: true,
-            customData: {},
-         },
-         customData: {},
-      };
+         }),
+      });
    },
 };

--- a/src/beatmap/schema/v1/info.ts
+++ b/src/beatmap/schema/v1/info.ts
@@ -1,17 +1,29 @@
-import type { IInfo } from '../../../types/beatmap/v1/info.ts';
-import type { DeepPartial } from '../../../types/utils.ts';
-import { deepCopy } from '../../../utils/misc.ts';
-import type { IWrapInfoAttribute } from '../../../types/beatmap/wrapper/info.ts';
-import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
-import { infoBeatmap } from './infoBeatmap.ts';
 import type { EnvironmentName } from '../../../types/beatmap/shared/environment.ts';
+import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
+import type { IInfo } from '../../../types/beatmap/v1/info.ts';
+import type { IWrapInfoAttribute } from '../../../types/beatmap/wrapper/info.ts';
+import { deepCopy } from '../../../utils/misc.ts';
 import { is360Environment } from '../../helpers/environment.ts';
+import { infoBeatmap } from './infoBeatmap.ts';
+
+type InfoPolyfills = Pick<IWrapInfoAttribute, 'filename'> & {
+   audio: Pick<
+      IWrapInfoAttribute['audio'],
+      | 'filename'
+      | 'audioDataFilename'
+      | 'lufs'
+      | 'duration'
+      | 'audioOffset'
+      | 'shuffle'
+      | 'shufflePeriod'
+   >;
+};
 
 /**
  * Schema serialization for v1 `Info`.
  */
-export const info: ISchemaContainer<IWrapInfoAttribute, IInfo> = {
-   serialize(data: IWrapInfoAttribute): IInfo {
+export const info: ISchemaContainer<IWrapInfoAttribute, IInfo, InfoPolyfills> = {
+   serialize(data) {
       return {
          songName: data.song.title,
          songSubName: data.song.subTitle,
@@ -25,7 +37,9 @@ export const info: ISchemaContainer<IWrapInfoAttribute, IInfo> = {
                (e) => !is360Environment(e),
             ) as EnvironmentName) ||
             'DefaultEnvironment',
-         difficultyLevels: data.difficulties.map(infoBeatmap.serialize),
+         difficultyLevels: data.difficulties.map((x) => {
+            return infoBeatmap.serialize(x);
+         }),
          oneSaber: data.difficulties.some(
             (m) => m.characteristic === 'OneSaber',
          ),
@@ -34,28 +48,37 @@ export const info: ISchemaContainer<IWrapInfoAttribute, IInfo> = {
          customEnvironmentHash: data.customData._customEnvironmentHash,
       };
    },
-   deserialize(data: DeepPartial<IInfo> = {}): DeepPartial<IWrapInfoAttribute> {
+   deserialize(data, options) {
       return {
          version: 1,
+         filename: options?.filename ?? 'Info.dat',
          song: {
-            title: data.songName,
-            subTitle: data.songSubName,
-            author: data.authorName,
+            title: data.songName ?? '',
+            subTitle: data.songSubName ?? '',
+            author: data.authorName ?? '',
          },
          audio: {
             filename: data.difficultyLevels?.find((e) => e?.audioPath)
-               ?.audioPath,
-            bpm: data.beatsPerMinute,
-            previewStartTime: data.previewStartTime,
-            previewDuration: data.previewDuration,
+               ?.audioPath ?? options?.audio?.filename ?? 'song.ogg',
+            audioDataFilename: options?.audio?.audioDataFilename ?? 'BPMInfo.dat',
+            bpm: data.beatsPerMinute ?? 120,
+            lufs: options?.audio?.lufs ?? 0,
+            duration: options?.audio?.duration ?? 0,
+            previewStartTime: data.previewStartTime ?? 0,
+            previewDuration: data.previewDuration ?? 0,
+            audioOffset: options?.audio?.audioOffset ?? 0,
+            shuffle: options?.audio?.shuffle ?? 0,
+            shufflePeriod: options?.audio?.shufflePeriod ?? 0.5,
          },
          songPreviewFilename: data.difficultyLevels?.find((e) => e?.audioPath)
-            ?.audioPath,
-         coverImageFilename: data.coverImagePath,
-         environmentBase: { normal: data.environmentName },
-
-         difficulties: data.difficultyLevels?.map(infoBeatmap.deserialize),
-
+            ?.audioPath ?? options?.audio?.filename ?? 'song.ogg',
+         coverImageFilename: data.coverImagePath ?? 'cover.jpg',
+         environmentBase: { normal: data.environmentName, allDirections: 'GlassDesertEnvironment' },
+         environmentNames: [data.environmentName],
+         colorSchemes: [],
+         difficulties: data.difficultyLevels?.map((x) => {
+            return infoBeatmap.deserialize(x);
+         }) ?? [],
          customData: {
             _contributors: data.contributors,
             _customEnvironment: data.customEnvironment,

--- a/src/beatmap/schema/v1/infoBeatmap.ts
+++ b/src/beatmap/schema/v1/infoBeatmap.ts
@@ -5,6 +5,7 @@ import type {
    IWrapInfoBeatmapAttribute,
 } from '../../../types/beatmap/wrapper/info.ts';
 import { shallowCopy } from '../../../utils/misc.ts';
+import { createInfoBeatmap } from '../../core/infoBeatmap.ts';
 import { DifficultyRanking } from '../../shared/difficulty.ts';
 
 type InfoBeatmapSerializationPolyfills = {
@@ -12,7 +13,11 @@ type InfoBeatmapSerializationPolyfills = {
 };
 type InfoBeatmapDeserializationPolyfills = Pick<
    IWrapInfoBeatmapAttribute,
-   'characteristic' | 'njs' | 'njsOffset' | 'lightshowFilename' | 'authors'
+   | 'characteristic'
+   | 'njs'
+   | 'njsOffset'
+   | 'lightshowFilename'
+   | 'authors'
 >;
 
 /**
@@ -44,19 +49,17 @@ export const infoBeatmap: ISchemaContainer<
       };
    },
    deserialize(data, options) {
-      return {
-         characteristic: data.characteristic ?? 'Standard',
-         difficulty: data.difficulty ?? 'Easy',
+      return createInfoBeatmap({
+         characteristic: data.characteristic,
+         difficulty: data.difficulty,
          authors: {
-            mappers: options?.authors?.mappers ?? [],
-            lighters: options?.authors?.lighters ?? [],
+            mappers: options?.authors?.mappers,
+            lighters: options?.authors?.lighters,
          },
-         filename: data.jsonPath ?? 'EasyStandard.dat',
-         lightshowFilename: options?.lightshowFilename ?? 'EasyLightshow.dat',
-         njs: options?.njs ?? 0,
-         njsOffset: options?.njsOffset ?? 0,
-         colorSchemeId: -1,
-         environmentId: 0,
+         filename: data.jsonPath,
+         lightshowFilename: options?.lightshowFilename,
+         njs: options?.njs,
+         njsOffset: options?.njsOffset,
          customData: {
             _editorOffset: data.offset,
             _editorOldOffset: data.oldOffset,
@@ -69,6 +72,6 @@ export const infoBeatmap: ISchemaContainer<
             _envColorRight: shallowCopy(data.envColorRight),
             _obstacleColor: shallowCopy(data.obstacleColor),
          },
-      };
+      });
    },
 };

--- a/src/beatmap/schema/v1/obstacle.ts
+++ b/src/beatmap/schema/v1/obstacle.ts
@@ -7,7 +7,7 @@ import { remap } from '../../../utils/math.ts';
  * Schema serialization for v1 `Obstacle`.
  */
 export const obstacle: ISchemaContainer<IWrapObstacleAttribute, IObstacle> = {
-   serialize(data: IWrapObstacleAttribute): IObstacle {
+   serialize(data) {
       let type = 0;
       if (data.height >= 0 && data.posY >= 0) {
          type = data.height * 1000 + data.posY + 4001;
@@ -24,7 +24,7 @@ export const obstacle: ISchemaContainer<IWrapObstacleAttribute, IObstacle> = {
          _width: data.width,
       };
    },
-   deserialize(data: Partial<IObstacle> = {}): Partial<IWrapObstacleAttribute> {
+   deserialize(data) {
       const type = data._type ?? 0;
       // FIXME: this might be entirely wrong
       const height = type === 1
@@ -40,12 +40,14 @@ export const obstacle: ISchemaContainer<IWrapObstacleAttribute, IObstacle> = {
          ? Math.floor((type - 4001) / 1000)
          : 0;
       return {
-         time: data._time,
+         time: data._time ?? 0,
+         laneRotation: 0,
          posY,
-         posX: data._lineIndex,
-         duration: data._duration,
-         width: data._width,
+         posX: data._lineIndex ?? 0,
+         duration: data._duration ?? 0,
+         width: data._width ?? 0,
          height,
+         customData: {},
       };
    },
 };

--- a/src/beatmap/schema/v1/obstacle.ts
+++ b/src/beatmap/schema/v1/obstacle.ts
@@ -2,6 +2,7 @@ import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IObstacle } from '../../../types/beatmap/v1/obstacle.ts';
 import type { IWrapObstacleAttribute } from '../../../types/beatmap/wrapper/obstacle.ts';
 import { remap } from '../../../utils/math.ts';
+import { createObstacle } from '../../core/obstacle.ts';
 
 /**
  * Schema serialization for v1 `Obstacle`.
@@ -39,15 +40,13 @@ export const obstacle: ISchemaContainer<IWrapObstacleAttribute, IObstacle> = {
          : type > 4000 && type <= 4005000
          ? Math.floor((type - 4001) / 1000)
          : 0;
-      return {
-         time: data._time ?? 0,
-         laneRotation: 0,
+      return createObstacle({
+         time: data._time,
+         posX: data._lineIndex,
          posY,
-         posX: data._lineIndex ?? 0,
-         duration: data._duration ?? 0,
-         width: data._width ?? 0,
+         duration: data._duration,
+         width: data._width,
          height,
-         customData: {},
-      };
+      });
    },
 };

--- a/src/beatmap/schema/v1/rotationEvent.ts
+++ b/src/beatmap/schema/v1/rotationEvent.ts
@@ -21,14 +21,13 @@ export const rotationEvent: ISchemaContainer<
          _value: r,
       };
    },
-   deserialize(
-      data: Partial<IEvent> = {},
-   ): Partial<IWrapRotationEventAttribute> {
+   deserialize(data) {
       const value = data._value ?? 0;
       return {
-         time: data._time,
+         time: data._time ?? 0,
          executionTime: data._type === 15 ? 1 : 0,
          rotation: value >= 1000 ? (value - 1360) % 360 : EventLaneRotationValue[value] ?? 0,
+         customData: {},
       };
    },
 };

--- a/src/beatmap/schema/v1/rotationEvent.ts
+++ b/src/beatmap/schema/v1/rotationEvent.ts
@@ -1,16 +1,14 @@
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IEvent } from '../../../types/beatmap/v1/event.ts';
 import type { IWrapRotationEventAttribute } from '../../../types/beatmap/wrapper/rotationEvent.ts';
+import { createRotationEvent } from '../../core/rotationEvent.ts';
 import { EventLaneRotationValue, RotationValueEventValue } from '../../shared/constants.ts';
 
 /**
  * Schema serialization for v1 `Rotation Event`.
  */
-export const rotationEvent: ISchemaContainer<
-   IWrapRotationEventAttribute,
-   IEvent
-> = {
-   serialize(data: IWrapRotationEventAttribute): IEvent {
+export const rotationEvent: ISchemaContainer<IWrapRotationEventAttribute, IEvent> = {
+   serialize(data) {
       let r = data.rotation % 360;
       if (r >= -60 && r <= 60 && r % 15 === 0 && r / 15 !== 0) {
          r = RotationValueEventValue[r] || r + 1360;
@@ -23,11 +21,10 @@ export const rotationEvent: ISchemaContainer<
    },
    deserialize(data) {
       const value = data._value ?? 0;
-      return {
-         time: data._time ?? 0,
+      return createRotationEvent({
+         time: data._time,
          executionTime: data._type === 15 ? 1 : 0,
          rotation: value >= 1000 ? (value - 1360) % 360 : EventLaneRotationValue[value] ?? 0,
-         customData: {},
-      };
+      });
    },
 };

--- a/src/beatmap/schema/v2/arc.ts
+++ b/src/beatmap/schema/v2/arc.ts
@@ -2,6 +2,7 @@ import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IArc } from '../../../types/beatmap/v2/arc.ts';
 import type { IWrapArcAttribute } from '../../../types/beatmap/wrapper/arc.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createArc } from '../../core/arc.ts';
 
 /**
  * Schema serialization for v2 `Arc`.
@@ -25,22 +26,20 @@ export const arc: ISchemaContainer<IWrapArcAttribute, IArc> = {
       };
    },
    deserialize(data) {
-      return {
-         color: data._colorType ?? 0,
-         time: data._headTime ?? 0,
-         posX: data._headLineIndex ?? 0,
-         posY: data._headLineLayer ?? 0,
-         direction: data._headCutDirection ?? 0,
-         lengthMultiplier: data._headControlPointLengthMultiplier ?? 0,
-         laneRotation: 0,
-         tailTime: data._tailTime ?? 0,
-         tailPosX: data._tailLineIndex ?? 0,
-         tailPosY: data._tailLineLayer ?? 0,
-         tailDirection: data._tailCutDirection ?? 0,
-         tailLengthMultiplier: data._tailControlPointLengthMultiplier ?? 0,
-         tailLaneRotation: 0,
-         midAnchor: data._sliderMidAnchorMode ?? 0,
-         customData: data._customData ?? {},
-      };
+      return createArc({
+         color: data._colorType,
+         time: data._headTime,
+         posX: data._headLineIndex,
+         posY: data._headLineLayer,
+         direction: data._headCutDirection,
+         lengthMultiplier: data._headControlPointLengthMultiplier,
+         tailTime: data._tailTime,
+         tailPosX: data._tailLineIndex,
+         tailPosY: data._tailLineLayer,
+         tailDirection: data._tailCutDirection,
+         tailLengthMultiplier: data._tailControlPointLengthMultiplier,
+         midAnchor: data._sliderMidAnchorMode,
+         customData: data._customData,
+      });
    },
 };

--- a/src/beatmap/schema/v2/arc.ts
+++ b/src/beatmap/schema/v2/arc.ts
@@ -7,7 +7,7 @@ import { deepCopy } from '../../../utils/misc.ts';
  * Schema serialization for v2 `Arc`.
  */
 export const arc: ISchemaContainer<IWrapArcAttribute, IArc> = {
-   serialize(data: IWrapArcAttribute): IArc {
+   serialize(data) {
       return {
          _colorType: data.color,
          _headTime: data.time,
@@ -24,21 +24,23 @@ export const arc: ISchemaContainer<IWrapArcAttribute, IArc> = {
          _customData: deepCopy(data.customData),
       };
    },
-   deserialize(data: Partial<IArc> = {}): Partial<IWrapArcAttribute> {
+   deserialize(data) {
       return {
-         color: data._colorType,
-         time: data._headTime,
-         posX: data._headLineIndex,
-         posY: data._headLineLayer,
-         direction: data._headCutDirection,
-         lengthMultiplier: data._headControlPointLengthMultiplier,
-         tailTime: data._tailTime,
-         tailPosX: data._tailLineIndex,
-         tailPosY: data._tailLineLayer,
-         tailDirection: data._tailCutDirection,
-         tailLengthMultiplier: data._tailControlPointLengthMultiplier,
-         midAnchor: data._sliderMidAnchorMode,
-         customData: data._customData,
+         color: data._colorType ?? 0,
+         time: data._headTime ?? 0,
+         posX: data._headLineIndex ?? 0,
+         posY: data._headLineLayer ?? 0,
+         direction: data._headCutDirection ?? 0,
+         lengthMultiplier: data._headControlPointLengthMultiplier ?? 0,
+         laneRotation: 0,
+         tailTime: data._tailTime ?? 0,
+         tailPosX: data._tailLineIndex ?? 0,
+         tailPosY: data._tailLineLayer ?? 0,
+         tailDirection: data._tailCutDirection ?? 0,
+         tailLengthMultiplier: data._tailControlPointLengthMultiplier ?? 0,
+         tailLaneRotation: 0,
+         midAnchor: data._sliderMidAnchorMode ?? 0,
+         customData: data._customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v2/audioData.ts
+++ b/src/beatmap/schema/v2/audioData.ts
@@ -1,13 +1,24 @@
+// deno-lint-ignore-file no-explicit-any
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IBPMInfo } from '../../../types/beatmap/v2/bpmInfo.ts';
 import type { IWrapAudioDataAttribute } from '../../../types/beatmap/wrapper/audioData.ts';
+import { createAudioData } from '../../core/audioData.ts';
 
-type AudioDataPolyfills = Pick<IWrapAudioDataAttribute, 'filename' | 'audioChecksum'>;
+type AudioDataDeserializationPolyfills = Pick<
+   IWrapAudioDataAttribute,
+   | 'filename'
+   | 'audioChecksum'
+>;
 
 /**
  * Schema serialization for v2 `Audio Data`.
  */
-export const audioData: ISchemaContainer<IWrapAudioDataAttribute, IBPMInfo, AudioDataPolyfills> = {
+export const audioData: ISchemaContainer<
+   IWrapAudioDataAttribute,
+   IBPMInfo,
+   Record<string, any>,
+   AudioDataDeserializationPolyfills
+> = {
    serialize(data) {
       return {
          _version: '2.0.0',
@@ -22,20 +33,18 @@ export const audioData: ISchemaContainer<IWrapAudioDataAttribute, IBPMInfo, Audi
       };
    },
    deserialize(data, options) {
-      return {
+      return createAudioData({
          version: 2,
-         filename: options?.filename ?? 'BPMInfo.dat',
-         audioChecksum: options?.audioChecksum ?? '',
-         sampleCount: data._songSampleCount ?? 0,
-         frequency: data._songFrequency ?? 0,
+         filename: options?.filename,
+         audioChecksum: options?.audioChecksum,
+         sampleCount: data._songSampleCount,
+         frequency: data._songFrequency,
          bpmData: data._regions?.map((bd) => ({
             startBeat: bd?._startBeat,
             endBeat: bd?._endBeat,
             startSampleIndex: bd?._startSampleIndex,
             endSampleIndex: bd?._endSampleIndex,
-         })) ?? [],
-         lufsData: [],
-         customData: {},
-      };
+         })),
+      });
    },
 };

--- a/src/beatmap/schema/v2/audioData.ts
+++ b/src/beatmap/schema/v2/audioData.ts
@@ -1,13 +1,14 @@
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IBPMInfo } from '../../../types/beatmap/v2/bpmInfo.ts';
 import type { IWrapAudioDataAttribute } from '../../../types/beatmap/wrapper/audioData.ts';
-import type { DeepPartial } from '../../../types/utils.ts';
+
+type AudioDataPolyfills = Pick<IWrapAudioDataAttribute, 'filename' | 'audioChecksum'>;
 
 /**
  * Schema serialization for v2 `Audio Data`.
  */
-export const audioData: ISchemaContainer<IWrapAudioDataAttribute, IBPMInfo> = {
-   serialize(data: IWrapAudioDataAttribute): IBPMInfo {
+export const audioData: ISchemaContainer<IWrapAudioDataAttribute, IBPMInfo, AudioDataPolyfills> = {
+   serialize(data) {
       return {
          _version: '2.0.0',
          _songSampleCount: data.sampleCount,
@@ -20,17 +21,21 @@ export const audioData: ISchemaContainer<IWrapAudioDataAttribute, IBPMInfo> = {
          })),
       };
    },
-   deserialize(data: DeepPartial<IBPMInfo> = {}): DeepPartial<IWrapAudioDataAttribute> {
+   deserialize(data, options) {
       return {
          version: 2,
-         sampleCount: data._songSampleCount,
-         frequency: data._songFrequency,
+         filename: options?.filename ?? 'BPMInfo.dat',
+         audioChecksum: options?.audioChecksum ?? '',
+         sampleCount: data._songSampleCount ?? 0,
+         frequency: data._songFrequency ?? 0,
          bpmData: data._regions?.map((bd) => ({
             startBeat: bd?._startBeat,
             endBeat: bd?._endBeat,
             startSampleIndex: bd?._startSampleIndex,
             endSampleIndex: bd?._endSampleIndex,
-         })),
+         })) ?? [],
+         lufsData: [],
+         customData: {},
       };
    },
 };

--- a/src/beatmap/schema/v2/basicEvent.ts
+++ b/src/beatmap/schema/v2/basicEvent.ts
@@ -2,12 +2,13 @@ import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IEvent } from '../../../types/beatmap/v2/event.ts';
 import type { IWrapBasicEventAttribute } from '../../../types/beatmap/wrapper/basicEvent.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createBasicEvent } from '../../core/basicEvent.ts';
 
 /**
  * Schema serialization for v2 `Basic Event`.
  */
 export const basicEvent: ISchemaContainer<IWrapBasicEventAttribute, IEvent> = {
-   serialize(data: IWrapBasicEventAttribute): IEvent {
+   serialize(data) {
       return {
          _time: data.time,
          _type: data.type,
@@ -17,12 +18,12 @@ export const basicEvent: ISchemaContainer<IWrapBasicEventAttribute, IEvent> = {
       };
    },
    deserialize(data) {
-      return {
-         time: data._time ?? 0,
-         type: data._type ?? 0,
-         value: data._value ?? 0,
-         floatValue: data._floatValue ?? 0,
-         customData: data._customData ?? {},
-      };
+      return createBasicEvent({
+         time: data._time,
+         type: data._type,
+         value: data._value,
+         floatValue: data._floatValue,
+         customData: data._customData,
+      });
    },
 };

--- a/src/beatmap/schema/v2/basicEvent.ts
+++ b/src/beatmap/schema/v2/basicEvent.ts
@@ -1,7 +1,7 @@
-import { deepCopy } from '../../../utils/misc.ts';
+import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IEvent } from '../../../types/beatmap/v2/event.ts';
 import type { IWrapBasicEventAttribute } from '../../../types/beatmap/wrapper/basicEvent.ts';
-import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
+import { deepCopy } from '../../../utils/misc.ts';
 
 /**
  * Schema serialization for v2 `Basic Event`.
@@ -16,13 +16,13 @@ export const basicEvent: ISchemaContainer<IWrapBasicEventAttribute, IEvent> = {
          _customData: deepCopy(data.customData),
       };
    },
-   deserialize(data: Partial<IEvent> = {}): Partial<IWrapBasicEventAttribute> {
+   deserialize(data) {
       return {
-         time: data._time,
-         type: data._type,
-         value: data._value,
-         floatValue: data._floatValue,
-         customData: data._customData,
+         time: data._time ?? 0,
+         type: data._type ?? 0,
+         value: data._value ?? 0,
+         floatValue: data._floatValue ?? 0,
+         customData: data._customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v2/basicEventTypesForKeywords.ts
+++ b/src/beatmap/schema/v2/basicEventTypesForKeywords.ts
@@ -1,7 +1,6 @@
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { ISpecialEventsKeywordFiltersKeywords } from '../../../types/beatmap/v2/specialEventsKeywordFiltersKeywords.ts';
 import type { IWrapBasicEventTypesForKeywordsAttribute } from '../../../types/beatmap/wrapper/basicEventTypesForKeywords.ts';
-import type { DeepPartial } from '../../../types/utils.ts';
 
 /**
  * Schema serialization for v2 `Basic Event Types For Keywords`.
@@ -10,18 +9,17 @@ export const basicEventTypesForKeywords: ISchemaContainer<
    IWrapBasicEventTypesForKeywordsAttribute,
    ISpecialEventsKeywordFiltersKeywords
 > = {
-   serialize(data: IWrapBasicEventTypesForKeywordsAttribute): ISpecialEventsKeywordFiltersKeywords {
+   serialize(data) {
       return {
          _keyword: data.keyword,
          _specialEvents: data.events,
       };
    },
-   deserialize(
-      data: DeepPartial<ISpecialEventsKeywordFiltersKeywords> = {},
-   ): DeepPartial<IWrapBasicEventTypesForKeywordsAttribute> {
+   deserialize(data) {
       return {
-         keyword: data._keyword,
-         events: data._specialEvents,
+         keyword: data._keyword ?? '',
+         events: data._specialEvents ?? [],
+         customData: {},
       };
    },
 };

--- a/src/beatmap/schema/v2/basicEventTypesForKeywords.ts
+++ b/src/beatmap/schema/v2/basicEventTypesForKeywords.ts
@@ -1,6 +1,7 @@
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { ISpecialEventsKeywordFiltersKeywords } from '../../../types/beatmap/v2/specialEventsKeywordFiltersKeywords.ts';
 import type { IWrapBasicEventTypesForKeywordsAttribute } from '../../../types/beatmap/wrapper/basicEventTypesForKeywords.ts';
+import { createBasicEventTypesForKeywords } from '../../core/basicEventTypesForKeywords.ts';
 
 /**
  * Schema serialization for v2 `Basic Event Types For Keywords`.
@@ -16,10 +17,9 @@ export const basicEventTypesForKeywords: ISchemaContainer<
       };
    },
    deserialize(data) {
-      return {
-         keyword: data._keyword ?? '',
-         events: data._specialEvents ?? [],
-         customData: {},
-      };
+      return createBasicEventTypesForKeywords({
+         keyword: data._keyword,
+         events: data._specialEvents,
+      });
    },
 };

--- a/src/beatmap/schema/v2/basicEventTypesWithKeywords.ts
+++ b/src/beatmap/schema/v2/basicEventTypesWithKeywords.ts
@@ -1,7 +1,6 @@
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { ISpecialEventsKeywordFilters } from '../../../types/beatmap/v2/specialEventsKeywordFilters.ts';
 import type { IWrapBasicEventTypesWithKeywordsAttribute } from '../../../types/beatmap/wrapper/mod.ts';
-import type { DeepPartial } from '../../../types/utils.ts';
 import { basicEventTypesForKeywords } from './basicEventTypesForKeywords.ts';
 
 /**
@@ -11,16 +10,18 @@ export const basicEventTypesWithKeywords: ISchemaContainer<
    IWrapBasicEventTypesWithKeywordsAttribute,
    ISpecialEventsKeywordFilters
 > = {
-   serialize(data: IWrapBasicEventTypesWithKeywordsAttribute): ISpecialEventsKeywordFilters {
+   serialize(data) {
       return {
-         _keywords: data.list.map(basicEventTypesForKeywords.serialize),
+         _keywords: data.list.map((x) => {
+            return basicEventTypesForKeywords.serialize(x);
+         }),
       };
    },
-   deserialize(
-      data: DeepPartial<ISpecialEventsKeywordFilters> = {},
-   ): DeepPartial<IWrapBasicEventTypesWithKeywordsAttribute> {
+   deserialize(data) {
       return {
-         list: data._keywords?.map(basicEventTypesForKeywords.deserialize),
+         list: data._keywords?.map((x) => {
+            return basicEventTypesForKeywords.deserialize(x);
+         }) ?? [],
       };
    },
 };

--- a/src/beatmap/schema/v2/bombNote.ts
+++ b/src/beatmap/schema/v2/bombNote.ts
@@ -1,13 +1,13 @@
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
-import type { IWrapBombNoteAttribute } from '../../../types/beatmap/wrapper/bombNote.ts';
 import type { INote } from '../../../types/beatmap/v2/note.ts';
+import type { IWrapBombNoteAttribute } from '../../../types/beatmap/wrapper/bombNote.ts';
 import { deepCopy } from '../../../utils/misc.ts';
 
 /**
  * Schema serialization for v2 `Bomb Note`.
  */
 export const bombNote: ISchemaContainer<IWrapBombNoteAttribute, INote> = {
-   serialize(data: IWrapBombNoteAttribute): INote {
+   serialize(data) {
       return {
          _time: data.time,
          _type: 3,
@@ -17,12 +17,15 @@ export const bombNote: ISchemaContainer<IWrapBombNoteAttribute, INote> = {
          _customData: deepCopy(data.customData),
       };
    },
-   deserialize(data: Partial<INote> = {}): Partial<IWrapBombNoteAttribute> {
+   deserialize(data) {
       return {
-         time: data._time,
-         posX: data._lineIndex,
-         posY: data._lineLayer,
-         customData: data._customData,
+         time: data._time ?? 0,
+         laneRotation: 0,
+         posX: data._lineIndex ?? 0,
+         posY: data._lineLayer ?? 0,
+         color: -1,
+         direction: 0,
+         customData: data._customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v2/bombNote.ts
+++ b/src/beatmap/schema/v2/bombNote.ts
@@ -2,6 +2,7 @@ import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { INote } from '../../../types/beatmap/v2/note.ts';
 import type { IWrapBombNoteAttribute } from '../../../types/beatmap/wrapper/bombNote.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createBombNote } from '../../core/bombNote.ts';
 
 /**
  * Schema serialization for v2 `Bomb Note`.
@@ -18,14 +19,12 @@ export const bombNote: ISchemaContainer<IWrapBombNoteAttribute, INote> = {
       };
    },
    deserialize(data) {
-      return {
-         time: data._time ?? 0,
-         laneRotation: 0,
-         posX: data._lineIndex ?? 0,
-         posY: data._lineLayer ?? 0,
-         color: -1,
-         direction: 0,
-         customData: data._customData ?? {},
-      };
+      return createBombNote({
+         time: data._time,
+         posX: data._lineIndex,
+         posY: data._lineLayer,
+         direction: data._cutDirection,
+         customData: data._customData,
+      });
    },
 };

--- a/src/beatmap/schema/v2/bpmEvent.ts
+++ b/src/beatmap/schema/v2/bpmEvent.ts
@@ -1,13 +1,13 @@
-import type { IEvent } from '../../../types/beatmap/v2/event.ts';
-import { deepCopy } from '../../../utils/misc.ts';
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
+import type { IEvent } from '../../../types/beatmap/v2/event.ts';
 import type { IWrapBPMEventAttribute } from '../../../types/beatmap/wrapper/bpmEvent.ts';
+import { deepCopy } from '../../../utils/misc.ts';
 
 /**
  * Schema serialization for v2 `BPM Event`.
  */
 export const bpmEvent: ISchemaContainer<IWrapBPMEventAttribute, IEvent> = {
-   serialize(data: IWrapBPMEventAttribute): IEvent {
+   serialize(data) {
       return {
          _time: data.time,
          _type: 100,
@@ -16,11 +16,11 @@ export const bpmEvent: ISchemaContainer<IWrapBPMEventAttribute, IEvent> = {
          _customData: deepCopy(data.customData),
       };
    },
-   deserialize(data: Partial<IEvent> = {}): Partial<IWrapBPMEventAttribute> {
+   deserialize(data) {
       return {
-         time: data._time,
-         bpm: data._floatValue ?? data._value,
-         customData: data._customData,
+         time: data._time ?? 0,
+         bpm: data._floatValue ?? data._value ?? 0,
+         customData: data._customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v2/bpmEvent.ts
+++ b/src/beatmap/schema/v2/bpmEvent.ts
@@ -2,6 +2,7 @@ import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IEvent } from '../../../types/beatmap/v2/event.ts';
 import type { IWrapBPMEventAttribute } from '../../../types/beatmap/wrapper/bpmEvent.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createBPMEvent } from '../../core/bpmEvent.ts';
 
 /**
  * Schema serialization for v2 `BPM Event`.
@@ -17,10 +18,10 @@ export const bpmEvent: ISchemaContainer<IWrapBPMEventAttribute, IEvent> = {
       };
    },
    deserialize(data) {
-      return {
-         time: data._time ?? 0,
-         bpm: data._floatValue ?? data._value ?? 0,
-         customData: data._customData ?? {},
-      };
+      return createBPMEvent({
+         time: data._time,
+         bpm: data._floatValue ?? data._value,
+         customData: data._customData,
+      });
    },
 };

--- a/src/beatmap/schema/v2/colorBoostEvent.ts
+++ b/src/beatmap/schema/v2/colorBoostEvent.ts
@@ -1,13 +1,13 @@
-import type { IEvent } from '../../../types/beatmap/v2/event.ts';
-import { deepCopy } from '../../../utils/misc.ts';
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
+import type { IEvent } from '../../../types/beatmap/v2/event.ts';
 import type { IWrapColorBoostEventAttribute } from '../../../types/beatmap/wrapper/colorBoostEvent.ts';
+import { deepCopy } from '../../../utils/misc.ts';
 
 /**
  * Schema serialization for v2 `Color Boost Event`.
  */
 export const colorBoostEvent: ISchemaContainer<IWrapColorBoostEventAttribute, IEvent> = {
-   serialize(data: IWrapColorBoostEventAttribute): IEvent {
+   serialize(data) {
       return {
          _time: data.time,
          _type: 5,
@@ -16,11 +16,11 @@ export const colorBoostEvent: ISchemaContainer<IWrapColorBoostEventAttribute, IE
          _customData: deepCopy(data.customData),
       };
    },
-   deserialize(data: Partial<IEvent> = {}): Partial<IWrapColorBoostEventAttribute> {
+   deserialize(data) {
       return {
-         time: data._time,
+         time: data._time ?? 0,
          toggle: data._value === 1,
-         customData: data._customData,
+         customData: data._customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v2/colorBoostEvent.ts
+++ b/src/beatmap/schema/v2/colorBoostEvent.ts
@@ -2,6 +2,7 @@ import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IEvent } from '../../../types/beatmap/v2/event.ts';
 import type { IWrapColorBoostEventAttribute } from '../../../types/beatmap/wrapper/colorBoostEvent.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createColorBoostEvent } from '../../core/colorBoostEvent.ts';
 
 /**
  * Schema serialization for v2 `Color Boost Event`.
@@ -17,10 +18,10 @@ export const colorBoostEvent: ISchemaContainer<IWrapColorBoostEventAttribute, IE
       };
    },
    deserialize(data) {
-      return {
-         time: data._time ?? 0,
-         toggle: data._value === 1,
-         customData: data._customData ?? {},
-      };
+      return createColorBoostEvent({
+         time: data._time,
+         toggle: !!data._value,
+         customData: data._customData,
+      });
    },
 };

--- a/src/beatmap/schema/v2/colorNote.ts
+++ b/src/beatmap/schema/v2/colorNote.ts
@@ -2,6 +2,8 @@ import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { INote } from '../../../types/beatmap/v2/note.ts';
 import type { IWrapColorNoteAttribute } from '../../../types/beatmap/wrapper/colorNote.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createColorNote } from '../../core/colorNote.ts';
+import { NoteColor } from '../../shared/constants.ts';
 
 /**
  * Schema serialization for v2 `Color Note`.
@@ -18,15 +20,13 @@ export const colorNote: ISchemaContainer<IWrapColorNoteAttribute, INote> = {
       };
    },
    deserialize(data) {
-      return {
-         time: data._time ?? 0,
-         laneRotation: 0,
-         posX: data._lineIndex ?? 0,
-         posY: data._lineLayer ?? 0,
-         color: data._type as 0 ?? 0,
-         direction: data._cutDirection ?? 0,
-         angleOffset: 0,
-         customData: data._customData ?? {},
-      };
+      return createColorNote({
+         time: data._time,
+         posX: data._lineIndex,
+         posY: data._lineLayer,
+         color: [NoteColor.RED, NoteColor.BLUE][data._type ?? 0],
+         direction: data._cutDirection,
+         customData: data._customData,
+      });
    },
 };

--- a/src/beatmap/schema/v2/colorNote.ts
+++ b/src/beatmap/schema/v2/colorNote.ts
@@ -7,7 +7,7 @@ import { deepCopy } from '../../../utils/misc.ts';
  * Schema serialization for v2 `Color Note`.
  */
 export const colorNote: ISchemaContainer<IWrapColorNoteAttribute, INote> = {
-   serialize(data: IWrapColorNoteAttribute): INote {
+   serialize(data) {
       return {
          _time: data.time,
          _type: data.color,
@@ -17,14 +17,16 @@ export const colorNote: ISchemaContainer<IWrapColorNoteAttribute, INote> = {
          _customData: deepCopy(data.customData),
       };
    },
-   deserialize(data: Partial<INote> = {}): Partial<IWrapColorNoteAttribute> {
+   deserialize(data) {
       return {
-         time: data._time,
-         posX: data._lineIndex,
-         posY: data._lineLayer,
-         color: data._type as 0,
-         direction: data._cutDirection,
-         customData: data._customData,
+         time: data._time ?? 0,
+         laneRotation: 0,
+         posX: data._lineIndex ?? 0,
+         posY: data._lineLayer ?? 0,
+         color: data._type as 0 ?? 0,
+         direction: data._cutDirection ?? 0,
+         angleOffset: 0,
+         customData: data._customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v2/compat/audioData.ts
+++ b/src/beatmap/schema/v2/compat/audioData.ts
@@ -1,13 +1,13 @@
 import { logger } from '../../../../logger.ts';
 import type { ICompatibilityOptions } from '../../../../types/beatmap/options/compatibility.ts';
-import type { IWrapAudioData } from '../../../../types/beatmap/wrapper/audioData.ts';
+import type { IWrapAudioDataAttribute } from '../../../../types/beatmap/wrapper/audioData.ts';
 import { tag } from './_common.ts';
 
 /**
  * Checks if beatmap audio data is compatible with v2 `AudioData` schema.
  */
-export function compatAudioData(
-   data: IWrapAudioData,
+export function compatAudioData<T extends IWrapAudioDataAttribute>(
+   data: T,
    options: ICompatibilityOptions,
 ) {
    const hasIncompat = !!data.lufsData.length;

--- a/src/beatmap/schema/v2/compat/difficulty.ts
+++ b/src/beatmap/schema/v2/compat/difficulty.ts
@@ -1,26 +1,26 @@
-import type { IWrapBeatmap } from '../../../../types/beatmap/wrapper/beatmap.ts';
-import type { ICompatibilityOptions } from '../../../../types/beatmap/options/compatibility.ts';
 import { logger } from '../../../../logger.ts';
-import { tag } from './_common.ts';
+import type { ICompatibilityOptions } from '../../../../types/beatmap/options/compatibility.ts';
+import type { IWrapBeatmapAttribute } from '../../../../types/beatmap/wrapper/beatmap.ts';
 import {
    hasMappingExtensionsBombNote,
    hasMappingExtensionsNote,
    hasMappingExtensionsObstacleV2,
    hasMappingExtensionsRotationV2,
 } from '../../../helpers/modded/has.ts';
+import { tag } from './_common.ts';
 
 /**
  * Checks if beatmap data is compatible with v2 `Difficulty` schema.
  */
-export function compatDifficulty(
-   bm: IWrapBeatmap,
+export function compatDifficulty<T extends IWrapBeatmapAttribute>(
+   bm: T,
    options: ICompatibilityOptions,
 ) {
-   const hasIncompat = !!bm.arcs.length ||
-      !!bm.lightColorEventBoxGroups.length ||
-      !!bm.lightRotationEventBoxGroups.length ||
-      !!bm.lightTranslationEventBoxGroups.length ||
-      !!bm.fxEventBoxGroups.length;
+   const hasIncompat = !!bm.difficulty.arcs.length ||
+      !!bm.lightshow.lightColorEventBoxGroups.length ||
+      !!bm.lightshow.lightRotationEventBoxGroups.length ||
+      !!bm.lightshow.lightTranslationEventBoxGroups.length ||
+      !!bm.lightshow.fxEventBoxGroups.length;
 
    if (hasIncompat) {
       if (options.throwOn.incompatibleObject) {
@@ -33,10 +33,10 @@ export function compatDifficulty(
       }
    }
 
-   const hasME = bm.colorNotes.some(hasMappingExtensionsNote) ||
-      bm.bombNotes.some(hasMappingExtensionsBombNote) ||
-      bm.obstacles.some(hasMappingExtensionsObstacleV2) ||
-      bm.rotationEvents.some(hasMappingExtensionsRotationV2);
+   const hasME = bm.difficulty.colorNotes.some(hasMappingExtensionsNote) ||
+      bm.difficulty.bombNotes.some(hasMappingExtensionsBombNote) ||
+      bm.difficulty.obstacles.some(hasMappingExtensionsObstacleV2) ||
+      bm.difficulty.rotationEvents.some(hasMappingExtensionsRotationV2);
 
    if (hasME) {
       if (options.throwOn.mappingExtensions) {

--- a/src/beatmap/schema/v2/compat/info.ts
+++ b/src/beatmap/schema/v2/compat/info.ts
@@ -1,10 +1,10 @@
 import type { ICompatibilityOptions } from '../../../../types/beatmap/options/compatibility.ts';
-import type { IWrapInfo } from '../../../../types/beatmap/wrapper/info.ts';
+import type { IWrapInfoAttribute } from '../../../../types/beatmap/wrapper/info.ts';
 
 /**
  * Check if beatmap info is compatible with v2 `Info` schema.
  */
-export function compatInfo(
-   _info: IWrapInfo,
+export function compatInfo<T extends IWrapInfoAttribute>(
+   _info: T,
    _options: ICompatibilityOptions,
 ) {}

--- a/src/beatmap/schema/v2/difficulty.ts
+++ b/src/beatmap/schema/v2/difficulty.ts
@@ -1,60 +1,75 @@
+import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IDifficulty } from '../../../types/beatmap/v2/difficulty.ts';
-import { colorNote } from './colorNote.ts';
-import { arc } from './arc.ts';
-import { obstacle } from './obstacle.ts';
-import { basicEvent } from './basicEvent.ts';
-import { waypoint } from './waypoint.ts';
-import { deepCopy } from '../../../utils/misc.ts';
-import type { IWrapColorBoostEventAttribute } from '../../../types/beatmap/wrapper/colorBoostEvent.ts';
+import type { IWrapBasicEventAttribute } from '../../../types/beatmap/wrapper/basicEvent.ts';
+import type { IWrapBeatmapAttribute } from '../../../types/beatmap/wrapper/beatmap.ts';
 import type { IWrapBombNoteAttribute } from '../../../types/beatmap/wrapper/bombNote.ts';
 import type { IWrapBPMEventAttribute } from '../../../types/beatmap/wrapper/bpmEvent.ts';
+import type { IWrapColorBoostEventAttribute } from '../../../types/beatmap/wrapper/colorBoostEvent.ts';
 import type { IWrapColorNoteAttribute } from '../../../types/beatmap/wrapper/colorNote.ts';
-import type { IWrapBasicEventAttribute } from '../../../types/beatmap/wrapper/basicEvent.ts';
 import type { IWrapRotationEventAttribute } from '../../../types/beatmap/wrapper/rotationEvent.ts';
-import type { IWrapBeatmapAttribute } from '../../../types/beatmap/wrapper/beatmap.ts';
-import type { DeepPartial } from '../../../types/utils.ts';
-import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
-import { basicEventTypesWithKeywords } from './basicEventTypesWithKeywords.ts';
-import { bombNote } from './bombNote.ts';
-import { colorBoostEvent } from './colorBoostEvent.ts';
-import { rotationEvent } from './rotationEvent.ts';
-import { bpmEvent } from './bpmEvent.ts';
+import { deepCopy } from '../../../utils/misc.ts';
 import { sortV2NoteFn, sortV2ObjectFn } from '../../helpers/sort.ts';
 import { compareVersion } from '../../helpers/version.ts';
+import { arc } from './arc.ts';
+import { basicEvent } from './basicEvent.ts';
+import { basicEventTypesWithKeywords } from './basicEventTypesWithKeywords.ts';
+import { bombNote } from './bombNote.ts';
+import { bpmEvent } from './bpmEvent.ts';
+import { colorBoostEvent } from './colorBoostEvent.ts';
+import { colorNote } from './colorNote.ts';
+import { obstacle } from './obstacle.ts';
+import { rotationEvent } from './rotationEvent.ts';
+import { waypoint } from './waypoint.ts';
+
+type DifficultyPolyfills = Pick<IWrapBeatmapAttribute, 'filename' | 'lightshowFilename'>;
 
 /**
  * Schema serialization for v2 `Difficulty`.
  */
 export const difficulty: ISchemaContainer<IWrapBeatmapAttribute, IDifficulty> = {
-   serialize(data: IWrapBeatmapAttribute): IDifficulty {
+   serialize(data) {
       return {
          _version: '2.6.0',
          _notes: [
-            ...data.difficulty.colorNotes.map(colorNote.serialize),
-            ...data.difficulty.bombNotes.map(bombNote.serialize),
+            ...data.difficulty.colorNotes.map((x) => {
+               return colorNote.serialize(x);
+            }),
+            ...data.difficulty.bombNotes.map((x) => {
+               return bombNote.serialize(x);
+            }),
          ].sort(sortV2NoteFn),
-         _sliders: data.difficulty.arcs.map(arc.serialize),
-         _obstacles: data.difficulty.obstacles.map(obstacle.serialize),
+         _sliders: data.difficulty.arcs.map((x) => {
+            return arc.serialize(x);
+         }),
+         _obstacles: data.difficulty.obstacles.map((x) => {
+            return obstacle.serialize(x);
+         }),
          _events: [
-            ...data.lightshow.basicEvents.map(basicEvent.serialize),
-            ...data.lightshow.colorBoostEvents.map(
-               colorBoostEvent.serialize,
-            ),
-            ...data.difficulty.rotationEvents.map(rotationEvent.serialize),
-            ...data.difficulty.bpmEvents.map(bpmEvent.serialize),
+            ...data.lightshow.basicEvents.map((x) => {
+               return basicEvent.serialize(x);
+            }),
+            ...data.lightshow.colorBoostEvents.map((x) => {
+               return colorBoostEvent.serialize(x);
+            }),
+            ...data.difficulty.rotationEvents.map((x) => {
+               return rotationEvent.serialize(x);
+            }),
+            ...data.difficulty.bpmEvents.map((x) => {
+               return bpmEvent.serialize(x);
+            }),
          ].sort(sortV2ObjectFn),
-         _waypoints: data.lightshow.waypoints.map(waypoint.serialize),
+         _waypoints: data.lightshow.waypoints.map((x) => {
+            return waypoint.serialize(x);
+         }),
          _specialEventsKeywordFilters: basicEventTypesWithKeywords.serialize(
             data.lightshow.basicEventTypesWithKeywords,
          ),
          _customData: deepCopy(data.difficulty.customData),
       };
    },
-   deserialize(
-      data: DeepPartial<IDifficulty> = {},
-   ): DeepPartial<IWrapBeatmapAttribute> {
-      const colorNotes: Partial<IWrapColorNoteAttribute>[] = [];
-      const bombNotes: Partial<IWrapBombNoteAttribute>[] = [];
+   deserialize(data, options?: Partial<DifficultyPolyfills>) {
+      const colorNotes: IWrapColorNoteAttribute[] = [];
+      const bombNotes: IWrapBombNoteAttribute[] = [];
       const _notes = data._notes || [];
       for (let i = 0; i < _notes.length; i++) {
          const obj = _notes[i];
@@ -66,10 +81,10 @@ export const difficulty: ISchemaContainer<IWrapBeatmapAttribute, IDifficulty> = 
       }
 
       const preV25 = compareVersion(data._version || '2.0.0', '2.5.0');
-      const basicEvents: Partial<IWrapBasicEventAttribute>[] = [];
-      const colorBoostEvents: Partial<IWrapColorBoostEventAttribute>[] = [];
-      const rotationEvents: Partial<IWrapRotationEventAttribute>[] = [];
-      const bpmEvents: Partial<IWrapBPMEventAttribute>[] = [];
+      const basicEvents: IWrapBasicEventAttribute[] = [];
+      const colorBoostEvents: IWrapColorBoostEventAttribute[] = [];
+      const rotationEvents: IWrapRotationEventAttribute[] = [];
+      const bpmEvents: IWrapBPMEventAttribute[] = [];
       const _events = data._events || [];
       for (let i = 0; i < _events.length; i++) {
          const obj = _events[i];
@@ -99,25 +114,40 @@ export const difficulty: ISchemaContainer<IWrapBeatmapAttribute, IDifficulty> = 
             }
          }
       }
-
       return {
          version: 2,
+         filename: options?.filename ?? 'EasyStandard.dat',
+         lightshowFilename: options?.lightshowFilename ?? 'EasyLightshow.dat',
          difficulty: {
             colorNotes,
             bombNotes,
-            obstacles: data._obstacles?.map(obstacle.deserialize),
-            bpmEvents,
+            obstacles: data._obstacles?.map((x) => {
+               return obstacle.deserialize(x);
+            }) ?? [],
+            arcs: [],
+            chains: [],
             rotationEvents,
-            customData: data._customData,
+            bpmEvents,
+            njsEvents: [],
+            customData: data._customData ?? {},
          },
          lightshow: {
+            waypoints: data._waypoints?.map((x) => {
+               return waypoint.deserialize(x);
+            }) ?? [],
             basicEvents,
             colorBoostEvents,
-            waypoints: data._waypoints?.map(waypoint.deserialize),
+            lightColorEventBoxGroups: [],
+            lightRotationEventBoxGroups: [],
+            lightTranslationEventBoxGroups: [],
+            fxEventBoxGroups: [],
+            useNormalEventsAsCompatibleEvents: true,
             basicEventTypesWithKeywords: basicEventTypesWithKeywords.deserialize(
-               data._specialEventsKeywordFilters,
+               data._specialEventsKeywordFilters ?? {},
             ),
+            customData: {},
          },
+         customData: {},
       };
    },
 };

--- a/src/beatmap/schema/v2/info.ts
+++ b/src/beatmap/schema/v2/info.ts
@@ -1,3 +1,4 @@
+// deno-lint-ignore-file no-explicit-any
 import type {
    Environment360Name,
    EnvironmentName,
@@ -7,17 +8,28 @@ import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IInfo, IInfoSet } from '../../../types/beatmap/v2/info.ts';
 import type { IWrapInfoAttribute } from '../../../types/beatmap/wrapper/info.ts';
 import { deepCopy, shallowCopy } from '../../../utils/misc.ts';
+import { createInfo } from '../../core/info.ts';
 import { is360Environment } from '../../helpers/environment.ts';
 import { infoBeatmap } from './infoBeatmap.ts';
 
-type InfoPolyfills = Pick<IWrapInfoAttribute, 'filename'> & {
-   audio: Pick<IWrapInfoAttribute['audio'], 'audioDataFilename' | 'lufs' | 'duration'>;
+type InfoDeserializationPolyfills = Pick<IWrapInfoAttribute, 'filename'> & {
+   audio: Pick<
+      IWrapInfoAttribute['audio'],
+      | 'audioDataFilename'
+      | 'lufs'
+      | 'duration'
+   >;
 };
 
 /**
  * Schema serialization for v2 `Info`.
  */
-export const info: ISchemaContainer<IWrapInfoAttribute, IInfo, InfoPolyfills> = {
+export const info: ISchemaContainer<
+   IWrapInfoAttribute,
+   IInfo,
+   Record<string, any>,
+   InfoDeserializationPolyfills
+> = {
    serialize(data) {
       const authorSet = new Set();
       const d: Required<IInfo> = {
@@ -91,110 +103,109 @@ export const info: ISchemaContainer<IWrapInfoAttribute, IInfo, InfoPolyfills> = 
       return d;
    },
    deserialize(data, options) {
-      return {
+      return createInfo({
          version: 2,
-         filename: options?.filename ?? 'Info.dat',
+         filename: options?.filename,
          song: {
-            title: data._songName ?? '',
-            subTitle: data._songSubName ?? '',
-            author: data._songAuthorName ?? '',
+            title: data._songName,
+            subTitle: data._songSubName,
+            author: data._songAuthorName,
          },
          audio: {
-            audioDataFilename: options?.audio?.audioDataFilename ?? 'BPMInfo.dat',
-            bpm: data._beatsPerMinute ?? 120,
-            lufs: options?.audio?.lufs ?? 0,
-            duration: options?.audio?.duration ?? 0,
-            previewStartTime: data._previewStartTime ?? 0,
-            previewDuration: data._previewDuration ?? 0,
-            filename: data._songFilename ?? 'song.ogg',
-            audioOffset: data._songTimeOffset ?? 0,
-            shuffle: data._shuffle ?? 0,
-            shufflePeriod: data._shufflePeriod ?? 0.5,
+            audioDataFilename: options?.audio?.audioDataFilename,
+            bpm: data._beatsPerMinute,
+            lufs: options?.audio?.lufs,
+            duration: options?.audio?.duration,
+            previewStartTime: data._previewStartTime,
+            previewDuration: data._previewDuration,
+            filename: data._songFilename,
+            audioOffset: data._songTimeOffset,
+            shuffle: data._shuffle,
+            shufflePeriod: data._shufflePeriod,
          },
-         songPreviewFilename: data._songFilename ?? 'song.ogg',
-         coverImageFilename: data._coverImageFilename ?? 'cover.jpg',
+         songPreviewFilename: data._songFilename,
+         coverImageFilename: data._coverImageFilename,
          environmentBase: {
-            normal: data._environmentName ?? 'DefaultEnvironment',
-            allDirections: data._allDirectionsEnvironmentName ?? 'GlassDesertEnvironment',
+            normal: data._environmentName,
+            allDirections: data._allDirectionsEnvironmentName,
          },
-         environmentNames: data._environmentNames ?? [],
+         environmentNames: data._environmentNames,
          colorSchemes: data._colorSchemes?.map((e) => {
             return {
-               name: e.colorScheme?.colorSchemeId ?? '',
+               name: e.colorScheme?.colorSchemeId,
                overrideNotes: !!e.useOverride,
                overrideLights: !!e.useOverride,
                saberLeftColor: {
-                  r: e.colorScheme?.saberAColor?.r ?? 0,
-                  g: e.colorScheme?.saberAColor?.g ?? 0,
-                  b: e.colorScheme?.saberAColor?.b ?? 0,
-                  a: e.colorScheme?.saberAColor?.a ?? 0,
+                  r: e.colorScheme?.saberAColor?.r,
+                  g: e.colorScheme?.saberAColor?.g,
+                  b: e.colorScheme?.saberAColor?.b,
+                  a: e.colorScheme?.saberAColor?.a,
                },
                saberRightColor: {
-                  r: e.colorScheme?.saberBColor?.r ?? 0,
-                  g: e.colorScheme?.saberBColor?.g ?? 0,
-                  b: e.colorScheme?.saberBColor?.b ?? 0,
-                  a: e.colorScheme?.saberBColor?.a ?? 0,
+                  r: e.colorScheme?.saberBColor?.r,
+                  g: e.colorScheme?.saberBColor?.g,
+                  b: e.colorScheme?.saberBColor?.b,
+                  a: e.colorScheme?.saberBColor?.a,
                },
                environment0Color: {
-                  r: e.colorScheme?.environmentColor0?.r ?? 0,
-                  g: e.colorScheme?.environmentColor0?.g ?? 0,
-                  b: e.colorScheme?.environmentColor0?.b ?? 0,
-                  a: e.colorScheme?.environmentColor0?.a ?? 0,
+                  r: e.colorScheme?.environmentColor0?.r,
+                  g: e.colorScheme?.environmentColor0?.g,
+                  b: e.colorScheme?.environmentColor0?.b,
+                  a: e.colorScheme?.environmentColor0?.a,
                },
                environment1Color: {
-                  r: e.colorScheme?.environmentColor1?.r ?? 0,
-                  g: e.colorScheme?.environmentColor1?.g ?? 0,
-                  b: e.colorScheme?.environmentColor1?.b ?? 0,
-                  a: e.colorScheme?.environmentColor1?.a ?? 0,
+                  r: e.colorScheme?.environmentColor1?.r,
+                  g: e.colorScheme?.environmentColor1?.g,
+                  b: e.colorScheme?.environmentColor1?.b,
+                  a: e.colorScheme?.environmentColor1?.a,
                },
                obstaclesColor: {
-                  r: e.colorScheme?.obstaclesColor?.r ?? 0,
-                  g: e.colorScheme?.obstaclesColor?.g ?? 0,
-                  b: e.colorScheme?.obstaclesColor?.b ?? 0,
-                  a: e.colorScheme?.obstaclesColor?.a ?? 0,
+                  r: e.colorScheme?.obstaclesColor?.r,
+                  g: e.colorScheme?.obstaclesColor?.g,
+                  b: e.colorScheme?.obstaclesColor?.b,
+                  a: e.colorScheme?.obstaclesColor?.a,
                },
                environment0ColorBoost: {
-                  r: e.colorScheme?.environmentColor0Boost?.r ?? 0,
-                  g: e.colorScheme?.environmentColor0Boost?.g ?? 0,
-                  b: e.colorScheme?.environmentColor0Boost?.b ?? 0,
-                  a: e.colorScheme?.environmentColor0Boost?.a ?? 0,
+                  r: e.colorScheme?.environmentColor0Boost?.r,
+                  g: e.colorScheme?.environmentColor0Boost?.g,
+                  b: e.colorScheme?.environmentColor0Boost?.b,
+                  a: e.colorScheme?.environmentColor0Boost?.a,
                },
                environment1ColorBoost: {
-                  r: e.colorScheme?.environmentColor1Boost?.r ?? 0,
-                  g: e.colorScheme?.environmentColor1Boost?.g ?? 0,
-                  b: e.colorScheme?.environmentColor1Boost?.b ?? 0,
-                  a: e.colorScheme?.environmentColor1Boost?.a ?? 0,
+                  r: e.colorScheme?.environmentColor1Boost?.r,
+                  g: e.colorScheme?.environmentColor1Boost?.g,
+                  b: e.colorScheme?.environmentColor1Boost?.b,
+                  a: e.colorScheme?.environmentColor1Boost?.a,
                },
                environmentWColor: e.colorScheme?.environmentColorW
                   ? {
-                     r: e.colorScheme?.environmentColorW?.r ?? 0,
-                     g: e.colorScheme?.environmentColorW?.g ?? 0,
-                     b: e.colorScheme?.environmentColorW?.b ?? 0,
-                     a: e.colorScheme?.environmentColorW?.a ?? 0,
+                     r: e.colorScheme?.environmentColorW?.r,
+                     g: e.colorScheme?.environmentColorW?.g,
+                     b: e.colorScheme?.environmentColorW?.b,
+                     a: e.colorScheme?.environmentColorW?.a,
                   }
                   : undefined,
                environmentWColorBoost: e.colorScheme?.environmentColorWBoost
                   ? {
-                     r: e.colorScheme?.environmentColorWBoost?.r ?? 0,
-                     g: e.colorScheme?.environmentColorWBoost?.g ?? 0,
-                     b: e.colorScheme?.environmentColorWBoost?.b ?? 0,
-                     a: e.colorScheme?.environmentColorWBoost?.a ?? 0,
+                     r: e.colorScheme?.environmentColorWBoost?.r,
+                     g: e.colorScheme?.environmentColorWBoost?.g,
+                     b: e.colorScheme?.environmentColorWBoost?.b,
+                     a: e.colorScheme?.environmentColorWBoost?.a,
                   }
                   : undefined,
             };
-         }) ?? [],
+         }),
          difficulties: data._difficultyBeatmapSets?.flatMap((set) => {
             return set._difficultyBeatmaps?.map((diff) => {
                return infoBeatmap.deserialize(diff, {
-                  characteristic: set._beatmapCharacteristicName ?? 'Standard',
+                  characteristic: set._beatmapCharacteristicName,
                   authors: {
-                     mappers: data._levelAuthorName?.split(',') ?? [],
-                     lighters: [],
+                     mappers: data._levelAuthorName?.split(','),
                   },
                });
             }) ?? [];
-         }) ?? [],
-         customData: data._customData ?? {},
-      };
+         }),
+         customData: data._customData,
+      });
    },
 };

--- a/src/beatmap/schema/v2/infoBeatmap.ts
+++ b/src/beatmap/schema/v2/infoBeatmap.ts
@@ -1,11 +1,16 @@
+// deno-lint-ignore-file no-explicit-any
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IInfoDifficulty } from '../../../types/beatmap/v2/info.ts';
 import type { IWrapInfoBeatmapAttribute } from '../../../types/beatmap/wrapper/info.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createInfoBeatmap } from '../../core/infoBeatmap.ts';
 import { DifficultyRanking } from '../../shared/difficulty.ts';
 
-type IInfoBeatmapPolyfills = Partial<
-   Pick<IWrapInfoBeatmapAttribute, 'characteristic' | 'lightshowFilename' | 'authors'>
+type IInfoBeatmapDeserializationPolyfills = Pick<
+   IWrapInfoBeatmapAttribute,
+   | 'characteristic'
+   | 'lightshowFilename'
+   | 'authors'
 >;
 
 /**
@@ -14,7 +19,8 @@ type IInfoBeatmapPolyfills = Partial<
 export const infoBeatmap: ISchemaContainer<
    IWrapInfoBeatmapAttribute,
    IInfoDifficulty,
-   IInfoBeatmapPolyfills
+   Record<string, any>,
+   IInfoBeatmapDeserializationPolyfills
 > = {
    serialize(data) {
       return {
@@ -29,20 +35,20 @@ export const infoBeatmap: ISchemaContainer<
       };
    },
    deserialize(data, options) {
-      return {
-         characteristic: options?.characteristic ?? 'Standard',
-         difficulty: data._difficulty ?? 'Easy',
+      return createInfoBeatmap({
+         characteristic: options?.characteristic,
+         difficulty: data._difficulty,
          authors: {
-            mappers: options?.authors?.mappers ?? [],
-            lighters: options?.authors?.lighters ?? [],
+            mappers: options?.authors?.mappers,
+            lighters: options?.authors?.lighters,
          },
-         filename: data._beatmapFilename ?? 'EasyStandard.dat',
-         lightshowFilename: options?.lightshowFilename ?? 'EasyLightshow.dat',
-         njs: data._noteJumpMovementSpeed ?? 0,
-         njsOffset: data._noteJumpStartBeatOffset ?? 0,
-         colorSchemeId: data._beatmapColorSchemeIdx ?? -1,
-         environmentId: data._environmentNameIdx ?? 0,
-         customData: data._customData ?? {},
-      };
+         filename: data._beatmapFilename,
+         lightshowFilename: options?.lightshowFilename,
+         njs: data._noteJumpMovementSpeed,
+         njsOffset: data._noteJumpStartBeatOffset,
+         colorSchemeId: data._beatmapColorSchemeIdx,
+         environmentId: data._environmentNameIdx,
+         customData: data._customData,
+      });
    },
 };

--- a/src/beatmap/schema/v2/infoBeatmap.ts
+++ b/src/beatmap/schema/v2/infoBeatmap.ts
@@ -1,14 +1,22 @@
-import type { IInfoDifficulty } from '../../../types/beatmap/v2/info.ts';
-import { deepCopy } from '../../../utils/misc.ts';
-import type { IWrapInfoBeatmapAttribute } from '../../../types/beatmap/wrapper/info.ts';
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
+import type { IInfoDifficulty } from '../../../types/beatmap/v2/info.ts';
+import type { IWrapInfoBeatmapAttribute } from '../../../types/beatmap/wrapper/info.ts';
+import { deepCopy } from '../../../utils/misc.ts';
 import { DifficultyRanking } from '../../shared/difficulty.ts';
+
+type IInfoBeatmapPolyfills = Partial<
+   Pick<IWrapInfoBeatmapAttribute, 'characteristic' | 'lightshowFilename' | 'authors'>
+>;
 
 /**
  * Schema serialization for v2 `Info Beatmap`.
  */
-export const infoBeatmap: ISchemaContainer<IWrapInfoBeatmapAttribute, IInfoDifficulty> = {
-   serialize(data: IWrapInfoBeatmapAttribute): IInfoDifficulty {
+export const infoBeatmap: ISchemaContainer<
+   IWrapInfoBeatmapAttribute,
+   IInfoDifficulty,
+   IInfoBeatmapPolyfills
+> = {
+   serialize(data) {
       return {
          _difficulty: data.difficulty,
          _difficultyRank: DifficultyRanking[data.difficulty],
@@ -20,15 +28,21 @@ export const infoBeatmap: ISchemaContainer<IWrapInfoBeatmapAttribute, IInfoDiffi
          _customData: deepCopy(data.customData),
       };
    },
-   deserialize(data: Partial<IInfoDifficulty> = {}): Partial<IWrapInfoBeatmapAttribute> {
+   deserialize(data, options) {
       return {
-         difficulty: data._difficulty,
-         filename: data._beatmapFilename,
-         njs: data._noteJumpMovementSpeed,
-         njsOffset: data._noteJumpStartBeatOffset,
-         colorSchemeId: data._beatmapColorSchemeIdx,
-         environmentId: data._environmentNameIdx,
-         customData: data._customData,
+         characteristic: options?.characteristic ?? 'Standard',
+         difficulty: data._difficulty ?? 'Easy',
+         authors: {
+            mappers: options?.authors?.mappers ?? [],
+            lighters: options?.authors?.lighters ?? [],
+         },
+         filename: data._beatmapFilename ?? 'EasyStandard.dat',
+         lightshowFilename: options?.lightshowFilename ?? 'EasyLightshow.dat',
+         njs: data._noteJumpMovementSpeed ?? 0,
+         njsOffset: data._noteJumpStartBeatOffset ?? 0,
+         colorSchemeId: data._beatmapColorSchemeIdx ?? -1,
+         environmentId: data._environmentNameIdx ?? 0,
+         customData: data._customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v2/obstacle.ts
+++ b/src/beatmap/schema/v2/obstacle.ts
@@ -8,7 +8,7 @@ import { deepCopy } from '../../../utils/misc.ts';
  * Schema serialization for v2 `Obstacle`.
  */
 export const obstacle: ISchemaContainer<IWrapObstacleAttribute, IObstacle> = {
-   serialize(data: IWrapObstacleAttribute): IObstacle {
+   serialize(data) {
       let type = 0;
       if (data.height >= 0 && data.posY >= 0) {
          type = Math.floor(data.height * 1000 + data.posY + 4001);
@@ -26,7 +26,7 @@ export const obstacle: ISchemaContainer<IWrapObstacleAttribute, IObstacle> = {
          _customData: deepCopy(data.customData),
       };
    },
-   deserialize(data: Partial<IObstacle> = {}): Partial<IWrapObstacleAttribute> {
+   deserialize(data) {
       const type = data._type ?? 0;
       const height = type === 1
          ? 3
@@ -41,13 +41,14 @@ export const obstacle: ISchemaContainer<IWrapObstacleAttribute, IObstacle> = {
          ? Math.floor((type - 4001) / 1000)
          : 0;
       return {
-         time: data._time,
+         time: data._time ?? 0,
+         laneRotation: 0,
          posY,
-         posX: data._lineIndex,
-         duration: data._duration,
-         width: data._width,
+         posX: data._lineIndex ?? 0,
+         duration: data._duration ?? 0,
+         width: data._width ?? 0,
          height,
-         customData: data._customData,
+         customData: data._customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v2/obstacle.ts
+++ b/src/beatmap/schema/v2/obstacle.ts
@@ -3,6 +3,7 @@ import type { IObstacle } from '../../../types/beatmap/v2/obstacle.ts';
 import type { IWrapObstacleAttribute } from '../../../types/beatmap/wrapper/obstacle.ts';
 import { remap } from '../../../utils/math.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createObstacle } from '../../core/obstacle.ts';
 
 /**
  * Schema serialization for v2 `Obstacle`.
@@ -40,15 +41,14 @@ export const obstacle: ISchemaContainer<IWrapObstacleAttribute, IObstacle> = {
          : type > 4000 && type <= 4005000
          ? Math.floor((type - 4001) / 1000)
          : 0;
-      return {
-         time: data._time ?? 0,
-         laneRotation: 0,
+      return createObstacle({
+         time: data._time,
          posY,
-         posX: data._lineIndex ?? 0,
-         duration: data._duration ?? 0,
-         width: data._width ?? 0,
+         posX: data._lineIndex,
+         duration: data._duration,
+         width: data._width,
          height,
-         customData: data._customData ?? {},
-      };
+         customData: data._customData,
+      });
    },
 };

--- a/src/beatmap/schema/v2/rotationEvent.ts
+++ b/src/beatmap/schema/v2/rotationEvent.ts
@@ -2,15 +2,13 @@ import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IEvent } from '../../../types/beatmap/v2/event.ts';
 import type { IWrapRotationEventAttribute } from '../../../types/beatmap/wrapper/rotationEvent.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createRotationEvent } from '../../core/rotationEvent.ts';
 import { EventLaneRotationValue, RotationValueEventValue } from '../../shared/constants.ts';
 
 /**
  * Schema serialization for v2 `Rotation Event`.
  */
-export const rotationEvent: ISchemaContainer<
-   IWrapRotationEventAttribute,
-   IEvent
-> = {
+export const rotationEvent: ISchemaContainer<IWrapRotationEventAttribute, IEvent> = {
    serialize(data) {
       let r = data.rotation % 360;
       const customData = deepCopy(data.customData);
@@ -30,15 +28,15 @@ export const rotationEvent: ISchemaContainer<
    },
    deserialize(data) {
       const value = data._value ?? 0;
-      return {
-         time: data._time ?? 0,
+      return createRotationEvent({
+         time: data._time,
          executionTime: data._type === 15 ? 1 : 0,
          rotation: typeof data._customData?._rotation === 'number'
             ? data._customData._rotation
             : value >= 1000
             ? (value - 1360) % 360
-            : EventLaneRotationValue[value] ?? 0,
-         customData: data._customData ?? {},
-      };
+            : EventLaneRotationValue[value],
+         customData: data._customData,
+      });
    },
 };

--- a/src/beatmap/schema/v2/rotationEvent.ts
+++ b/src/beatmap/schema/v2/rotationEvent.ts
@@ -1,7 +1,7 @@
-import type { IEvent } from '../../../types/beatmap/v2/event.ts';
-import { deepCopy } from '../../../utils/misc.ts';
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
+import type { IEvent } from '../../../types/beatmap/v2/event.ts';
 import type { IWrapRotationEventAttribute } from '../../../types/beatmap/wrapper/rotationEvent.ts';
+import { deepCopy } from '../../../utils/misc.ts';
 import { EventLaneRotationValue, RotationValueEventValue } from '../../shared/constants.ts';
 
 /**
@@ -11,7 +11,7 @@ export const rotationEvent: ISchemaContainer<
    IWrapRotationEventAttribute,
    IEvent
 > = {
-   serialize(data: IWrapRotationEventAttribute): IEvent {
+   serialize(data) {
       let r = data.rotation % 360;
       const customData = deepCopy(data.customData);
       if (r >= -60 && r <= 60 && r % 15 === 0 && r / 15 !== 0) {
@@ -28,19 +28,17 @@ export const rotationEvent: ISchemaContainer<
          _customData: customData,
       };
    },
-   deserialize(
-      data: Partial<IEvent> = {},
-   ): Partial<IWrapRotationEventAttribute> {
+   deserialize(data) {
       const value = data._value ?? 0;
       return {
-         time: data._time,
+         time: data._time ?? 0,
          executionTime: data._type === 15 ? 1 : 0,
          rotation: typeof data._customData?._rotation === 'number'
             ? data._customData._rotation
             : value >= 1000
             ? (value - 1360) % 360
             : EventLaneRotationValue[value] ?? 0,
-         customData: data._customData,
+         customData: data._customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v2/waypoint.ts
+++ b/src/beatmap/schema/v2/waypoint.ts
@@ -7,7 +7,7 @@ import { deepCopy } from '../../../utils/misc.ts';
  * Schema serialization for v2 `Waypoint`.
  */
 export const waypoint: ISchemaContainer<IWrapWaypointAttribute, IWaypoint> = {
-   serialize(data: IWrapWaypointAttribute): IWaypoint {
+   serialize(data) {
       return {
          _time: data.time,
          _lineIndex: data.posX,
@@ -16,13 +16,14 @@ export const waypoint: ISchemaContainer<IWrapWaypointAttribute, IWaypoint> = {
          _customData: deepCopy(data.customData),
       };
    },
-   deserialize(data: Partial<IWaypoint> = {}): Partial<IWrapWaypointAttribute> {
+   deserialize(data) {
       return {
-         time: data._time,
-         posX: data._lineIndex,
-         posY: data._lineLayer,
-         direction: data._offsetDirection,
-         customData: data._customData,
+         time: data._time ?? 0,
+         posX: data._lineIndex ?? 0,
+         posY: data._lineLayer ?? 0,
+         direction: data._offsetDirection ?? 0,
+         laneRotation: 0,
+         customData: data._customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v2/waypoint.ts
+++ b/src/beatmap/schema/v2/waypoint.ts
@@ -2,6 +2,7 @@ import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IWaypoint } from '../../../types/beatmap/v2/waypoint.ts';
 import type { IWrapWaypointAttribute } from '../../../types/beatmap/wrapper/waypoint.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createWaypoint } from '../../core/waypoint.ts';
 
 /**
  * Schema serialization for v2 `Waypoint`.
@@ -17,13 +18,12 @@ export const waypoint: ISchemaContainer<IWrapWaypointAttribute, IWaypoint> = {
       };
    },
    deserialize(data) {
-      return {
-         time: data._time ?? 0,
-         posX: data._lineIndex ?? 0,
-         posY: data._lineLayer ?? 0,
-         direction: data._offsetDirection ?? 0,
-         laneRotation: 0,
-         customData: data._customData ?? {},
-      };
+      return createWaypoint({
+         time: data._time,
+         posX: data._lineIndex,
+         posY: data._lineLayer,
+         direction: data._offsetDirection,
+         customData: data._customData,
+      });
    },
 };

--- a/src/beatmap/schema/v3/arc.ts
+++ b/src/beatmap/schema/v3/arc.ts
@@ -2,6 +2,7 @@ import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IArc } from '../../../types/beatmap/v3/arc.ts';
 import type { IWrapArcAttribute } from '../../../types/beatmap/wrapper/arc.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createArc } from '../../core/arc.ts';
 
 /**
  * Schema serialization for v3 `Arc`.
@@ -25,22 +26,20 @@ export const arc: ISchemaContainer<IWrapArcAttribute, IArc> = {
       };
    },
    deserialize(data) {
-      return {
-         time: data.b ?? 0,
-         color: data.c ?? 0,
-         posX: data.x ?? 0,
-         posY: data.y ?? 0,
-         direction: data.d ?? 0,
-         lengthMultiplier: data.mu ?? 0,
-         laneRotation: 0,
-         tailTime: data.tb ?? 0,
-         tailPosX: data.tx ?? 0,
-         tailPosY: data.ty ?? 0,
-         tailDirection: data.tc ?? 0,
-         tailLengthMultiplier: data.tmu ?? 0,
-         midAnchor: data.m ?? 0,
-         tailLaneRotation: 0,
-         customData: data.customData ?? {},
-      };
+      return createArc({
+         time: data.b,
+         color: data.c,
+         posX: data.x,
+         posY: data.y,
+         direction: data.d,
+         lengthMultiplier: data.mu,
+         tailTime: data.tb,
+         tailPosX: data.tx,
+         tailPosY: data.ty,
+         tailDirection: data.tc,
+         tailLengthMultiplier: data.tmu,
+         midAnchor: data.m,
+         customData: data.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v3/arc.ts
+++ b/src/beatmap/schema/v3/arc.ts
@@ -7,7 +7,7 @@ import { deepCopy } from '../../../utils/misc.ts';
  * Schema serialization for v3 `Arc`.
  */
 export const arc: ISchemaContainer<IWrapArcAttribute, IArc> = {
-   serialize(data: IWrapArcAttribute): IArc {
+   serialize(data) {
       return {
          b: data.time,
          c: data.color,
@@ -24,21 +24,23 @@ export const arc: ISchemaContainer<IWrapArcAttribute, IArc> = {
          customData: deepCopy(data.customData),
       };
    },
-   deserialize(data: Partial<IArc> = {}): Partial<IWrapArcAttribute> {
+   deserialize(data) {
       return {
-         time: data.b,
-         color: data.c,
-         posX: data.x,
-         posY: data.y,
-         direction: data.d,
-         lengthMultiplier: data.mu,
-         tailTime: data.tb,
-         tailPosX: data.tx,
-         tailPosY: data.ty,
-         tailDirection: data.tc,
-         tailLengthMultiplier: data.tmu,
-         midAnchor: data.m,
-         customData: data.customData,
+         time: data.b ?? 0,
+         color: data.c ?? 0,
+         posX: data.x ?? 0,
+         posY: data.y ?? 0,
+         direction: data.d ?? 0,
+         lengthMultiplier: data.mu ?? 0,
+         laneRotation: 0,
+         tailTime: data.tb ?? 0,
+         tailPosX: data.tx ?? 0,
+         tailPosY: data.ty ?? 0,
+         tailDirection: data.tc ?? 0,
+         tailLengthMultiplier: data.tmu ?? 0,
+         midAnchor: data.m ?? 0,
+         tailLaneRotation: 0,
+         customData: data.customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v3/basicEvent.ts
+++ b/src/beatmap/schema/v3/basicEvent.ts
@@ -2,6 +2,7 @@ import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IBasicEvent } from '../../../types/beatmap/v3/basicEvent.ts';
 import type { IWrapBasicEventAttribute } from '../../../types/beatmap/wrapper/basicEvent.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createBasicEvent } from '../../core/basicEvent.ts';
 
 /**
  * Schema serialization for v3 `Basic Event`.
@@ -17,12 +18,12 @@ export const basicEvent: ISchemaContainer<IWrapBasicEventAttribute, IBasicEvent>
       };
    },
    deserialize(data) {
-      return {
-         time: data.b ?? 0,
-         type: data.et ?? 0,
-         value: data.i ?? 0,
-         floatValue: data.f ?? 0,
-         customData: data.customData ?? {},
-      };
+      return createBasicEvent({
+         time: data.b,
+         type: data.et,
+         value: data.i,
+         floatValue: data.f,
+         customData: data.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v3/basicEvent.ts
+++ b/src/beatmap/schema/v3/basicEvent.ts
@@ -1,13 +1,13 @@
-import type { IBasicEvent } from '../../../types/beatmap/v3/basicEvent.ts';
-import { deepCopy } from '../../../utils/misc.ts';
-import type { IWrapBasicEventAttribute } from '../../../types/beatmap/wrapper/basicEvent.ts';
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
+import type { IBasicEvent } from '../../../types/beatmap/v3/basicEvent.ts';
+import type { IWrapBasicEventAttribute } from '../../../types/beatmap/wrapper/basicEvent.ts';
+import { deepCopy } from '../../../utils/misc.ts';
 
 /**
  * Schema serialization for v3 `Basic Event`.
  */
 export const basicEvent: ISchemaContainer<IWrapBasicEventAttribute, IBasicEvent> = {
-   serialize(data: IWrapBasicEventAttribute): IBasicEvent {
+   serialize(data) {
       return {
          b: data.time,
          et: data.type,
@@ -16,13 +16,13 @@ export const basicEvent: ISchemaContainer<IWrapBasicEventAttribute, IBasicEvent>
          customData: deepCopy(data.customData),
       };
    },
-   deserialize(data: Partial<IBasicEvent> = {}): Partial<IWrapBasicEventAttribute> {
+   deserialize(data) {
       return {
-         time: data.b,
-         type: data.et,
-         value: data.i,
-         floatValue: data.f,
-         customData: data.customData,
+         time: data.b ?? 0,
+         type: data.et ?? 0,
+         value: data.i ?? 0,
+         floatValue: data.f ?? 0,
+         customData: data.customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v3/basicEventTypesForKeywords.ts
+++ b/src/beatmap/schema/v3/basicEventTypesForKeywords.ts
@@ -1,7 +1,6 @@
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IBasicEventTypesForKeywords } from '../../../types/beatmap/v3/basicEventTypesForKeywords.ts';
 import type { IWrapBasicEventTypesForKeywordsAttribute } from '../../../types/beatmap/wrapper/basicEventTypesForKeywords.ts';
-import type { DeepPartial } from '../../../types/utils.ts';
 
 /**
  * Schema serialization for v3 `Basic Event Types For Keywords`.
@@ -10,18 +9,17 @@ export const basicEventTypesForKeywords: ISchemaContainer<
    IWrapBasicEventTypesForKeywordsAttribute,
    IBasicEventTypesForKeywords
 > = {
-   serialize(data: IWrapBasicEventTypesForKeywordsAttribute): IBasicEventTypesForKeywords {
+   serialize(data) {
       return {
          k: data.keyword,
          e: data.events.map((e) => e),
       };
    },
-   deserialize(
-      data: DeepPartial<IBasicEventTypesForKeywords> = {},
-   ): DeepPartial<IWrapBasicEventTypesForKeywordsAttribute> {
+   deserialize(data) {
       return {
-         keyword: data.k,
-         events: data.e?.map((e) => e),
+         keyword: data.k ?? '',
+         events: data.e?.map((e) => e) ?? [],
+         customData: {},
       };
    },
 };

--- a/src/beatmap/schema/v3/basicEventTypesForKeywords.ts
+++ b/src/beatmap/schema/v3/basicEventTypesForKeywords.ts
@@ -1,6 +1,7 @@
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IBasicEventTypesForKeywords } from '../../../types/beatmap/v3/basicEventTypesForKeywords.ts';
 import type { IWrapBasicEventTypesForKeywordsAttribute } from '../../../types/beatmap/wrapper/basicEventTypesForKeywords.ts';
+import { createBasicEventTypesForKeywords } from '../../core/basicEventTypesForKeywords.ts';
 
 /**
  * Schema serialization for v3 `Basic Event Types For Keywords`.
@@ -16,10 +17,9 @@ export const basicEventTypesForKeywords: ISchemaContainer<
       };
    },
    deserialize(data) {
-      return {
-         keyword: data.k ?? '',
-         events: data.e?.map((e) => e) ?? [],
-         customData: {},
-      };
+      return createBasicEventTypesForKeywords({
+         keyword: data.k,
+         events: data.e?.map((e) => e),
+      });
    },
 };

--- a/src/beatmap/schema/v3/basicEventTypesWithKeywords.ts
+++ b/src/beatmap/schema/v3/basicEventTypesWithKeywords.ts
@@ -1,7 +1,6 @@
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IBasicEventTypesWithKeywords } from '../../../types/beatmap/v3/basicEventTypesWithKeywords.ts';
 import type { IWrapBasicEventTypesWithKeywordsAttribute } from '../../../types/beatmap/wrapper/basicEventTypesWithKeywords.ts';
-import type { DeepPartial } from '../../../types/utils.ts';
 import { basicEventTypesForKeywords } from './basicEventTypesForKeywords.ts';
 
 /**
@@ -11,18 +10,18 @@ export const basicEventTypesWithKeywords: ISchemaContainer<
    IWrapBasicEventTypesWithKeywordsAttribute,
    IBasicEventTypesWithKeywords
 > = {
-   serialize(
-      data: IWrapBasicEventTypesWithKeywordsAttribute,
-   ): Required<IBasicEventTypesWithKeywords> {
+   serialize(data) {
       return {
-         d: data.list.map(basicEventTypesForKeywords.serialize),
+         d: data.list.map((x) => {
+            return basicEventTypesForKeywords.serialize(x);
+         }),
       };
    },
-   deserialize(
-      data: DeepPartial<IBasicEventTypesWithKeywords> = {},
-   ): DeepPartial<IWrapBasicEventTypesWithKeywordsAttribute> {
+   deserialize(data) {
       return {
-         list: data.d?.map(basicEventTypesForKeywords.deserialize),
+         list: data.d?.map((x) => {
+            return basicEventTypesForKeywords.deserialize(x);
+         }) ?? [],
       };
    },
 };

--- a/src/beatmap/schema/v3/bombNote.ts
+++ b/src/beatmap/schema/v3/bombNote.ts
@@ -1,13 +1,13 @@
-import type { IBombNote } from '../../../types/beatmap/v3/bombNote.ts';
-import { deepCopy } from '../../../utils/misc.ts';
-import type { IWrapBombNoteAttribute } from '../../../types/beatmap/wrapper/bombNote.ts';
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
+import type { IBombNote } from '../../../types/beatmap/v3/bombNote.ts';
+import type { IWrapBombNoteAttribute } from '../../../types/beatmap/wrapper/bombNote.ts';
+import { deepCopy } from '../../../utils/misc.ts';
 
 /**
  * Schema serialization for v3 `Bomb Note`.
  */
 export const bombNote: ISchemaContainer<IWrapBombNoteAttribute, IBombNote> = {
-   serialize(data: IWrapBombNoteAttribute): IBombNote {
+   serialize(data) {
       return {
          b: data.time,
          x: data.posX,
@@ -15,12 +15,15 @@ export const bombNote: ISchemaContainer<IWrapBombNoteAttribute, IBombNote> = {
          customData: deepCopy(data.customData),
       };
    },
-   deserialize(data: Partial<IBombNote> = {}): Partial<IWrapBombNoteAttribute> {
+   deserialize(data) {
       return {
-         time: data.b,
-         posX: data.x,
-         posY: data.y,
-         customData: data.customData,
+         time: data.b ?? 0,
+         laneRotation: 0,
+         posX: data.x ?? 0,
+         posY: data.y ?? 0,
+         color: -1,
+         direction: 0,
+         customData: data.customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v3/bombNote.ts
+++ b/src/beatmap/schema/v3/bombNote.ts
@@ -2,6 +2,7 @@ import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IBombNote } from '../../../types/beatmap/v3/bombNote.ts';
 import type { IWrapBombNoteAttribute } from '../../../types/beatmap/wrapper/bombNote.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createBombNote } from '../../core/bombNote.ts';
 
 /**
  * Schema serialization for v3 `Bomb Note`.
@@ -16,14 +17,11 @@ export const bombNote: ISchemaContainer<IWrapBombNoteAttribute, IBombNote> = {
       };
    },
    deserialize(data) {
-      return {
-         time: data.b ?? 0,
-         laneRotation: 0,
-         posX: data.x ?? 0,
-         posY: data.y ?? 0,
-         color: -1,
-         direction: 0,
-         customData: data.customData ?? {},
-      };
+      return createBombNote({
+         time: data.b,
+         posX: data.x,
+         posY: data.y,
+         customData: data.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v3/bpmEvent.ts
+++ b/src/beatmap/schema/v3/bpmEvent.ts
@@ -7,18 +7,18 @@ import { deepCopy } from '../../../utils/misc.ts';
  * Schema serialization for v3 `BPM Event`.
  */
 export const bpmEvent: ISchemaContainer<IWrapBPMEventAttribute, IBPMEvent> = {
-   serialize(data: IWrapBPMEventAttribute): IBPMEvent {
+   serialize(data) {
       return {
          b: data.time,
          m: data.bpm,
          customData: deepCopy(data.customData),
       };
    },
-   deserialize(data: Partial<IBPMEvent> = {}): Partial<IWrapBPMEventAttribute> {
+   deserialize(data) {
       return {
-         time: data.b,
-         bpm: data.m,
-         customData: data.customData,
+         time: data.b ?? 0,
+         bpm: data.m ?? 0,
+         customData: data.customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v3/bpmEvent.ts
+++ b/src/beatmap/schema/v3/bpmEvent.ts
@@ -2,6 +2,7 @@ import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IBPMEvent } from '../../../types/beatmap/v3/bpmEvent.ts';
 import type { IWrapBPMEventAttribute } from '../../../types/beatmap/wrapper/bpmEvent.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createBPMEvent } from '../../core/bpmEvent.ts';
 
 /**
  * Schema serialization for v3 `BPM Event`.
@@ -15,10 +16,10 @@ export const bpmEvent: ISchemaContainer<IWrapBPMEventAttribute, IBPMEvent> = {
       };
    },
    deserialize(data) {
-      return {
-         time: data.b ?? 0,
-         bpm: data.m ?? 0,
-         customData: data.customData ?? {},
-      };
+      return createBPMEvent({
+         time: data.b,
+         bpm: data.m,
+         customData: data.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v3/chain.ts
+++ b/src/beatmap/schema/v3/chain.ts
@@ -7,7 +7,7 @@ import { deepCopy } from '../../../utils/misc.ts';
  * Schema serialization for v3 `Chain`.
  */
 export const chain: ISchemaContainer<IWrapChainAttribute, IChain> = {
-   serialize(data: IWrapChainAttribute): IChain {
+   serialize(data) {
       return {
          b: data.time,
          c: data.color,
@@ -22,19 +22,21 @@ export const chain: ISchemaContainer<IWrapChainAttribute, IChain> = {
          customData: deepCopy(data.customData),
       };
    },
-   deserialize(data: Partial<IChain> = {}): Partial<IWrapChainAttribute> {
+   deserialize(data) {
       return {
-         time: data.b,
-         color: data.c,
-         posX: data.x,
-         posY: data.y,
-         direction: data.d,
-         tailTime: data.tb,
-         tailPosX: data.tx,
-         tailPosY: data.ty,
-         sliceCount: data.sc,
-         squish: data.s,
-         customData: data.customData,
+         time: data.b ?? 0,
+         laneRotation: 0,
+         color: data.c ?? 0,
+         posX: data.x ?? 0,
+         posY: data.y ?? 0,
+         direction: data.d ?? 0,
+         tailTime: data.tb ?? 0,
+         tailLaneRotation: 0,
+         tailPosX: data.tx ?? 0,
+         tailPosY: data.ty ?? 0,
+         sliceCount: data.sc ?? 0,
+         squish: data.s ?? 0,
+         customData: data.customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v3/chain.ts
+++ b/src/beatmap/schema/v3/chain.ts
@@ -2,6 +2,7 @@ import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IChain } from '../../../types/beatmap/v3/chain.ts';
 import type { IWrapChainAttribute } from '../../../types/beatmap/wrapper/chain.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createChain } from '../../core/chain.ts';
 
 /**
  * Schema serialization for v3 `Chain`.
@@ -23,20 +24,18 @@ export const chain: ISchemaContainer<IWrapChainAttribute, IChain> = {
       };
    },
    deserialize(data) {
-      return {
-         time: data.b ?? 0,
-         laneRotation: 0,
-         color: data.c ?? 0,
-         posX: data.x ?? 0,
-         posY: data.y ?? 0,
-         direction: data.d ?? 0,
-         tailTime: data.tb ?? 0,
-         tailLaneRotation: 0,
-         tailPosX: data.tx ?? 0,
-         tailPosY: data.ty ?? 0,
-         sliceCount: data.sc ?? 0,
-         squish: data.s ?? 0,
-         customData: data.customData ?? {},
-      };
+      return createChain({
+         time: data.b,
+         color: data.c,
+         posX: data.x,
+         posY: data.y,
+         direction: data.d,
+         tailTime: data.tb,
+         tailPosX: data.tx,
+         tailPosY: data.ty,
+         sliceCount: data.sc,
+         squish: data.s,
+         customData: data.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v3/colorBoostEvent.ts
+++ b/src/beatmap/schema/v3/colorBoostEvent.ts
@@ -7,18 +7,18 @@ import { deepCopy } from '../../../utils/misc.ts';
  * Schema serialization for v3 `Color Boost Event`.
  */
 export const colorBoostEvent: ISchemaContainer<IWrapColorBoostEventAttribute, IColorBoostEvent> = {
-   serialize(data: IWrapColorBoostEventAttribute): IColorBoostEvent {
+   serialize(data) {
       return {
          b: data.time,
          o: data.toggle,
          customData: deepCopy(data.customData),
       };
    },
-   deserialize(data: Partial<IColorBoostEvent> = {}): Partial<IWrapColorBoostEventAttribute> {
+   deserialize(data = {}) {
       return {
-         time: data.b,
-         toggle: data.o,
-         customData: data.customData,
+         time: data.b ?? 0,
+         toggle: !!data.o,
+         customData: data.customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v3/colorBoostEvent.ts
+++ b/src/beatmap/schema/v3/colorBoostEvent.ts
@@ -2,6 +2,7 @@ import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IColorBoostEvent } from '../../../types/beatmap/v3/colorBoostEvent.ts';
 import type { IWrapColorBoostEventAttribute } from '../../../types/beatmap/wrapper/colorBoostEvent.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createColorBoostEvent } from '../../core/colorBoostEvent.ts';
 
 /**
  * Schema serialization for v3 `Color Boost Event`.
@@ -15,10 +16,10 @@ export const colorBoostEvent: ISchemaContainer<IWrapColorBoostEventAttribute, IC
       };
    },
    deserialize(data = {}) {
-      return {
-         time: data.b ?? 0,
+      return createColorBoostEvent({
+         time: data.b,
          toggle: !!data.o,
-         customData: data.customData ?? {},
-      };
+         customData: data.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v3/colorNote.ts
+++ b/src/beatmap/schema/v3/colorNote.ts
@@ -1,13 +1,13 @@
-import type { IColorNote } from '../../../types/beatmap/v3/colorNote.ts';
-import { deepCopy } from '../../../utils/misc.ts';
-import type { IWrapColorNoteAttribute } from '../../../types/beatmap/wrapper/colorNote.ts';
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
+import type { IColorNote } from '../../../types/beatmap/v3/colorNote.ts';
+import type { IWrapColorNoteAttribute } from '../../../types/beatmap/wrapper/colorNote.ts';
+import { deepCopy } from '../../../utils/misc.ts';
 
 /**
  * Schema serialization for v3 `Color Note`.
  */
 export const colorNote: ISchemaContainer<IWrapColorNoteAttribute, IColorNote> = {
-   serialize(data: IWrapColorNoteAttribute): IColorNote {
+   serialize(data) {
       return {
          b: data.time,
          c: data.color,
@@ -18,15 +18,16 @@ export const colorNote: ISchemaContainer<IWrapColorNoteAttribute, IColorNote> = 
          customData: deepCopy(data.customData),
       };
    },
-   deserialize(data: Partial<IColorNote> = {}): Partial<IWrapColorNoteAttribute> {
+   deserialize(data) {
       return {
-         time: data.b,
-         posX: data.x,
-         posY: data.y,
-         color: data.c,
-         direction: data.d,
-         angleOffset: data.a,
-         customData: data.customData,
+         time: data.b ?? 0,
+         laneRotation: 0,
+         posX: data.x ?? 0,
+         posY: data.y ?? 0,
+         color: data.c ?? 0,
+         direction: data.d ?? 0,
+         angleOffset: data.a ?? 0,
+         customData: data.customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v3/colorNote.ts
+++ b/src/beatmap/schema/v3/colorNote.ts
@@ -2,6 +2,7 @@ import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IColorNote } from '../../../types/beatmap/v3/colorNote.ts';
 import type { IWrapColorNoteAttribute } from '../../../types/beatmap/wrapper/colorNote.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createColorNote } from '../../core/colorNote.ts';
 
 /**
  * Schema serialization for v3 `Color Note`.
@@ -19,15 +20,14 @@ export const colorNote: ISchemaContainer<IWrapColorNoteAttribute, IColorNote> = 
       };
    },
    deserialize(data) {
-      return {
-         time: data.b ?? 0,
-         laneRotation: 0,
-         posX: data.x ?? 0,
-         posY: data.y ?? 0,
-         color: data.c ?? 0,
-         direction: data.d ?? 0,
-         angleOffset: data.a ?? 0,
-         customData: data.customData ?? {},
-      };
+      return createColorNote({
+         time: data.b,
+         posX: data.x,
+         posY: data.y,
+         color: data.c,
+         direction: data.d,
+         angleOffset: data.a,
+         customData: data.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v3/compat/difficulty.ts
+++ b/src/beatmap/schema/v3/compat/difficulty.ts
@@ -1,27 +1,27 @@
-import type { IWrapBeatmap } from '../../../../types/beatmap/wrapper/beatmap.ts';
+import { logger } from '../../../../logger.ts';
 import type { ICompatibilityOptions } from '../../../../types/beatmap/options/compatibility.ts';
+import type { IWrapBeatmapAttribute } from '../../../../types/beatmap/wrapper/beatmap.ts';
 import {
+   hasMappingExtensionsArc,
    hasMappingExtensionsBombNote,
+   hasMappingExtensionsChain,
    hasMappingExtensionsNote,
    hasMappingExtensionsObstacleV3,
 } from '../../../helpers/modded/has.ts';
-import { logger } from '../../../../logger.ts';
 import { tag } from './_common.ts';
-import { hasMappingExtensionsArc } from '../../../helpers/modded/has.ts';
-import { hasMappingExtensionsChain } from '../../../helpers/modded/has.ts';
 
 /**
  * Checks if beatmap data is compatible with v3 `Difficulty` schema.
  */
-export function compatDifficulty(
-   bm: IWrapBeatmap,
+export function compatDifficulty<T extends IWrapBeatmapAttribute>(
+   bm: T,
    options: ICompatibilityOptions,
 ) {
-   const hasME = bm.colorNotes.some(hasMappingExtensionsNote) ||
-      bm.bombNotes.some(hasMappingExtensionsBombNote) ||
-      bm.arcs.some(hasMappingExtensionsArc) ||
-      bm.chains.some(hasMappingExtensionsChain) ||
-      bm.obstacles.some(hasMappingExtensionsObstacleV3);
+   const hasME = bm.difficulty.colorNotes.some(hasMappingExtensionsNote) ||
+      bm.difficulty.bombNotes.some(hasMappingExtensionsBombNote) ||
+      bm.difficulty.arcs.some(hasMappingExtensionsArc) ||
+      bm.difficulty.chains.some(hasMappingExtensionsChain) ||
+      bm.difficulty.obstacles.some(hasMappingExtensionsObstacleV3);
 
    if (hasME) {
       if (options.throwOn.mappingExtensions) {

--- a/src/beatmap/schema/v3/compat/lightshow.ts
+++ b/src/beatmap/schema/v3/compat/lightshow.ts
@@ -1,10 +1,10 @@
-import type { IWrapBeatmap } from '../../../../types/beatmap/wrapper/beatmap.ts';
 import type { ICompatibilityOptions } from '../../../../types/beatmap/options/compatibility.ts';
+import type { IWrapBeatmapAttribute } from '../../../../types/beatmap/wrapper/beatmap.ts';
 
 /**
  * Checks if beatmap data is compatible with v3 `Lightshow` schema.
  */
-export function compatLightshow(
-   _bm: IWrapBeatmap,
+export function compatLightshow<T extends IWrapBeatmapAttribute>(
+   _bm: T,
    _options: ICompatibilityOptions,
 ) {}

--- a/src/beatmap/schema/v3/difficulty.ts
+++ b/src/beatmap/schema/v3/difficulty.ts
@@ -1,7 +1,11 @@
+// deno-lint-ignore-file no-explicit-any
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IDifficulty } from '../../../types/beatmap/v3/difficulty.ts';
 import type { IWrapBeatmapAttribute } from '../../../types/beatmap/wrapper/beatmap.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createBeatmap } from '../../core/beatmap.ts';
+import { createDifficulty } from '../../core/difficulty.ts';
+import { createLightshow } from '../../core/lightshow.ts';
 import { FxType } from '../../shared/constants.ts';
 import { arc } from './arc.ts';
 import { basicEvent } from './basicEvent.ts';
@@ -19,152 +23,156 @@ import { obstacle } from './obstacle.ts';
 import { rotationEvent } from './rotationEvent.ts';
 import { waypoint } from './waypoint.ts';
 
-type DifficultyPolyfills = Pick<IWrapBeatmapAttribute, 'filename' | 'lightshowFilename'>;
+type DifficultyDeserializationPolyfills = Pick<
+   IWrapBeatmapAttribute,
+   'filename' | 'lightshowFilename'
+>;
 
 /**
  * Schema serialization for v3 `Difficulty`.
  */
-export const difficulty: ISchemaContainer<IWrapBeatmapAttribute, IDifficulty, DifficultyPolyfills> =
-   {
-      serialize(data: IWrapBeatmapAttribute): Required<IDifficulty> {
-         const json: Required<IDifficulty> = {
-            version: '3.3.0',
-            bpmEvents: data.difficulty.bpmEvents.map((x) => {
-               return bpmEvent.serialize(x);
-            }),
-            rotationEvents: data.difficulty.rotationEvents.map((x) => {
-               return rotationEvent.serialize(x);
-            }),
-            colorNotes: data.difficulty.colorNotes.map((x) => {
-               return colorNote.serialize(x);
-            }),
-            bombNotes: data.difficulty.bombNotes.map((x) => {
-               return bombNote.serialize(x);
-            }),
-            obstacles: data.difficulty.obstacles.map((x) => {
-               return obstacle.serialize(x);
-            }),
-            sliders: data.difficulty.arcs.map((x) => {
-               return arc.serialize(x);
-            }),
-            burstSliders: data.difficulty.chains.map((x) => {
-               return chain.serialize(x);
-            }),
-            waypoints: data.lightshow.waypoints.map((x) => {
-               return waypoint.serialize(x);
-            }),
-            basicBeatmapEvents: data.lightshow.basicEvents.map((x) => {
-               return basicEvent.serialize(x);
-            }),
-            colorBoostBeatmapEvents: data.lightshow.colorBoostEvents.map((x) => {
-               return colorBoostEvent.serialize(x);
-            }),
-            lightColorEventBoxGroups: data.lightshow.lightColorEventBoxGroups.map((x) => {
-               return lightColorEventBoxGroup.serialize(x);
-            }),
-            lightRotationEventBoxGroups: data.lightshow.lightRotationEventBoxGroups.map((x) => {
-               return lightRotationEventBoxGroup.serialize(x);
-            }),
-            lightTranslationEventBoxGroups: data.lightshow.lightTranslationEventBoxGroups.map(
-               (x) => {
-                  return lightTranslationEventBoxGroup.serialize(x);
-               },
-            ),
-            vfxEventBoxGroups: [],
-            basicEventTypesWithKeywords: basicEventTypesWithKeywords.serialize(
-               data.lightshow.basicEventTypesWithKeywords,
-            ),
-            _fxEventsCollection: {
-               _fl: [],
-               _il: [],
+export const difficulty: ISchemaContainer<
+   IWrapBeatmapAttribute,
+   IDifficulty,
+   Record<string, any>,
+   DifficultyDeserializationPolyfills
+> = {
+   serialize(data) {
+      const json: Required<IDifficulty> = {
+         version: '3.3.0',
+         bpmEvents: data.difficulty.bpmEvents.map((x) => {
+            return bpmEvent.serialize(x);
+         }),
+         rotationEvents: data.difficulty.rotationEvents.map((x) => {
+            return rotationEvent.serialize(x);
+         }),
+         colorNotes: data.difficulty.colorNotes.map((x) => {
+            return colorNote.serialize(x);
+         }),
+         bombNotes: data.difficulty.bombNotes.map((x) => {
+            return bombNote.serialize(x);
+         }),
+         obstacles: data.difficulty.obstacles.map((x) => {
+            return obstacle.serialize(x);
+         }),
+         sliders: data.difficulty.arcs.map((x) => {
+            return arc.serialize(x);
+         }),
+         burstSliders: data.difficulty.chains.map((x) => {
+            return chain.serialize(x);
+         }),
+         waypoints: data.lightshow.waypoints.map((x) => {
+            return waypoint.serialize(x);
+         }),
+         basicBeatmapEvents: data.lightshow.basicEvents.map((x) => {
+            return basicEvent.serialize(x);
+         }),
+         colorBoostBeatmapEvents: data.lightshow.colorBoostEvents.map((x) => {
+            return colorBoostEvent.serialize(x);
+         }),
+         lightColorEventBoxGroups: data.lightshow.lightColorEventBoxGroups.map((x) => {
+            return lightColorEventBoxGroup.serialize(x);
+         }),
+         lightRotationEventBoxGroups: data.lightshow.lightRotationEventBoxGroups.map((x) => {
+            return lightRotationEventBoxGroup.serialize(x);
+         }),
+         lightTranslationEventBoxGroups: data.lightshow.lightTranslationEventBoxGroups.map(
+            (x) => {
+               return lightTranslationEventBoxGroup.serialize(x);
             },
-            useNormalEventsAsCompatibleEvents: data.lightshow.useNormalEventsAsCompatibleEvents,
-            customData: deepCopy(data.difficulty.customData),
-         };
-         for (
-            const obj of data.lightshow.fxEventBoxGroups.map((x) => {
-               return fxEventBoxGroup.serialize(x);
-            })
-         ) {
-            json.vfxEventBoxGroups.push(obj.object);
-            for (const box of obj.boxData) {
-               obj.object.e!.push(box.data);
-               for (const evt of box.eventData) {
-                  box.data.l!.push(json._fxEventsCollection._fl!.length);
-                  json._fxEventsCollection._fl!.push(evt);
-               }
+         ),
+         vfxEventBoxGroups: [],
+         basicEventTypesWithKeywords: basicEventTypesWithKeywords.serialize(
+            data.lightshow.basicEventTypesWithKeywords,
+         ),
+         _fxEventsCollection: {
+            _fl: [],
+            _il: [],
+         },
+         useNormalEventsAsCompatibleEvents: data.lightshow.useNormalEventsAsCompatibleEvents,
+         customData: deepCopy(data.difficulty.customData),
+      };
+      for (
+         const obj of data.lightshow.fxEventBoxGroups.map((x) => {
+            return fxEventBoxGroup.serialize(x);
+         })
+      ) {
+         json.vfxEventBoxGroups.push(obj.object);
+         for (const box of obj.boxData) {
+            obj.object.e!.push(box.data);
+            for (const evt of box.eventData) {
+               box.data.l!.push(json._fxEventsCollection._fl!.length);
+               json._fxEventsCollection._fl!.push(evt);
             }
          }
-         return json;
-      },
-      deserialize(data, options) {
-         const fx = data._fxEventsCollection?._fl;
-         return {
-            version: 3,
-            filename: options?.filename ?? 'Easy.dat',
-            lightshowFilename: options?.lightshowFilename ?? 'EasyLightshow.dat',
-            difficulty: {
-               colorNotes: data.colorNotes?.map((x) => {
-                  return colorNote.deserialize(x);
-               }) ?? [],
-               bombNotes: data.bombNotes?.map((x) => {
-                  return bombNote.deserialize(x);
-               }) ?? [],
-               obstacles: data.obstacles?.map((x) => {
-                  return obstacle.deserialize(x);
-               }) ?? [],
-               arcs: data.sliders?.map((x) => {
-                  return arc.deserialize(x);
-               }) ?? [],
-               chains: data.burstSliders?.map((x) => {
-                  return chain.deserialize(x);
-               }) ?? [],
-               rotationEvents: data.rotationEvents?.map((x) => {
-                  return rotationEvent.deserialize(x);
-               }) ?? [],
-               bpmEvents: data.bpmEvents?.map((x) => {
-                  return bpmEvent.deserialize(x);
-               }) ?? [],
-               njsEvents: [],
-               customData: {},
-            },
-            lightshow: {
-               waypoints: data.waypoints?.map((x) => {
-                  return waypoint.deserialize(x);
-               }) ?? [],
-               basicEvents: data.basicBeatmapEvents?.map((x) => {
-                  return basicEvent.deserialize(x);
-               }) ?? [],
-               colorBoostEvents: data.colorBoostBeatmapEvents?.map((x) => {
-                  return colorBoostEvent.deserialize(x);
-               }) ?? [],
-               lightColorEventBoxGroups: data.lightColorEventBoxGroups?.map((x) => {
-                  return lightColorEventBoxGroup.deserialize(x);
-               }) ?? [],
-               lightRotationEventBoxGroups: data.lightRotationEventBoxGroups?.map((x) => {
-                  return lightRotationEventBoxGroup.deserialize(x);
-               }) ?? [],
-               lightTranslationEventBoxGroups: data.lightTranslationEventBoxGroups?.map(
-                  (x) => {
-                     return lightTranslationEventBoxGroup.deserialize(x);
-                  },
-               ) ?? [],
-               fxEventBoxGroups: data.vfxEventBoxGroups?.map((obj) =>
-                  fxEventBoxGroup.deserialize({
-                     object: { ...obj, t: FxType.FLOAT },
-                     boxData: obj.e?.map((box) => ({
-                        data: box,
-                        eventData: box.l?.map((idx) => fx![idx]) ?? [],
-                     })) ?? [],
-                  })
-               ) ?? [],
-               basicEventTypesWithKeywords: basicEventTypesWithKeywords.deserialize(
-                  data.basicEventTypesWithKeywords ?? {},
-               ),
-               useNormalEventsAsCompatibleEvents: data.useNormalEventsAsCompatibleEvents ?? false,
-               customData: {},
-            },
-            customData: data.customData ?? {},
-         };
-      },
-   };
+      }
+      return json;
+   },
+   deserialize(data, options) {
+      const fx = data._fxEventsCollection?._fl;
+      return createBeatmap({
+         version: 3,
+         filename: options?.filename,
+         lightshowFilename: options?.lightshowFilename,
+         difficulty: createDifficulty({
+            colorNotes: data.colorNotes?.map((x) => {
+               return colorNote.deserialize(x);
+            }),
+            bombNotes: data.bombNotes?.map((x) => {
+               return bombNote.deserialize(x);
+            }),
+            obstacles: data.obstacles?.map((x) => {
+               return obstacle.deserialize(x);
+            }),
+            arcs: data.sliders?.map((x) => {
+               return arc.deserialize(x);
+            }),
+            chains: data.burstSliders?.map((x) => {
+               return chain.deserialize(x);
+            }),
+            rotationEvents: data.rotationEvents?.map((x) => {
+               return rotationEvent.deserialize(x);
+            }),
+            bpmEvents: data.bpmEvents?.map((x) => {
+               return bpmEvent.deserialize(x);
+            }),
+            customData: data.customData,
+         }),
+         lightshow: createLightshow({
+            waypoints: data.waypoints?.map((x) => {
+               return waypoint.deserialize(x);
+            }),
+            basicEvents: data.basicBeatmapEvents?.map((x) => {
+               return basicEvent.deserialize(x);
+            }),
+            colorBoostEvents: data.colorBoostBeatmapEvents?.map((x) => {
+               return colorBoostEvent.deserialize(x);
+            }),
+            lightColorEventBoxGroups: data.lightColorEventBoxGroups?.map((x) => {
+               return lightColorEventBoxGroup.deserialize(x);
+            }),
+            lightRotationEventBoxGroups: data.lightRotationEventBoxGroups?.map((x) => {
+               return lightRotationEventBoxGroup.deserialize(x);
+            }),
+            lightTranslationEventBoxGroups: data.lightTranslationEventBoxGroups?.map(
+               (x) => {
+                  return lightTranslationEventBoxGroup.deserialize(x);
+               },
+            ),
+            fxEventBoxGroups: data.vfxEventBoxGroups?.map((obj) =>
+               fxEventBoxGroup.deserialize({
+                  object: { ...obj, t: FxType.FLOAT },
+                  boxData: obj.e?.map((box) => ({
+                     data: box,
+                     eventData: box.l?.map((idx) => fx![idx]) ?? [],
+                  })) ?? [],
+               })
+            ),
+            basicEventTypesWithKeywords: basicEventTypesWithKeywords.deserialize(
+               data.basicEventTypesWithKeywords ?? {},
+            ),
+            useNormalEventsAsCompatibleEvents: data.useNormalEventsAsCompatibleEvents,
+         }),
+      });
+   },
+};

--- a/src/beatmap/schema/v3/difficulty.ts
+++ b/src/beatmap/schema/v3/difficulty.ts
@@ -1,4 +1,9 @@
+import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IDifficulty } from '../../../types/beatmap/v3/difficulty.ts';
+import type { IWrapBeatmapAttribute } from '../../../types/beatmap/wrapper/beatmap.ts';
+import { deepCopy } from '../../../utils/misc.ts';
+import { FxType } from '../../shared/constants.ts';
+import { arc } from './arc.ts';
 import { basicEvent } from './basicEvent.ts';
 import { basicEventTypesWithKeywords } from './basicEventTypesWithKeywords.ts';
 import { bombNote } from './bombNote.ts';
@@ -6,126 +11,160 @@ import { bpmEvent } from './bpmEvent.ts';
 import { chain } from './chain.ts';
 import { colorBoostEvent } from './colorBoostEvent.ts';
 import { colorNote } from './colorNote.ts';
+import { fxEventBoxGroup } from './fxEventBoxGroup.ts';
 import { lightColorEventBoxGroup } from './lightColorEventBoxGroup.ts';
 import { lightRotationEventBoxGroup } from './lightRotationEventBoxGroup.ts';
 import { lightTranslationEventBoxGroup } from './lightTranslationEventBoxGroup.ts';
 import { obstacle } from './obstacle.ts';
 import { rotationEvent } from './rotationEvent.ts';
-import { arc } from './arc.ts';
 import { waypoint } from './waypoint.ts';
-import type { DeepPartial } from '../../../types/utils.ts';
-import { deepCopy } from '../../../utils/misc.ts';
-import { fxEventBoxGroup } from './fxEventBoxGroup.ts';
-import type { IWrapBeatmapAttribute } from '../../../types/beatmap/wrapper/beatmap.ts';
-import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
+
+type DifficultyPolyfills = Pick<IWrapBeatmapAttribute, 'filename' | 'lightshowFilename'>;
 
 /**
  * Schema serialization for v3 `Difficulty`.
  */
-export const difficulty: ISchemaContainer<IWrapBeatmapAttribute, IDifficulty> = {
-   serialize(data: IWrapBeatmapAttribute): Required<IDifficulty> {
-      const json: Required<IDifficulty> = {
-         version: '3.3.0',
-         bpmEvents: data.difficulty.bpmEvents.map(bpmEvent.serialize),
-         rotationEvents: data.difficulty.rotationEvents.map(
-            rotationEvent.serialize,
-         ),
-         colorNotes: data.difficulty.colorNotes.map(colorNote.serialize),
-         bombNotes: data.difficulty.bombNotes.map(bombNote.serialize),
-         obstacles: data.difficulty.obstacles.map(obstacle.serialize),
-         sliders: data.difficulty.arcs.map(arc.serialize),
-         burstSliders: data.difficulty.chains.map(chain.serialize),
-         waypoints: data.lightshow.waypoints.map(waypoint.serialize),
-         basicBeatmapEvents: data.lightshow.basicEvents.map(
-            basicEvent.serialize,
-         ),
-         colorBoostBeatmapEvents: data.lightshow.colorBoostEvents.map(
-            colorBoostEvent.serialize,
-         ),
-         lightColorEventBoxGroups: data.lightshow.lightColorEventBoxGroups.map(
-            lightColorEventBoxGroup.serialize,
-         ),
-         lightRotationEventBoxGroups: data.lightshow.lightRotationEventBoxGroups.map(
-            lightRotationEventBoxGroup.serialize,
-         ),
-         lightTranslationEventBoxGroups: data.lightshow.lightTranslationEventBoxGroups.map(
-            lightTranslationEventBoxGroup.serialize,
-         ),
-         vfxEventBoxGroups: [],
-         basicEventTypesWithKeywords: basicEventTypesWithKeywords.serialize(
-            data.lightshow.basicEventTypesWithKeywords,
-         ),
-         _fxEventsCollection: {
-            _fl: [],
-            _il: [],
-         },
-         useNormalEventsAsCompatibleEvents: data.lightshow.useNormalEventsAsCompatibleEvents,
-         customData: deepCopy(data.difficulty.customData),
-      };
-      for (
-         const obj of data.lightshow.fxEventBoxGroups.map(
-            fxEventBoxGroup.serialize,
-         )
-      ) {
-         json.vfxEventBoxGroups.push(obj.object);
-         for (const box of obj.boxData) {
-            obj.object.e!.push(box.data);
-            for (const evt of box.eventData) {
-               box.data.l!.push(json._fxEventsCollection._fl!.length);
-               json._fxEventsCollection._fl!.push(evt);
+export const difficulty: ISchemaContainer<IWrapBeatmapAttribute, IDifficulty, DifficultyPolyfills> =
+   {
+      serialize(data: IWrapBeatmapAttribute): Required<IDifficulty> {
+         const json: Required<IDifficulty> = {
+            version: '3.3.0',
+            bpmEvents: data.difficulty.bpmEvents.map((x) => {
+               return bpmEvent.serialize(x);
+            }),
+            rotationEvents: data.difficulty.rotationEvents.map((x) => {
+               return rotationEvent.serialize(x);
+            }),
+            colorNotes: data.difficulty.colorNotes.map((x) => {
+               return colorNote.serialize(x);
+            }),
+            bombNotes: data.difficulty.bombNotes.map((x) => {
+               return bombNote.serialize(x);
+            }),
+            obstacles: data.difficulty.obstacles.map((x) => {
+               return obstacle.serialize(x);
+            }),
+            sliders: data.difficulty.arcs.map((x) => {
+               return arc.serialize(x);
+            }),
+            burstSliders: data.difficulty.chains.map((x) => {
+               return chain.serialize(x);
+            }),
+            waypoints: data.lightshow.waypoints.map((x) => {
+               return waypoint.serialize(x);
+            }),
+            basicBeatmapEvents: data.lightshow.basicEvents.map((x) => {
+               return basicEvent.serialize(x);
+            }),
+            colorBoostBeatmapEvents: data.lightshow.colorBoostEvents.map((x) => {
+               return colorBoostEvent.serialize(x);
+            }),
+            lightColorEventBoxGroups: data.lightshow.lightColorEventBoxGroups.map((x) => {
+               return lightColorEventBoxGroup.serialize(x);
+            }),
+            lightRotationEventBoxGroups: data.lightshow.lightRotationEventBoxGroups.map((x) => {
+               return lightRotationEventBoxGroup.serialize(x);
+            }),
+            lightTranslationEventBoxGroups: data.lightshow.lightTranslationEventBoxGroups.map(
+               (x) => {
+                  return lightTranslationEventBoxGroup.serialize(x);
+               },
+            ),
+            vfxEventBoxGroups: [],
+            basicEventTypesWithKeywords: basicEventTypesWithKeywords.serialize(
+               data.lightshow.basicEventTypesWithKeywords,
+            ),
+            _fxEventsCollection: {
+               _fl: [],
+               _il: [],
+            },
+            useNormalEventsAsCompatibleEvents: data.lightshow.useNormalEventsAsCompatibleEvents,
+            customData: deepCopy(data.difficulty.customData),
+         };
+         for (
+            const obj of data.lightshow.fxEventBoxGroups.map((x) => {
+               return fxEventBoxGroup.serialize(x);
+            })
+         ) {
+            json.vfxEventBoxGroups.push(obj.object);
+            for (const box of obj.boxData) {
+               obj.object.e!.push(box.data);
+               for (const evt of box.eventData) {
+                  box.data.l!.push(json._fxEventsCollection._fl!.length);
+                  json._fxEventsCollection._fl!.push(evt);
+               }
             }
          }
-      }
-      return json;
-   },
-   deserialize: function (
-      data: DeepPartial<IDifficulty> = {},
-   ): DeepPartial<IWrapBeatmapAttribute> {
-      const d: DeepPartial<IWrapBeatmapAttribute> = {
-         version: 3,
-         difficulty: {},
-         lightshow: {},
-      };
-      d.difficulty!.bpmEvents = data.bpmEvents?.map(bpmEvent.deserialize);
-      d.difficulty!.rotationEvents = data.rotationEvents?.map(
-         rotationEvent.deserialize,
-      );
-      d.difficulty!.colorNotes = data.colorNotes?.map(colorNote.deserialize);
-      d.difficulty!.bombNotes = data.bombNotes?.map(bombNote.deserialize);
-      d.difficulty!.obstacles = data.obstacles?.map(obstacle.deserialize);
-      d.difficulty!.arcs = data.sliders?.map(arc.deserialize);
-      d.difficulty!.chains = data.burstSliders?.map(chain.deserialize);
-      d.lightshow!.waypoints = data.waypoints?.map(waypoint.deserialize);
-      d.lightshow!.basicEvents = data.basicBeatmapEvents?.map(
-         basicEvent.deserialize,
-      );
-      d.lightshow!.colorBoostEvents = data.colorBoostBeatmapEvents?.map(
-         colorBoostEvent.deserialize,
-      );
-      d.lightshow!.lightColorEventBoxGroups = data.lightColorEventBoxGroups?.map(
-         lightColorEventBoxGroup.deserialize,
-      );
-      d.lightshow!.lightRotationEventBoxGroups = data.lightRotationEventBoxGroups?.map(
-         lightRotationEventBoxGroup.deserialize,
-      );
-      d.lightshow!.lightTranslationEventBoxGroups = data.lightTranslationEventBoxGroups?.map(
-         lightTranslationEventBoxGroup.deserialize,
-      );
-      const fx = data._fxEventsCollection?._fl;
-      d.lightshow!.fxEventBoxGroups = data.vfxEventBoxGroups?.map((obj) =>
-         fxEventBoxGroup.deserialize({
-            object: obj,
-            boxData: obj.e?.map((box) => ({
-               data: box,
-               eventData: box.l?.map((idx) => fx![idx]),
-            })),
-         })
-      );
-      d.lightshow!.basicEventTypesWithKeywords = basicEventTypesWithKeywords.deserialize(
-         data.basicEventTypesWithKeywords,
-      );
-      d.lightshow!.useNormalEventsAsCompatibleEvents = data.useNormalEventsAsCompatibleEvents;
-      d.difficulty!.customData = data.customData;
-      return d;
-   },
-};
+         return json;
+      },
+      deserialize(data, options) {
+         const fx = data._fxEventsCollection?._fl;
+         return {
+            version: 3,
+            filename: options?.filename ?? 'Easy.dat',
+            lightshowFilename: options?.lightshowFilename ?? 'EasyLightshow.dat',
+            difficulty: {
+               colorNotes: data.colorNotes?.map((x) => {
+                  return colorNote.deserialize(x);
+               }) ?? [],
+               bombNotes: data.bombNotes?.map((x) => {
+                  return bombNote.deserialize(x);
+               }) ?? [],
+               obstacles: data.obstacles?.map((x) => {
+                  return obstacle.deserialize(x);
+               }) ?? [],
+               arcs: data.sliders?.map((x) => {
+                  return arc.deserialize(x);
+               }) ?? [],
+               chains: data.burstSliders?.map((x) => {
+                  return chain.deserialize(x);
+               }) ?? [],
+               rotationEvents: data.rotationEvents?.map((x) => {
+                  return rotationEvent.deserialize(x);
+               }) ?? [],
+               bpmEvents: data.bpmEvents?.map((x) => {
+                  return bpmEvent.deserialize(x);
+               }) ?? [],
+               njsEvents: [],
+               customData: {},
+            },
+            lightshow: {
+               waypoints: data.waypoints?.map((x) => {
+                  return waypoint.deserialize(x);
+               }) ?? [],
+               basicEvents: data.basicBeatmapEvents?.map((x) => {
+                  return basicEvent.deserialize(x);
+               }) ?? [],
+               colorBoostEvents: data.colorBoostBeatmapEvents?.map((x) => {
+                  return colorBoostEvent.deserialize(x);
+               }) ?? [],
+               lightColorEventBoxGroups: data.lightColorEventBoxGroups?.map((x) => {
+                  return lightColorEventBoxGroup.deserialize(x);
+               }) ?? [],
+               lightRotationEventBoxGroups: data.lightRotationEventBoxGroups?.map((x) => {
+                  return lightRotationEventBoxGroup.deserialize(x);
+               }) ?? [],
+               lightTranslationEventBoxGroups: data.lightTranslationEventBoxGroups?.map(
+                  (x) => {
+                     return lightTranslationEventBoxGroup.deserialize(x);
+                  },
+               ) ?? [],
+               fxEventBoxGroups: data.vfxEventBoxGroups?.map((obj) =>
+                  fxEventBoxGroup.deserialize({
+                     object: { ...obj, t: FxType.FLOAT },
+                     boxData: obj.e?.map((box) => ({
+                        data: box,
+                        eventData: box.l?.map((idx) => fx![idx]) ?? [],
+                     })) ?? [],
+                  })
+               ) ?? [],
+               basicEventTypesWithKeywords: basicEventTypesWithKeywords.deserialize(
+                  data.basicEventTypesWithKeywords ?? {},
+               ),
+               useNormalEventsAsCompatibleEvents: data.useNormalEventsAsCompatibleEvents ?? false,
+               customData: {},
+            },
+            customData: data.customData ?? {},
+         };
+      },
+   };

--- a/src/beatmap/schema/v3/fxEventBox.ts
+++ b/src/beatmap/schema/v3/fxEventBox.ts
@@ -2,6 +2,7 @@ import type { IFxEventFloatBoxContainer } from '../../../types/beatmap/container
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IWrapFxEventBoxAttribute } from '../../../types/beatmap/wrapper/fxEventBox.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createFxEventBox } from '../../core/fxEventBox.ts';
 import { fxEventFloat } from './fxEventFloat.ts';
 import { indexFilter } from './indexFilter.ts';
 
@@ -9,7 +10,7 @@ import { indexFilter } from './indexFilter.ts';
  * Schema serialization for v3 `FX Event Box`.
  */
 export const fxEventBox: ISchemaContainer<IWrapFxEventBoxAttribute, IFxEventFloatBoxContainer> = {
-   serialize(data: IWrapFxEventBoxAttribute): IFxEventFloatBoxContainer {
+   serialize(data) {
       return {
          data: {
             f: indexFilter.serialize(data.filter),
@@ -28,18 +29,18 @@ export const fxEventBox: ISchemaContainer<IWrapFxEventBoxAttribute, IFxEventFloa
       };
    },
    deserialize(data) {
-      return {
+      return createFxEventBox({
          filter: indexFilter.deserialize(data.data?.f ?? {}),
-         beatDistribution: data.data?.w ?? 0,
-         beatDistributionType: data.data?.d ?? 1,
-         fxDistribution: data.data?.s ?? 0,
-         fxDistributionType: data.data?.t ?? 1,
-         affectFirst: data.data?.b ?? 0,
-         easing: data.data?.i ?? 0,
+         beatDistribution: data.data?.w,
+         beatDistributionType: data.data?.d,
+         fxDistribution: data.data?.s,
+         fxDistributionType: data.data?.t,
+         affectFirst: data.data?.b,
+         easing: data.data?.i,
          events: data.eventData?.map((x) => {
             return fxEventFloat.deserialize(x);
-         }) ?? [],
-         customData: data.data?.customData ?? {},
-      };
+         }),
+         customData: data.data?.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v3/fxEventBox.ts
+++ b/src/beatmap/schema/v3/fxEventBox.ts
@@ -1,10 +1,9 @@
+import type { IFxEventFloatBoxContainer } from '../../../types/beatmap/container/v3.ts';
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IWrapFxEventBoxAttribute } from '../../../types/beatmap/wrapper/fxEventBox.ts';
-import type { DeepPartial } from '../../../types/utils.ts';
 import { deepCopy } from '../../../utils/misc.ts';
-import { indexFilter } from './indexFilter.ts';
 import { fxEventFloat } from './fxEventFloat.ts';
-import type { IFxEventFloatBoxContainer } from '../../../types/beatmap/container/v3.ts';
+import { indexFilter } from './indexFilter.ts';
 
 /**
  * Schema serialization for v3 `FX Event Box`.
@@ -23,22 +22,24 @@ export const fxEventBox: ISchemaContainer<IWrapFxEventBoxAttribute, IFxEventFloa
             l: [],
             customData: deepCopy(data.customData),
          },
-         eventData: data.events.map(fxEventFloat.serialize),
+         eventData: data.events.map((x) => {
+            return fxEventFloat.serialize(x);
+         }),
       };
    },
-   deserialize(
-      data: DeepPartial<IFxEventFloatBoxContainer> = {},
-   ): DeepPartial<IWrapFxEventBoxAttribute> {
+   deserialize(data) {
       return {
-         filter: indexFilter.deserialize(data.data?.f),
-         beatDistribution: data.data?.w,
-         beatDistributionType: data.data?.d,
-         fxDistribution: data.data?.s,
-         fxDistributionType: data.data?.t,
-         affectFirst: data.data?.b,
-         easing: data.data?.i,
-         events: data.eventData?.map(fxEventFloat.deserialize),
-         customData: data.data?.customData,
+         filter: indexFilter.deserialize(data.data?.f ?? {}),
+         beatDistribution: data.data?.w ?? 0,
+         beatDistributionType: data.data?.d ?? 1,
+         fxDistribution: data.data?.s ?? 0,
+         fxDistributionType: data.data?.t ?? 1,
+         affectFirst: data.data?.b ?? 0,
+         easing: data.data?.i ?? 0,
+         events: data.eventData?.map((x) => {
+            return fxEventFloat.deserialize(x);
+         }) ?? [],
+         customData: data.data?.customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v3/fxEventBoxGroup.ts
+++ b/src/beatmap/schema/v3/fxEventBoxGroup.ts
@@ -7,6 +7,7 @@ import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IFxEventBox } from '../../../types/beatmap/v3/fxEventBox.ts';
 import type { IWrapFxEventBoxGroupAttribute } from '../../../types/beatmap/wrapper/fxEventBoxGroup.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createFxEventBoxGroup } from '../../core/fxEventBoxGroup.ts';
 import { fxEventBox } from './fxEventBox.ts';
 
 /**
@@ -31,13 +32,13 @@ export const fxEventBoxGroup: ISchemaContainer<
       };
    },
    deserialize(data) {
-      return {
-         time: data.object?.b ?? 0,
-         id: data.object?.g ?? 0,
+      return createFxEventBoxGroup({
+         time: data.object?.b,
+         id: data.object?.g,
          boxes: data.boxData?.map((x) => {
             return fxEventBox.deserialize(x);
-         }) ?? [],
-         customData: data.object?.customData ?? {},
-      };
+         }),
+         customData: data.object?.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v3/fxEventBoxGroup.ts
+++ b/src/beatmap/schema/v3/fxEventBoxGroup.ts
@@ -1,14 +1,13 @@
-import type { DeepPartial } from '../../../types/utils.ts';
-import { fxEventBox } from './fxEventBox.ts';
-import { deepCopy } from '../../../utils/misc.ts';
-import type { IFxEventBox } from '../../../types/beatmap/v3/fxEventBox.ts';
-import type { IWrapFxEventBoxGroupAttribute } from '../../../types/beatmap/wrapper/fxEventBoxGroup.ts';
 import type {
    IEventBoxGroupContainer,
    IFxEventFloatBoxContainer,
 } from '../../../types/beatmap/container/v3.ts';
 import { FxType } from '../../../types/beatmap/shared/constants.ts';
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
+import type { IFxEventBox } from '../../../types/beatmap/v3/fxEventBox.ts';
+import type { IWrapFxEventBoxGroupAttribute } from '../../../types/beatmap/wrapper/fxEventBoxGroup.ts';
+import { deepCopy } from '../../../utils/misc.ts';
+import { fxEventBox } from './fxEventBox.ts';
 
 /**
  * Schema serialization for v3 `FX Event Box Group`.
@@ -17,9 +16,7 @@ export const fxEventBoxGroup: ISchemaContainer<
    IWrapFxEventBoxGroupAttribute,
    IEventBoxGroupContainer<IFxEventBox, IFxEventFloatBoxContainer>
 > = {
-   serialize(
-      data: IWrapFxEventBoxGroupAttribute,
-   ): IEventBoxGroupContainer<IFxEventBox, IFxEventFloatBoxContainer> {
+   serialize(data) {
       return {
          object: {
             t: FxType.FLOAT,
@@ -28,17 +25,19 @@ export const fxEventBoxGroup: ISchemaContainer<
             e: [],
             customData: deepCopy(data.customData),
          },
-         boxData: data.boxes.map(fxEventBox.serialize),
+         boxData: data.boxes.map((x) => {
+            return fxEventBox.serialize(x);
+         }),
       };
    },
-   deserialize(
-      data: DeepPartial<IEventBoxGroupContainer<IFxEventBox, IFxEventFloatBoxContainer>> = {},
-   ): DeepPartial<IWrapFxEventBoxGroupAttribute> {
-      const d: DeepPartial<IWrapFxEventBoxGroupAttribute> = {};
-      d.time = data.object?.b;
-      d.id = data.object?.g;
-      d.boxes = data.boxData?.map(fxEventBox.deserialize);
-      d.customData = data.object?.customData;
-      return d;
+   deserialize(data) {
+      return {
+         time: data.object?.b ?? 0,
+         id: data.object?.g ?? 0,
+         boxes: data.boxData?.map((x) => {
+            return fxEventBox.deserialize(x);
+         }) ?? [],
+         customData: data.object?.customData ?? {},
+      };
    },
 };

--- a/src/beatmap/schema/v3/fxEventFloat.ts
+++ b/src/beatmap/schema/v3/fxEventFloat.ts
@@ -7,7 +7,7 @@ import { deepCopy } from '../../../utils/misc.ts';
  * Schema serialization for v3 `FX Event Float`.
  */
 export const fxEventFloat: ISchemaContainer<IWrapFxEventFloatAttribute, IFxEventFloat> = {
-   serialize(data: IWrapFxEventFloatAttribute): IFxEventFloat {
+   serialize(data) {
       return {
          b: data.time,
          i: data.easing,
@@ -16,13 +16,13 @@ export const fxEventFloat: ISchemaContainer<IWrapFxEventFloatAttribute, IFxEvent
          customData: deepCopy(data.customData),
       };
    },
-   deserialize(data: Partial<IFxEventFloat> = {}): Partial<IWrapFxEventFloatAttribute> {
+   deserialize(data) {
       return {
-         time: data.b,
-         easing: data.i,
-         previous: data.p,
-         value: data.v,
-         customData: data.customData,
+         time: data.b ?? 0,
+         easing: data.i ?? 0,
+         previous: data.p ?? 0,
+         value: data.v ?? 0,
+         customData: data.customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v3/fxEventFloat.ts
+++ b/src/beatmap/schema/v3/fxEventFloat.ts
@@ -2,6 +2,7 @@ import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IFxEventFloat } from '../../../types/beatmap/v3/fxEventFloat.ts';
 import type { IWrapFxEventFloatAttribute } from '../../../types/beatmap/wrapper/fxEventFloat.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createFxEventFloat } from '../../core/fxEventFloat.ts';
 
 /**
  * Schema serialization for v3 `FX Event Float`.
@@ -17,12 +18,12 @@ export const fxEventFloat: ISchemaContainer<IWrapFxEventFloatAttribute, IFxEvent
       };
    },
    deserialize(data) {
-      return {
-         time: data.b ?? 0,
-         easing: data.i ?? 0,
-         previous: data.p ?? 0,
-         value: data.v ?? 0,
-         customData: data.customData ?? {},
-      };
+      return createFxEventFloat({
+         time: data.b,
+         easing: data.i,
+         previous: data.p,
+         value: data.v,
+         customData: data.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v3/fxEventInt.ts
+++ b/src/beatmap/schema/v3/fxEventInt.ts
@@ -7,7 +7,7 @@ import { deepCopy } from '../../../utils/misc.ts';
  * Schema serialization for v3 `FX Event Int`.
  */
 export const fxEventInt: ISchemaContainer<IWrapFxEventIntAttribute, IFxEventInt> = {
-   serialize(data: IWrapFxEventIntAttribute): IFxEventInt {
+   serialize(data) {
       return {
          b: data.time,
          p: data.previous,
@@ -15,12 +15,12 @@ export const fxEventInt: ISchemaContainer<IWrapFxEventIntAttribute, IFxEventInt>
          customData: deepCopy(data.customData),
       };
    },
-   deserialize(data: Partial<IFxEventInt> = {}): Partial<IWrapFxEventIntAttribute> {
+   deserialize(data) {
       return {
-         time: data.b,
-         previous: data.p,
-         value: data.v,
-         customData: data.customData,
+         time: data.b ?? 0,
+         previous: data.p ?? 0,
+         value: data.v ?? 0,
+         customData: data.customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v3/fxEventInt.ts
+++ b/src/beatmap/schema/v3/fxEventInt.ts
@@ -2,6 +2,7 @@ import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IFxEventInt } from '../../../types/beatmap/v3/fxEventInt.ts';
 import type { IWrapFxEventIntAttribute } from '../../../types/beatmap/wrapper/fxEventInt.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createFxEventInt } from '../../core/fxEventInt.ts';
 
 /**
  * Schema serialization for v3 `FX Event Int`.
@@ -16,11 +17,11 @@ export const fxEventInt: ISchemaContainer<IWrapFxEventIntAttribute, IFxEventInt>
       };
    },
    deserialize(data) {
-      return {
-         time: data.b ?? 0,
-         previous: data.p ?? 0,
-         value: data.v ?? 0,
-         customData: data.customData ?? {},
-      };
+      return createFxEventInt({
+         time: data.b,
+         previous: data.p,
+         value: data.v,
+         customData: data.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v3/indexFilter.ts
+++ b/src/beatmap/schema/v3/indexFilter.ts
@@ -7,7 +7,7 @@ import { deepCopy } from '../../../utils/misc.ts';
  * Schema serialization for v3 `Index Filter`.
  */
 export const indexFilter: ISchemaContainer<IWrapIndexFilterAttribute, IIndexFilter> = {
-   serialize(data: IWrapIndexFilterAttribute): Required<IIndexFilter> {
+   serialize(data) {
       return {
          f: data.type,
          p: data.p0,
@@ -21,18 +21,18 @@ export const indexFilter: ISchemaContainer<IWrapIndexFilterAttribute, IIndexFilt
          customData: deepCopy(data.customData),
       };
    },
-   deserialize(data: Partial<IIndexFilter> = {}): Partial<IWrapIndexFilterAttribute> {
+   deserialize(data) {
       return {
-         type: data.f,
-         p0: data.p,
-         p1: data.t,
-         reverse: data.r,
-         chunks: data.c,
-         random: data.n,
-         seed: data.s,
-         limit: data.l,
-         limitAffectsType: data.d,
-         customData: data.customData,
+         type: data.f ?? 1,
+         p0: data.p ?? 0,
+         p1: data.t ?? 0,
+         reverse: data.r ?? 0,
+         chunks: data.c ?? 0,
+         random: data.n ?? 0,
+         seed: data.s ?? 0,
+         limit: data.l ?? 0,
+         limitAffectsType: data.d ?? 0,
+         customData: data.customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v3/indexFilter.ts
+++ b/src/beatmap/schema/v3/indexFilter.ts
@@ -2,6 +2,7 @@ import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IIndexFilter } from '../../../types/beatmap/v3/indexFilter.ts';
 import type { IWrapIndexFilterAttribute } from '../../../types/beatmap/wrapper/indexFilter.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createIndexFilter } from '../../core/indexFilter.ts';
 
 /**
  * Schema serialization for v3 `Index Filter`.
@@ -22,17 +23,17 @@ export const indexFilter: ISchemaContainer<IWrapIndexFilterAttribute, IIndexFilt
       };
    },
    deserialize(data) {
-      return {
-         type: data.f ?? 1,
-         p0: data.p ?? 0,
-         p1: data.t ?? 0,
-         reverse: data.r ?? 0,
-         chunks: data.c ?? 0,
-         random: data.n ?? 0,
-         seed: data.s ?? 0,
-         limit: data.l ?? 0,
-         limitAffectsType: data.d ?? 0,
-         customData: data.customData ?? {},
-      };
+      return createIndexFilter({
+         type: data.f,
+         p0: data.p,
+         p1: data.t,
+         reverse: data.r,
+         chunks: data.c,
+         random: data.n,
+         seed: data.s,
+         limit: data.l,
+         limitAffectsType: data.d,
+         customData: data.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v3/lightColorEvent.ts
+++ b/src/beatmap/schema/v3/lightColorEvent.ts
@@ -8,7 +8,7 @@ import { EaseType, TransitionType } from '../../shared/constants.ts';
  * Schema serialization for v3 `Light Color Event`.
  */
 export const lightColorEvent: ISchemaContainer<IWrapLightColorEventAttribute, ILightColorEvent> = {
-   serialize(data: IWrapLightColorEventAttribute): ILightColorEvent {
+   serialize(data) {
       return {
          b: data.time,
          c: data.color,
@@ -24,17 +24,17 @@ export const lightColorEvent: ISchemaContainer<IWrapLightColorEventAttribute, IL
          customData: deepCopy(data.customData),
       };
    },
-   deserialize(data: Partial<ILightColorEvent> = {}): Partial<IWrapLightColorEventAttribute> {
+   deserialize(data) {
       return {
-         time: data.b,
-         color: data.c,
-         frequency: data.f,
+         time: data.b ?? 0,
+         color: data.c ?? 0,
+         frequency: data.f ?? 0,
          previous: data.i === TransitionType.EXTEND ? 1 : 0,
          easing: data.i === TransitionType.INTERPOLATE ? EaseType.LINEAR : EaseType.NONE,
-         brightness: data.s,
-         strobeBrightness: data.sb,
-         strobeFade: data.sf,
-         customData: data.customData,
+         brightness: data.s ?? 0,
+         strobeBrightness: data.sb ?? 0,
+         strobeFade: data.sf ?? 0,
+         customData: data.customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v3/lightColorEvent.ts
+++ b/src/beatmap/schema/v3/lightColorEvent.ts
@@ -2,6 +2,7 @@ import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { ILightColorEvent } from '../../../types/beatmap/v3/lightColorEvent.ts';
 import type { IWrapLightColorEventAttribute } from '../../../types/beatmap/wrapper/lightColorEvent.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createLightColorEvent } from '../../core/lightColorEvent.ts';
 import { EaseType, TransitionType } from '../../shared/constants.ts';
 
 /**
@@ -25,16 +26,16 @@ export const lightColorEvent: ISchemaContainer<IWrapLightColorEventAttribute, IL
       };
    },
    deserialize(data) {
-      return {
-         time: data.b ?? 0,
-         color: data.c ?? 0,
-         frequency: data.f ?? 0,
+      return createLightColorEvent({
+         time: data.b,
+         color: data.c,
+         frequency: data.f,
          previous: data.i === TransitionType.EXTEND ? 1 : 0,
          easing: data.i === TransitionType.INTERPOLATE ? EaseType.LINEAR : EaseType.NONE,
-         brightness: data.s ?? 0,
-         strobeBrightness: data.sb ?? 0,
-         strobeFade: data.sf ?? 0,
-         customData: data.customData ?? {},
-      };
+         brightness: data.s,
+         strobeBrightness: data.sb,
+         strobeFade: data.sf,
+         customData: data.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v3/lightColorEventBox.ts
+++ b/src/beatmap/schema/v3/lightColorEventBox.ts
@@ -1,7 +1,6 @@
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { ILightColorEventBox } from '../../../types/beatmap/v3/lightColorEventBox.ts';
 import type { IWrapLightColorEventBoxAttribute } from '../../../types/beatmap/wrapper/lightColorEventBox.ts';
-import type { DeepPartial } from '../../../types/utils.ts';
 import { deepCopy } from '../../../utils/misc.ts';
 import { indexFilter } from './indexFilter.ts';
 import { lightColorEvent } from './lightColorEvent.ts';
@@ -13,7 +12,7 @@ export const lightColorEventBox: ISchemaContainer<
    IWrapLightColorEventBoxAttribute,
    ILightColorEventBox
 > = {
-   serialize(data: IWrapLightColorEventBoxAttribute): ILightColorEventBox {
+   serialize(data) {
       return {
          f: indexFilter.serialize(data.filter),
          w: data.beatDistribution,
@@ -22,23 +21,25 @@ export const lightColorEventBox: ISchemaContainer<
          t: data.brightnessDistributionType,
          b: data.affectFirst,
          i: data.easing,
-         e: data.events.map(lightColorEvent.serialize),
+         e: data.events.map((x) => {
+            return lightColorEvent.serialize(x);
+         }),
          customData: deepCopy(data.customData),
       };
    },
-   deserialize(
-      data: DeepPartial<ILightColorEventBox> = {},
-   ): DeepPartial<IWrapLightColorEventBoxAttribute> {
+   deserialize(data) {
       return {
-         filter: indexFilter.deserialize(data.f),
-         beatDistribution: data.w,
-         beatDistributionType: data.d,
-         brightnessDistribution: data.r,
-         brightnessDistributionType: data.t,
-         affectFirst: data.b,
-         easing: data.i,
-         events: data.e?.map(lightColorEvent.deserialize),
-         customData: data.customData,
+         filter: indexFilter.deserialize(data.f ?? {}),
+         beatDistribution: data.w ?? 0,
+         beatDistributionType: data.d ?? 1,
+         brightnessDistribution: data.r ?? 0,
+         brightnessDistributionType: data.t ?? 1,
+         affectFirst: data.b ?? 0,
+         easing: data.i ?? 0,
+         events: data.e?.map((x) => {
+            return lightColorEvent.deserialize(x);
+         }) ?? [],
+         customData: data.customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v3/lightColorEventBox.ts
+++ b/src/beatmap/schema/v3/lightColorEventBox.ts
@@ -2,6 +2,7 @@ import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { ILightColorEventBox } from '../../../types/beatmap/v3/lightColorEventBox.ts';
 import type { IWrapLightColorEventBoxAttribute } from '../../../types/beatmap/wrapper/lightColorEventBox.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createLightColorEventBox } from '../../core/lightColorEventBox.ts';
 import { indexFilter } from './indexFilter.ts';
 import { lightColorEvent } from './lightColorEvent.ts';
 
@@ -28,18 +29,18 @@ export const lightColorEventBox: ISchemaContainer<
       };
    },
    deserialize(data) {
-      return {
+      return createLightColorEventBox({
          filter: indexFilter.deserialize(data.f ?? {}),
-         beatDistribution: data.w ?? 0,
-         beatDistributionType: data.d ?? 1,
-         brightnessDistribution: data.r ?? 0,
-         brightnessDistributionType: data.t ?? 1,
-         affectFirst: data.b ?? 0,
-         easing: data.i ?? 0,
+         beatDistribution: data.w,
+         beatDistributionType: data.d,
+         brightnessDistribution: data.r,
+         brightnessDistributionType: data.t,
+         affectFirst: data.b,
+         easing: data.i,
          events: data.e?.map((x) => {
             return lightColorEvent.deserialize(x);
-         }) ?? [],
-         customData: data.customData ?? {},
-      };
+         }),
+         customData: data.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v3/lightColorEventBoxGroup.ts
+++ b/src/beatmap/schema/v3/lightColorEventBoxGroup.ts
@@ -1,7 +1,6 @@
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { ILightColorEventBoxGroup } from '../../../types/beatmap/v3/lightColorEventBoxGroup.ts';
 import type { IWrapLightColorEventBoxGroupAttribute } from '../../../types/beatmap/wrapper/lightColorEventBoxGroup.ts';
-import type { DeepPartial } from '../../../types/utils.ts';
 import { deepCopy } from '../../../utils/misc.ts';
 import { lightColorEventBox } from './lightColorEventBox.ts';
 
@@ -12,22 +11,24 @@ export const lightColorEventBoxGroup: ISchemaContainer<
    IWrapLightColorEventBoxGroupAttribute,
    ILightColorEventBoxGroup
 > = {
-   serialize(data: IWrapLightColorEventBoxGroupAttribute): ILightColorEventBoxGroup {
+   serialize(data) {
       return {
          b: data.time,
          g: data.id,
-         e: data.boxes.map(lightColorEventBox.serialize),
+         e: data.boxes.map((x) => {
+            return lightColorEventBox.serialize(x);
+         }),
          customData: deepCopy(data.customData),
       };
    },
-   deserialize(
-      data: DeepPartial<ILightColorEventBoxGroup> = {},
-   ): DeepPartial<IWrapLightColorEventBoxGroupAttribute> {
+   deserialize(data) {
       return {
-         time: data.b,
-         id: data.g,
-         boxes: data.e?.map(lightColorEventBox.deserialize),
-         customData: data.customData,
+         time: data.b ?? 0,
+         id: data.g ?? 0,
+         boxes: data.e?.map((x) => {
+            return lightColorEventBox.deserialize(x);
+         }) ?? [],
+         customData: data.customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v3/lightColorEventBoxGroup.ts
+++ b/src/beatmap/schema/v3/lightColorEventBoxGroup.ts
@@ -2,6 +2,7 @@ import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { ILightColorEventBoxGroup } from '../../../types/beatmap/v3/lightColorEventBoxGroup.ts';
 import type { IWrapLightColorEventBoxGroupAttribute } from '../../../types/beatmap/wrapper/lightColorEventBoxGroup.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createLightColorEventBoxGroup } from '../../core/lightColorEventBoxGroup.ts';
 import { lightColorEventBox } from './lightColorEventBox.ts';
 
 /**
@@ -22,13 +23,13 @@ export const lightColorEventBoxGroup: ISchemaContainer<
       };
    },
    deserialize(data) {
-      return {
-         time: data.b ?? 0,
-         id: data.g ?? 0,
+      return createLightColorEventBoxGroup({
+         time: data.b,
+         id: data.g,
          boxes: data.e?.map((x) => {
             return lightColorEventBox.deserialize(x);
-         }) ?? [],
-         customData: data.customData ?? {},
-      };
+         }),
+         customData: data.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v3/lightRotationEvent.ts
+++ b/src/beatmap/schema/v3/lightRotationEvent.ts
@@ -2,6 +2,7 @@ import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { ILightRotationEvent } from '../../../types/beatmap/v3/lightRotationEvent.ts';
 import type { IWrapLightRotationEventAttribute } from '../../../types/beatmap/wrapper/lightRotationEvent.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createLightRotationEvent } from '../../core/lightRotationEvent.ts';
 
 /**
  * Schema serialization for v3 `Light Rotation Event`.
@@ -22,14 +23,14 @@ export const lightRotationEvent: ISchemaContainer<
       };
    },
    deserialize(data) {
-      return {
-         time: data.b ?? 0,
-         easing: data.e ?? 0,
-         loop: data.l ?? 0,
-         direction: data.o ?? 0,
-         previous: data.p ?? 0,
-         rotation: data.r ?? 0,
-         customData: data.customData ?? {},
-      };
+      return createLightRotationEvent({
+         time: data.b,
+         easing: data.e,
+         loop: data.l,
+         direction: data.o,
+         previous: data.p,
+         rotation: data.r,
+         customData: data.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v3/lightRotationEvent.ts
+++ b/src/beatmap/schema/v3/lightRotationEvent.ts
@@ -10,7 +10,7 @@ export const lightRotationEvent: ISchemaContainer<
    IWrapLightRotationEventAttribute,
    ILightRotationEvent
 > = {
-   serialize(data: IWrapLightRotationEventAttribute): ILightRotationEvent {
+   serialize(data) {
       return {
          b: data.time,
          e: data.easing,
@@ -21,15 +21,15 @@ export const lightRotationEvent: ISchemaContainer<
          customData: deepCopy(data.customData),
       };
    },
-   deserialize(data: Partial<ILightRotationEvent> = {}): Partial<IWrapLightRotationEventAttribute> {
+   deserialize(data) {
       return {
-         time: data.b,
-         easing: data.e,
-         loop: data.l,
-         direction: data.o,
-         previous: data.p,
-         rotation: data.r,
-         customData: data.customData,
+         time: data.b ?? 0,
+         easing: data.e ?? 0,
+         loop: data.l ?? 0,
+         direction: data.o ?? 0,
+         previous: data.p ?? 0,
+         rotation: data.r ?? 0,
+         customData: data.customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v3/lightRotationEventBox.ts
+++ b/src/beatmap/schema/v3/lightRotationEventBox.ts
@@ -2,6 +2,7 @@ import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { ILightRotationEventBox } from '../../../types/beatmap/v3/lightRotationEventBox.ts';
 import type { IWrapLightRotationEventBoxAttribute } from '../../../types/beatmap/wrapper/lightRotationEventBox.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createLightRotationEventBox } from '../../core/lightRotationEventBox.ts';
 import { indexFilter } from './indexFilter.ts';
 import { lightRotationEvent } from './lightRotationEvent.ts';
 
@@ -30,20 +31,20 @@ export const lightRotationEventBox: ISchemaContainer<
       };
    },
    deserialize(data) {
-      return {
+      return createLightRotationEventBox({
          filter: indexFilter.deserialize(data.f ?? {}),
-         beatDistribution: data.w ?? 0,
-         beatDistributionType: data.d ?? 1,
-         rotationDistribution: data.s ?? 0,
-         rotationDistributionType: data.t ?? 1,
-         axis: data.a ?? 0,
-         flip: data.r ?? 0,
-         affectFirst: data.b ?? 0,
-         easing: data.i ?? 0,
+         beatDistribution: data.w,
+         beatDistributionType: data.d,
+         rotationDistribution: data.s,
+         rotationDistributionType: data.t,
+         axis: data.a,
+         flip: data.r,
+         affectFirst: data.b,
+         easing: data.i,
          events: data.l?.map((x) => {
             return lightRotationEvent.deserialize(x);
-         }) ?? [],
-         customData: data.customData ?? {},
-      };
+         }),
+         customData: data.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v3/lightRotationEventBox.ts
+++ b/src/beatmap/schema/v3/lightRotationEventBox.ts
@@ -1,7 +1,6 @@
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { ILightRotationEventBox } from '../../../types/beatmap/v3/lightRotationEventBox.ts';
 import type { IWrapLightRotationEventBoxAttribute } from '../../../types/beatmap/wrapper/lightRotationEventBox.ts';
-import type { DeepPartial } from '../../../types/utils.ts';
 import { deepCopy } from '../../../utils/misc.ts';
 import { indexFilter } from './indexFilter.ts';
 import { lightRotationEvent } from './lightRotationEvent.ts';
@@ -13,7 +12,7 @@ export const lightRotationEventBox: ISchemaContainer<
    IWrapLightRotationEventBoxAttribute,
    ILightRotationEventBox
 > = {
-   serialize(data: IWrapLightRotationEventBoxAttribute): ILightRotationEventBox {
+   serialize(data) {
       return {
          f: indexFilter.serialize(data.filter),
          w: data.beatDistribution,
@@ -24,25 +23,27 @@ export const lightRotationEventBox: ISchemaContainer<
          r: data.flip,
          b: data.affectFirst,
          i: data.easing,
-         l: data.events.map(lightRotationEvent.serialize),
+         l: data.events.map((x) => {
+            return lightRotationEvent.serialize(x);
+         }),
          customData: deepCopy(data.customData),
       };
    },
-   deserialize(
-      data: DeepPartial<ILightRotationEventBox> = {},
-   ): DeepPartial<IWrapLightRotationEventBoxAttribute> {
+   deserialize(data) {
       return {
-         filter: indexFilter.deserialize(data.f),
-         beatDistribution: data.w,
-         beatDistributionType: data.d,
-         rotationDistribution: data.s,
-         rotationDistributionType: data.t,
-         axis: data.a,
-         flip: data.r,
-         affectFirst: data.b,
-         easing: data.i,
-         events: data.l?.map(lightRotationEvent.deserialize),
-         customData: data.customData,
+         filter: indexFilter.deserialize(data.f ?? {}),
+         beatDistribution: data.w ?? 0,
+         beatDistributionType: data.d ?? 1,
+         rotationDistribution: data.s ?? 0,
+         rotationDistributionType: data.t ?? 1,
+         axis: data.a ?? 0,
+         flip: data.r ?? 0,
+         affectFirst: data.b ?? 0,
+         easing: data.i ?? 0,
+         events: data.l?.map((x) => {
+            return lightRotationEvent.deserialize(x);
+         }) ?? [],
+         customData: data.customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v3/lightRotationEventBoxGroup.ts
+++ b/src/beatmap/schema/v3/lightRotationEventBoxGroup.ts
@@ -2,6 +2,7 @@ import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { ILightRotationEventBoxGroup } from '../../../types/beatmap/v3/lightRotationEventBoxGroup.ts';
 import type { IWrapLightRotationEventBoxGroupAttribute } from '../../../types/beatmap/wrapper/lightRotationEventBoxGroup.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createLightRotationEventBoxGroup } from '../../core/lightRotationEventBoxGroup.ts';
 import { lightRotationEventBox } from './lightRotationEventBox.ts';
 
 /**
@@ -22,13 +23,13 @@ export const lightRotationEventBoxGroup: ISchemaContainer<
       };
    },
    deserialize(data) {
-      return {
-         time: data.b ?? 0,
-         id: data.g ?? 0,
+      return createLightRotationEventBoxGroup({
+         time: data.b,
+         id: data.g,
          boxes: data.e?.map((x) => {
             return lightRotationEventBox.deserialize(x);
-         }) ?? [],
-         customData: data.customData ?? {},
-      };
+         }),
+         customData: data.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v3/lightRotationEventBoxGroup.ts
+++ b/src/beatmap/schema/v3/lightRotationEventBoxGroup.ts
@@ -1,9 +1,8 @@
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { ILightRotationEventBoxGroup } from '../../../types/beatmap/v3/lightRotationEventBoxGroup.ts';
-import type { DeepPartial } from '../../../types/utils.ts';
-import { lightRotationEventBox } from './lightRotationEventBox.ts';
-import { deepCopy } from '../../../utils/misc.ts';
 import type { IWrapLightRotationEventBoxGroupAttribute } from '../../../types/beatmap/wrapper/lightRotationEventBoxGroup.ts';
+import { deepCopy } from '../../../utils/misc.ts';
+import { lightRotationEventBox } from './lightRotationEventBox.ts';
 
 /**
  * Schema serialization for v3 `Light Rotation Event Box Group`.
@@ -12,22 +11,24 @@ export const lightRotationEventBoxGroup: ISchemaContainer<
    IWrapLightRotationEventBoxGroupAttribute,
    ILightRotationEventBoxGroup
 > = {
-   serialize(data: IWrapLightRotationEventBoxGroupAttribute): ILightRotationEventBoxGroup {
+   serialize(data) {
       return {
          b: data.time,
          g: data.id,
-         e: data.boxes.map(lightRotationEventBox.serialize),
+         e: data.boxes.map((x) => {
+            return lightRotationEventBox.serialize(x);
+         }),
          customData: deepCopy(data.customData),
       };
    },
-   deserialize(
-      data: DeepPartial<ILightRotationEventBoxGroup> = {},
-   ): DeepPartial<IWrapLightRotationEventBoxGroupAttribute> {
+   deserialize(data) {
       return {
-         time: data.b,
-         id: data.g,
-         boxes: data.e?.map(lightRotationEventBox.deserialize),
-         customData: data.customData,
+         time: data.b ?? 0,
+         id: data.g ?? 0,
+         boxes: data.e?.map((x) => {
+            return lightRotationEventBox.deserialize(x);
+         }) ?? [],
+         customData: data.customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v3/lightTranslationEvent.ts
+++ b/src/beatmap/schema/v3/lightTranslationEvent.ts
@@ -2,6 +2,7 @@ import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { ILightTranslationEvent } from '../../../types/beatmap/v3/lightTranslationEvent.ts';
 import type { IWrapLightTranslationEventAttribute } from '../../../types/beatmap/wrapper/lightTranslationEvent.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createLightTranslationEvent } from '../../core/lightTranslationEvent.ts';
 
 /**
  * Schema serialization for v3 `Light Translation Event`.
@@ -20,12 +21,12 @@ export const lightTranslationEvent: ISchemaContainer<
       };
    },
    deserialize(data) {
-      return {
-         time: data.b ?? 0,
-         easing: data.e ?? 0,
-         previous: data.p ?? 0,
-         translation: data.t ?? 0,
-         customData: data.customData ?? {},
-      };
+      return createLightTranslationEvent({
+         time: data.b,
+         easing: data.e,
+         previous: data.p,
+         translation: data.t,
+         customData: data.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v3/lightTranslationEvent.ts
+++ b/src/beatmap/schema/v3/lightTranslationEvent.ts
@@ -10,7 +10,7 @@ export const lightTranslationEvent: ISchemaContainer<
    IWrapLightTranslationEventAttribute,
    ILightTranslationEvent
 > = {
-   serialize(data: IWrapLightTranslationEventAttribute): ILightTranslationEvent {
+   serialize(data) {
       return {
          b: data.time,
          e: data.easing,
@@ -19,15 +19,13 @@ export const lightTranslationEvent: ISchemaContainer<
          customData: deepCopy(data.customData),
       };
    },
-   deserialize(
-      data: Partial<ILightTranslationEvent> = {},
-   ): Partial<IWrapLightTranslationEventAttribute> {
+   deserialize(data) {
       return {
-         time: data.b,
-         easing: data.e,
-         previous: data.p,
-         translation: data.t,
-         customData: data.customData,
+         time: data.b ?? 0,
+         easing: data.e ?? 0,
+         previous: data.p ?? 0,
+         translation: data.t ?? 0,
+         customData: data.customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v3/lightTranslationEventBox.ts
+++ b/src/beatmap/schema/v3/lightTranslationEventBox.ts
@@ -2,6 +2,7 @@ import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { ILightTranslationEventBox } from '../../../types/beatmap/v3/lightTranslationEventBox.ts';
 import type { IWrapLightTranslationEventBoxAttribute } from '../../../types/beatmap/wrapper/lightTranslationEventBox.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createLightTranslationEventBox } from '../../core/lightTranslationEventBox.ts';
 import { indexFilter } from './indexFilter.ts';
 import { lightTranslationEvent } from './lightTranslationEvent.ts';
 
@@ -30,20 +31,20 @@ export const lightTranslationEventBox: ISchemaContainer<
       };
    },
    deserialize(data) {
-      return {
+      return createLightTranslationEventBox({
          filter: indexFilter.deserialize(data.f ?? {}),
-         beatDistribution: data.w ?? 0,
-         beatDistributionType: data.d ?? 1,
-         gapDistribution: data.s ?? 0,
-         gapDistributionType: data.t ?? 1,
-         axis: data.a ?? 0,
-         flip: data.r ?? 0,
-         affectFirst: data.b ?? 0,
-         easing: data.i ?? 0,
+         beatDistribution: data.w,
+         beatDistributionType: data.d,
+         gapDistribution: data.s,
+         gapDistributionType: data.t,
+         axis: data.a,
+         flip: data.r,
+         affectFirst: data.b,
+         easing: data.i,
          events: data.l?.map((x) => {
             return lightTranslationEvent.deserialize(x);
-         }) ?? [],
-         customData: data.customData ?? {},
-      };
+         }),
+         customData: data.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v3/lightTranslationEventBox.ts
+++ b/src/beatmap/schema/v3/lightTranslationEventBox.ts
@@ -1,7 +1,6 @@
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { ILightTranslationEventBox } from '../../../types/beatmap/v3/lightTranslationEventBox.ts';
 import type { IWrapLightTranslationEventBoxAttribute } from '../../../types/beatmap/wrapper/lightTranslationEventBox.ts';
-import type { DeepPartial } from '../../../types/utils.ts';
 import { deepCopy } from '../../../utils/misc.ts';
 import { indexFilter } from './indexFilter.ts';
 import { lightTranslationEvent } from './lightTranslationEvent.ts';
@@ -13,7 +12,7 @@ export const lightTranslationEventBox: ISchemaContainer<
    IWrapLightTranslationEventBoxAttribute,
    ILightTranslationEventBox
 > = {
-   serialize(data: IWrapLightTranslationEventBoxAttribute): ILightTranslationEventBox {
+   serialize(data) {
       return {
          f: indexFilter.serialize(data.filter),
          w: data.beatDistribution,
@@ -24,25 +23,27 @@ export const lightTranslationEventBox: ISchemaContainer<
          r: data.flip,
          b: data.affectFirst,
          i: data.easing,
-         l: data.events.map(lightTranslationEvent.serialize),
+         l: data.events.map((x) => {
+            return lightTranslationEvent.serialize(x);
+         }),
          customData: deepCopy(data.customData),
       };
    },
-   deserialize(
-      data: DeepPartial<ILightTranslationEventBox> = {},
-   ): DeepPartial<IWrapLightTranslationEventBoxAttribute> {
+   deserialize(data) {
       return {
-         filter: indexFilter.deserialize(data.f),
-         beatDistribution: data.w,
-         beatDistributionType: data.d,
-         gapDistribution: data.s,
-         gapDistributionType: data.t,
-         axis: data.a,
-         flip: data.r,
-         affectFirst: data.b,
-         easing: data.i,
-         events: data.l?.map(lightTranslationEvent.deserialize),
-         customData: data.customData,
+         filter: indexFilter.deserialize(data.f ?? {}),
+         beatDistribution: data.w ?? 0,
+         beatDistributionType: data.d ?? 1,
+         gapDistribution: data.s ?? 0,
+         gapDistributionType: data.t ?? 1,
+         axis: data.a ?? 0,
+         flip: data.r ?? 0,
+         affectFirst: data.b ?? 0,
+         easing: data.i ?? 0,
+         events: data.l?.map((x) => {
+            return lightTranslationEvent.deserialize(x);
+         }) ?? [],
+         customData: data.customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v3/lightTranslationEventBoxGroup.ts
+++ b/src/beatmap/schema/v3/lightTranslationEventBoxGroup.ts
@@ -1,8 +1,7 @@
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { ILightTranslationEventBoxGroup } from '../../../types/beatmap/v3/lightTranslationEventBoxGroup.ts';
-import type { DeepPartial } from '../../../types/utils.ts';
-import { deepCopy } from '../../../utils/misc.ts';
 import type { IWrapLightTranslationEventBoxGroupAttribute } from '../../../types/beatmap/wrapper/lightTranslationEventBoxGroup.ts';
+import { deepCopy } from '../../../utils/misc.ts';
 import { lightTranslationEventBox } from './lightTranslationEventBox.ts';
 
 /**
@@ -12,22 +11,24 @@ export const lightTranslationEventBoxGroup: ISchemaContainer<
    IWrapLightTranslationEventBoxGroupAttribute,
    ILightTranslationEventBoxGroup
 > = {
-   serialize(data: IWrapLightTranslationEventBoxGroupAttribute): ILightTranslationEventBoxGroup {
+   serialize(data) {
       return {
          b: data.time,
          g: data.id,
-         e: data.boxes.map(lightTranslationEventBox.serialize),
+         e: data.boxes.map((x) => {
+            return lightTranslationEventBox.serialize(x);
+         }),
          customData: deepCopy(data.customData),
       };
    },
-   deserialize(
-      data: DeepPartial<ILightTranslationEventBoxGroup> = {},
-   ): DeepPartial<IWrapLightTranslationEventBoxGroupAttribute> {
+   deserialize(data) {
       return {
-         time: data.b,
-         id: data.g,
-         boxes: data.e?.map(lightTranslationEventBox.deserialize),
-         customData: data.customData,
+         time: data.b ?? 0,
+         id: data.g ?? 0,
+         boxes: data.e?.map((x) => {
+            return lightTranslationEventBox.deserialize(x);
+         }) ?? [],
+         customData: data.customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v3/lightTranslationEventBoxGroup.ts
+++ b/src/beatmap/schema/v3/lightTranslationEventBoxGroup.ts
@@ -2,6 +2,7 @@ import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { ILightTranslationEventBoxGroup } from '../../../types/beatmap/v3/lightTranslationEventBoxGroup.ts';
 import type { IWrapLightTranslationEventBoxGroupAttribute } from '../../../types/beatmap/wrapper/lightTranslationEventBoxGroup.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createLightTranslationEventBoxGroup } from '../../core/lightTranslationEventBoxGroup.ts';
 import { lightTranslationEventBox } from './lightTranslationEventBox.ts';
 
 /**
@@ -22,13 +23,13 @@ export const lightTranslationEventBoxGroup: ISchemaContainer<
       };
    },
    deserialize(data) {
-      return {
-         time: data.b ?? 0,
-         id: data.g ?? 0,
+      return createLightTranslationEventBoxGroup({
+         time: data.b,
+         id: data.g,
          boxes: data.e?.map((x) => {
             return lightTranslationEventBox.deserialize(x);
-         }) ?? [],
-         customData: data.customData ?? {},
-      };
+         }),
+         customData: data.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v3/obstacle.ts
+++ b/src/beatmap/schema/v3/obstacle.ts
@@ -7,7 +7,7 @@ import { deepCopy } from '../../../utils/misc.ts';
  * Schema serialization for v3 `Obstacle`.
  */
 export const obstacle: ISchemaContainer<IWrapObstacleAttribute, IObstacle> = {
-   serialize(data: IWrapObstacleAttribute): IObstacle {
+   serialize(data) {
       return {
          b: data.time,
          x: data.posX,
@@ -18,15 +18,16 @@ export const obstacle: ISchemaContainer<IWrapObstacleAttribute, IObstacle> = {
          customData: deepCopy(data.customData),
       };
    },
-   deserialize(data: Partial<IObstacle> = {}): Partial<IWrapObstacleAttribute> {
+   deserialize(data) {
       return {
-         time: data.b,
-         posX: data.x,
-         posY: data.y,
-         duration: data.d,
-         width: data.w,
-         height: data.h,
-         customData: data.customData,
+         time: data.b ?? 0,
+         laneRotation: 0,
+         posX: data.x ?? 0,
+         posY: data.y ?? 0,
+         duration: data.d ?? 0,
+         width: data.w ?? 0,
+         height: data.h ?? 0,
+         customData: data.customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v3/obstacle.ts
+++ b/src/beatmap/schema/v3/obstacle.ts
@@ -2,6 +2,7 @@ import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IObstacle } from '../../../types/beatmap/v3/obstacle.ts';
 import type { IWrapObstacleAttribute } from '../../../types/beatmap/wrapper/obstacle.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createObstacle } from '../../core/obstacle.ts';
 
 /**
  * Schema serialization for v3 `Obstacle`.
@@ -19,15 +20,14 @@ export const obstacle: ISchemaContainer<IWrapObstacleAttribute, IObstacle> = {
       };
    },
    deserialize(data) {
-      return {
-         time: data.b ?? 0,
-         laneRotation: 0,
-         posX: data.x ?? 0,
-         posY: data.y ?? 0,
-         duration: data.d ?? 0,
-         width: data.w ?? 0,
-         height: data.h ?? 0,
-         customData: data.customData ?? {},
-      };
+      return createObstacle({
+         time: data.b,
+         posX: data.x,
+         posY: data.y,
+         duration: data.d,
+         width: data.w,
+         height: data.h,
+         customData: data.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v3/rotationEvent.ts
+++ b/src/beatmap/schema/v3/rotationEvent.ts
@@ -2,6 +2,7 @@ import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IRotationEvent } from '../../../types/beatmap/v3/rotationEvent.ts';
 import type { IWrapRotationEventAttribute } from '../../../types/beatmap/wrapper/rotationEvent.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createRotationEvent } from '../../core/rotationEvent.ts';
 
 /**
  * Schema serialization for v3 `Rotation Event`.
@@ -16,11 +17,11 @@ export const rotationEvent: ISchemaContainer<IWrapRotationEventAttribute, IRotat
       };
    },
    deserialize(data) {
-      return {
-         time: data.b ?? 0,
-         executionTime: data.e ?? 0,
-         rotation: data.r ?? 0,
-         customData: data.customData ?? {},
-      };
+      return createRotationEvent({
+         time: data.b,
+         executionTime: data.e,
+         rotation: data.r,
+         customData: data.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v3/rotationEvent.ts
+++ b/src/beatmap/schema/v3/rotationEvent.ts
@@ -7,7 +7,7 @@ import { deepCopy } from '../../../utils/misc.ts';
  * Schema serialization for v3 `Rotation Event`.
  */
 export const rotationEvent: ISchemaContainer<IWrapRotationEventAttribute, IRotationEvent> = {
-   serialize(data: IWrapRotationEventAttribute): IRotationEvent {
+   serialize(data) {
       return {
          b: data.time,
          e: data.executionTime,
@@ -15,12 +15,12 @@ export const rotationEvent: ISchemaContainer<IWrapRotationEventAttribute, IRotat
          customData: deepCopy(data.customData),
       };
    },
-   deserialize(data: Partial<IRotationEvent> = {}): Partial<IWrapRotationEventAttribute> {
+   deserialize(data) {
       return {
-         time: data.b,
-         executionTime: data.e,
-         rotation: data.r,
-         customData: data.customData,
+         time: data.b ?? 0,
+         executionTime: data.e ?? 0,
+         rotation: data.r ?? 0,
+         customData: data.customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v3/waypoint.ts
+++ b/src/beatmap/schema/v3/waypoint.ts
@@ -2,6 +2,7 @@ import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IWaypoint } from '../../../types/beatmap/v3/waypoint.ts';
 import type { IWrapWaypointAttribute } from '../../../types/beatmap/wrapper/waypoint.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createWaypoint } from '../../core/waypoint.ts';
 
 /**
  * Schema serialization for v3 `Waypoint`.
@@ -17,13 +18,12 @@ export const waypoint: ISchemaContainer<IWrapWaypointAttribute, IWaypoint> = {
       };
    },
    deserialize(data) {
-      return {
-         time: data.b ?? 0,
-         laneRotation: 0,
-         posX: data.x ?? 0,
-         posY: data.y ?? 0,
-         direction: data.d ?? 0,
-         customData: data.customData ?? {},
-      };
+      return createWaypoint({
+         time: data.b,
+         posX: data.x,
+         posY: data.y,
+         direction: data.d,
+         customData: data.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v3/waypoint.ts
+++ b/src/beatmap/schema/v3/waypoint.ts
@@ -7,7 +7,7 @@ import { deepCopy } from '../../../utils/misc.ts';
  * Schema serialization for v3 `Waypoint`.
  */
 export const waypoint: ISchemaContainer<IWrapWaypointAttribute, IWaypoint> = {
-   serialize(data: IWrapWaypointAttribute): IWaypoint {
+   serialize(data) {
       return {
          b: data.time,
          x: data.posX,
@@ -16,13 +16,14 @@ export const waypoint: ISchemaContainer<IWrapWaypointAttribute, IWaypoint> = {
          customData: deepCopy(data.customData),
       };
    },
-   deserialize(data: Partial<IWaypoint> = {}): Partial<IWrapWaypointAttribute> {
+   deserialize(data) {
       return {
-         time: data.b,
-         posX: data.x,
-         posY: data.y,
-         direction: data.d,
-         customData: data.customData,
+         time: data.b ?? 0,
+         laneRotation: 0,
+         posX: data.x ?? 0,
+         posY: data.y ?? 0,
+         direction: data.d ?? 0,
+         customData: data.customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v4/arc.ts
+++ b/src/beatmap/schema/v4/arc.ts
@@ -1,13 +1,13 @@
+import type { IArcContainer } from '../../../types/beatmap/container/v4.ts';
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IWrapArcAttribute } from '../../../types/beatmap/wrapper/arc.ts';
 import { deepCopy } from '../../../utils/misc.ts';
-import type { IArcContainer } from '../../../types/beatmap/container/v4.ts';
 
 /**
  * Schema serialization for v4 `Arc`.
  */
 export const arc: ISchemaContainer<IWrapArcAttribute, IArcContainer> = {
-   serialize(data: IWrapArcAttribute): IArcContainer {
+   serialize(data) {
       return {
          object: {
             ai: 0,
@@ -43,23 +43,23 @@ export const arc: ISchemaContainer<IWrapArcAttribute, IArcContainer> = {
          },
       };
    },
-   deserialize(data: Partial<IArcContainer> = {}): Partial<IWrapArcAttribute> {
+   deserialize(data) {
       return {
-         time: data.object?.hb,
-         laneRotation: data.object?.hr,
-         tailTime: data.object?.tb,
-         tailLaneRotation: data.object?.tr,
-         color: data.headData?.c,
-         posX: data.headData?.x,
-         posY: data.headData?.y,
-         direction: data.headData?.d,
-         lengthMultiplier: data.data?.m,
-         tailPosX: data.tailData?.x,
-         tailPosY: data.tailData?.y,
-         tailDirection: data.tailData?.d,
-         tailLengthMultiplier: data.data?.tm,
-         midAnchor: data.data?.a,
-         customData: data.data?.customData,
+         time: data.object?.hb ?? 0,
+         laneRotation: data.object?.hr ?? 0,
+         tailTime: data.object?.tb ?? 0,
+         tailLaneRotation: data.object?.tr ?? 0,
+         color: data.headData?.c ?? 0,
+         posX: data.headData?.x ?? 0,
+         posY: data.headData?.y ?? 0,
+         direction: data.headData?.d ?? 0,
+         lengthMultiplier: data.data?.m ?? 0,
+         tailPosX: data.tailData?.x ?? 0,
+         tailPosY: data.tailData?.y ?? 0,
+         tailDirection: data.tailData?.d ?? 0,
+         tailLengthMultiplier: data.data?.tm ?? 0,
+         midAnchor: data.data?.a ?? 0,
+         customData: data.data?.customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v4/arc.ts
+++ b/src/beatmap/schema/v4/arc.ts
@@ -2,6 +2,7 @@ import type { IArcContainer } from '../../../types/beatmap/container/v4.ts';
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IWrapArcAttribute } from '../../../types/beatmap/wrapper/arc.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createArc } from '../../core/arc.ts';
 
 /**
  * Schema serialization for v4 `Arc`.
@@ -44,22 +45,22 @@ export const arc: ISchemaContainer<IWrapArcAttribute, IArcContainer> = {
       };
    },
    deserialize(data) {
-      return {
-         time: data.object?.hb ?? 0,
-         laneRotation: data.object?.hr ?? 0,
-         tailTime: data.object?.tb ?? 0,
-         tailLaneRotation: data.object?.tr ?? 0,
-         color: data.headData?.c ?? 0,
-         posX: data.headData?.x ?? 0,
-         posY: data.headData?.y ?? 0,
-         direction: data.headData?.d ?? 0,
-         lengthMultiplier: data.data?.m ?? 0,
-         tailPosX: data.tailData?.x ?? 0,
-         tailPosY: data.tailData?.y ?? 0,
-         tailDirection: data.tailData?.d ?? 0,
-         tailLengthMultiplier: data.data?.tm ?? 0,
-         midAnchor: data.data?.a ?? 0,
-         customData: data.data?.customData ?? {},
-      };
+      return createArc({
+         time: data.object?.hb,
+         laneRotation: data.object?.hr,
+         tailTime: data.object?.tb,
+         tailLaneRotation: data.object?.tr,
+         color: data.headData?.c,
+         posX: data.headData?.x,
+         posY: data.headData?.y,
+         direction: data.headData?.d,
+         lengthMultiplier: data.data?.m,
+         tailPosX: data.tailData?.x,
+         tailPosY: data.tailData?.y,
+         tailDirection: data.tailData?.d,
+         tailLengthMultiplier: data.data?.tm,
+         midAnchor: data.data?.a,
+         customData: data.data?.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v4/audioData.ts
+++ b/src/beatmap/schema/v4/audioData.ts
@@ -1,13 +1,14 @@
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IAudio } from '../../../types/beatmap/v4/audioData.ts';
 import type { IWrapAudioDataAttribute } from '../../../types/beatmap/wrapper/audioData.ts';
-import type { DeepPartial } from '../../../types/utils.ts';
+
+type AudioDataPolyfills = Pick<IWrapAudioDataAttribute, 'filename'>;
 
 /**
  * Schema serialization for v4 `Audio Data`.
  */
-export const audioData: ISchemaContainer<IWrapAudioDataAttribute, IAudio> = {
-   serialize(data: IWrapAudioDataAttribute): IAudio {
+export const audioData: ISchemaContainer<IWrapAudioDataAttribute, IAudio, AudioDataPolyfills> = {
+   serialize(data) {
       return {
          version: '4.0.0',
          songChecksum: data.audioChecksum,
@@ -26,23 +27,25 @@ export const audioData: ISchemaContainer<IWrapAudioDataAttribute, IAudio> = {
          })),
       };
    },
-   deserialize(data: DeepPartial<IAudio> = {}): DeepPartial<IWrapAudioDataAttribute> {
+   deserialize(data, options) {
       return {
          version: 4,
-         audioChecksum: data.songChecksum,
-         sampleCount: data.songSampleCount,
-         frequency: data.songFrequency,
+         filename: options?.filename ?? 'AudioData.dat',
+         audioChecksum: data.songChecksum ?? '',
+         sampleCount: data.songSampleCount ?? 0,
+         frequency: data.songFrequency ?? 0,
          bpmData: data.bpmData?.map((bd) => ({
             startBeat: bd?.sb,
             endBeat: bd?.eb,
             startSampleIndex: bd?.si,
             endSampleIndex: bd?.ei,
-         })),
+         })) ?? [],
          lufsData: data.lufsData?.map((l) => ({
             lufs: l?.l,
             startSampleIndex: l?.si,
             endSampleIndex: l?.ei,
-         })),
+         })) ?? [],
+         customData: {},
       };
    },
 };

--- a/src/beatmap/schema/v4/audioData.ts
+++ b/src/beatmap/schema/v4/audioData.ts
@@ -1,6 +1,7 @@
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IAudio } from '../../../types/beatmap/v4/audioData.ts';
 import type { IWrapAudioDataAttribute } from '../../../types/beatmap/wrapper/audioData.ts';
+import { createAudioData } from '../../core/audioData.ts';
 
 type AudioDataPolyfills = Pick<IWrapAudioDataAttribute, 'filename'>;
 
@@ -28,24 +29,23 @@ export const audioData: ISchemaContainer<IWrapAudioDataAttribute, IAudio, AudioD
       };
    },
    deserialize(data, options) {
-      return {
+      return createAudioData({
          version: 4,
-         filename: options?.filename ?? 'AudioData.dat',
-         audioChecksum: data.songChecksum ?? '',
-         sampleCount: data.songSampleCount ?? 0,
-         frequency: data.songFrequency ?? 0,
+         filename: options?.filename,
+         audioChecksum: data.songChecksum,
+         sampleCount: data.songSampleCount,
+         frequency: data.songFrequency,
          bpmData: data.bpmData?.map((bd) => ({
             startBeat: bd?.sb,
             endBeat: bd?.eb,
             startSampleIndex: bd?.si,
             endSampleIndex: bd?.ei,
-         })) ?? [],
+         })),
          lufsData: data.lufsData?.map((l) => ({
             lufs: l?.l,
             startSampleIndex: l?.si,
             endSampleIndex: l?.ei,
-         })) ?? [],
-         customData: {},
-      };
+         })),
+      });
    },
 };

--- a/src/beatmap/schema/v4/basicEvent.ts
+++ b/src/beatmap/schema/v4/basicEvent.ts
@@ -2,6 +2,7 @@ import type { IBasicEventContainer } from '../../../types/beatmap/container/v4.t
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IWrapBasicEventAttribute } from '../../../types/beatmap/wrapper/basicEvent.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createBasicEvent } from '../../core/basicEvent.ts';
 
 /**
  * Schema serialization for v4 `Basic Event`.
@@ -23,12 +24,12 @@ export const basicEvent: ISchemaContainer<IWrapBasicEventAttribute, IBasicEventC
       };
    },
    deserialize(data) {
-      return {
-         time: data.object?.b ?? 0,
-         type: data.data?.t ?? 0,
-         value: data.data?.i ?? 0,
-         floatValue: data.data?.f ?? 0,
-         customData: data.data?.customData ?? {},
-      };
+      return createBasicEvent({
+         time: data.object?.b,
+         type: data.data?.t,
+         value: data.data?.i,
+         floatValue: data.data?.f,
+         customData: data.data?.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v4/basicEvent.ts
+++ b/src/beatmap/schema/v4/basicEvent.ts
@@ -1,14 +1,13 @@
-import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
-import { deepCopy } from '../../../utils/misc.ts';
-import type { IWrapBasicEventAttribute } from '../../../types/beatmap/wrapper/basicEvent.ts';
 import type { IBasicEventContainer } from '../../../types/beatmap/container/v4.ts';
-import type { DeepPartial } from '../../../types/utils.ts';
+import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
+import type { IWrapBasicEventAttribute } from '../../../types/beatmap/wrapper/basicEvent.ts';
+import { deepCopy } from '../../../utils/misc.ts';
 
 /**
  * Schema serialization for v4 `Basic Event`.
  */
 export const basicEvent: ISchemaContainer<IWrapBasicEventAttribute, IBasicEventContainer> = {
-   serialize(data: IWrapBasicEventAttribute): IBasicEventContainer {
+   serialize(data) {
       return {
          object: {
             b: data.time,
@@ -23,15 +22,13 @@ export const basicEvent: ISchemaContainer<IWrapBasicEventAttribute, IBasicEventC
          },
       };
    },
-   deserialize(
-      data: DeepPartial<IBasicEventContainer> = {},
-   ): DeepPartial<IWrapBasicEventAttribute> {
+   deserialize(data) {
       return {
-         time: data.object?.b,
-         type: data.data?.t,
-         value: data.data?.i,
-         floatValue: data.data?.f,
-         customData: data.data?.customData,
+         time: data.object?.b ?? 0,
+         type: data.data?.t ?? 0,
+         value: data.data?.i ?? 0,
+         floatValue: data.data?.f ?? 0,
+         customData: data.data?.customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v4/bombNote.ts
+++ b/src/beatmap/schema/v4/bombNote.ts
@@ -1,14 +1,13 @@
-import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
-import { deepCopy } from '../../../utils/misc.ts';
-import type { IWrapBombNoteAttribute } from '../../../types/beatmap/wrapper/bombNote.ts';
 import type { IBombNoteContainer } from '../../../types/beatmap/container/v4.ts';
-import type { DeepPartial } from '../../../types/utils.ts';
+import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
+import type { IWrapBombNoteAttribute } from '../../../types/beatmap/wrapper/bombNote.ts';
+import { deepCopy } from '../../../utils/misc.ts';
 
 /**
  * Schema serialization for v4 `Bomb Note`.
  */
 export const bombNote: ISchemaContainer<IWrapBombNoteAttribute, IBombNoteContainer> = {
-   serialize(data: IWrapBombNoteAttribute): Required<IBombNoteContainer> {
+   serialize(data) {
       return {
          object: {
             b: data.time,
@@ -23,13 +22,15 @@ export const bombNote: ISchemaContainer<IWrapBombNoteAttribute, IBombNoteContain
          },
       };
    },
-   deserialize(data: DeepPartial<IBombNoteContainer> = {}): Partial<IWrapBombNoteAttribute> {
+   deserialize(data) {
       return {
-         time: data.object?.b,
-         laneRotation: data.object?.r,
-         posX: data.data?.x,
-         posY: data.data?.y,
-         customData: data.data?.customData,
+         time: data.object?.b ?? 0,
+         laneRotation: data.object?.r ?? 0,
+         posX: data.data?.x ?? 0,
+         posY: data.data?.y ?? 0,
+         color: -1,
+         direction: 0,
+         customData: data.data?.customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v4/bombNote.ts
+++ b/src/beatmap/schema/v4/bombNote.ts
@@ -2,6 +2,7 @@ import type { IBombNoteContainer } from '../../../types/beatmap/container/v4.ts'
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IWrapBombNoteAttribute } from '../../../types/beatmap/wrapper/bombNote.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createBombNote } from '../../core/bombNote.ts';
 
 /**
  * Schema serialization for v4 `Bomb Note`.
@@ -23,14 +24,12 @@ export const bombNote: ISchemaContainer<IWrapBombNoteAttribute, IBombNoteContain
       };
    },
    deserialize(data) {
-      return {
-         time: data.object?.b ?? 0,
-         laneRotation: data.object?.r ?? 0,
-         posX: data.data?.x ?? 0,
-         posY: data.data?.y ?? 0,
-         color: -1,
-         direction: 0,
-         customData: data.data?.customData ?? {},
-      };
+      return createBombNote({
+         time: data.object?.b,
+         laneRotation: data.object?.r,
+         posX: data.data?.x,
+         posY: data.data?.y,
+         customData: data.data?.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v4/chain.ts
+++ b/src/beatmap/schema/v4/chain.ts
@@ -1,5 +1,5 @@
-import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IChainContainer } from '../../../types/beatmap/container/v4.ts';
+import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IWrapChainAttribute } from '../../../types/beatmap/wrapper/chain.ts';
 import { deepCopy } from '../../../utils/misc.ts';
 
@@ -7,7 +7,7 @@ import { deepCopy } from '../../../utils/misc.ts';
  * Schema serialization for v4 `Chain`.
  */
 export const chain: ISchemaContainer<IWrapChainAttribute, IChainContainer> = {
-   serialize(data: IWrapChainAttribute): IChainContainer {
+   serialize(data) {
       return {
          object: {
             hb: data.time,
@@ -35,21 +35,21 @@ export const chain: ISchemaContainer<IWrapChainAttribute, IChainContainer> = {
          },
       };
    },
-   deserialize(data: Partial<IChainContainer> = {}): Partial<IWrapChainAttribute> {
+   deserialize(data) {
       return {
-         time: data.object?.hb,
-         laneRotation: data.object?.hr,
-         color: data.data?.c,
-         posX: data.data?.x,
-         posY: data.data?.y,
-         direction: data.data?.d,
-         tailTime: data.object?.tb,
-         tailLaneRotation: data.object?.tr,
-         tailPosX: data.chainData?.tx,
-         tailPosY: data.chainData?.ty,
-         sliceCount: data.chainData?.c,
-         squish: data.chainData?.s,
-         customData: data.chainData?.customData,
+         time: data.object?.hb ?? 0,
+         laneRotation: data.object?.hr ?? 0,
+         color: data.data?.c ?? 0,
+         posX: data.data?.x ?? 0,
+         posY: data.data?.y ?? 0,
+         direction: data.data?.d ?? 0,
+         tailTime: data.object?.tb ?? 0,
+         tailLaneRotation: data.object?.tr ?? 0,
+         tailPosX: data.chainData?.tx ?? 0,
+         tailPosY: data.chainData?.ty ?? 0,
+         sliceCount: data.chainData?.c ?? 0,
+         squish: data.chainData?.s ?? 0,
+         customData: data.chainData?.customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v4/chain.ts
+++ b/src/beatmap/schema/v4/chain.ts
@@ -2,6 +2,7 @@ import type { IChainContainer } from '../../../types/beatmap/container/v4.ts';
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IWrapChainAttribute } from '../../../types/beatmap/wrapper/chain.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createChain } from '../../core/chain.ts';
 
 /**
  * Schema serialization for v4 `Chain`.
@@ -36,20 +37,20 @@ export const chain: ISchemaContainer<IWrapChainAttribute, IChainContainer> = {
       };
    },
    deserialize(data) {
-      return {
-         time: data.object?.hb ?? 0,
-         laneRotation: data.object?.hr ?? 0,
-         color: data.data?.c ?? 0,
-         posX: data.data?.x ?? 0,
-         posY: data.data?.y ?? 0,
-         direction: data.data?.d ?? 0,
-         tailTime: data.object?.tb ?? 0,
-         tailLaneRotation: data.object?.tr ?? 0,
-         tailPosX: data.chainData?.tx ?? 0,
-         tailPosY: data.chainData?.ty ?? 0,
-         sliceCount: data.chainData?.c ?? 0,
-         squish: data.chainData?.s ?? 0,
-         customData: data.chainData?.customData ?? {},
-      };
+      return createChain({
+         time: data.object?.hb,
+         laneRotation: data.object?.hr,
+         color: data.data?.c,
+         posX: data.data?.x,
+         posY: data.data?.y,
+         direction: data.data?.d,
+         tailTime: data.object?.tb,
+         tailLaneRotation: data.object?.tr,
+         tailPosX: data.chainData?.tx,
+         tailPosY: data.chainData?.ty,
+         sliceCount: data.chainData?.c,
+         squish: data.chainData?.s,
+         customData: data.chainData?.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v4/colorBoostEvent.ts
+++ b/src/beatmap/schema/v4/colorBoostEvent.ts
@@ -1,5 +1,5 @@
-import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IColorBoostEventContainer } from '../../../types/beatmap/container/v4.ts';
+import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IWrapColorBoostEventAttribute } from '../../../types/beatmap/wrapper/colorBoostEvent.ts';
 import { deepCopy } from '../../../utils/misc.ts';
 
@@ -10,7 +10,7 @@ export const colorBoostEvent: ISchemaContainer<
    IWrapColorBoostEventAttribute,
    IColorBoostEventContainer
 > = {
-   serialize(data: IWrapColorBoostEventAttribute): Required<IColorBoostEventContainer> {
+   serialize(data) {
       return {
          object: {
             b: data.time,
@@ -23,13 +23,11 @@ export const colorBoostEvent: ISchemaContainer<
          },
       };
    },
-   deserialize(
-      data: Partial<IColorBoostEventContainer> = {},
-   ): Partial<IWrapColorBoostEventAttribute> {
+   deserialize(data) {
       return {
-         time: data.object?.b,
+         time: data.object?.b ?? 0,
          toggle: !!data.data?.b,
-         customData: data.data?.customData,
+         customData: data.data?.customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v4/colorBoostEvent.ts
+++ b/src/beatmap/schema/v4/colorBoostEvent.ts
@@ -2,6 +2,7 @@ import type { IColorBoostEventContainer } from '../../../types/beatmap/container
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IWrapColorBoostEventAttribute } from '../../../types/beatmap/wrapper/colorBoostEvent.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createColorBoostEvent } from '../../core/colorBoostEvent.ts';
 
 /**
  * Schema serialization for v4 `Color Boost Event`.
@@ -24,10 +25,10 @@ export const colorBoostEvent: ISchemaContainer<
       };
    },
    deserialize(data) {
-      return {
-         time: data.object?.b ?? 0,
+      return createColorBoostEvent({
+         time: data.object?.b,
          toggle: !!data.data?.b,
-         customData: data.data?.customData ?? {},
-      };
+         customData: data.data?.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v4/colorNote.ts
+++ b/src/beatmap/schema/v4/colorNote.ts
@@ -1,8 +1,7 @@
-import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
-import { deepCopy } from '../../../utils/misc.ts';
-import type { IWrapColorNoteAttribute } from '../../../types/beatmap/wrapper/colorNote.ts';
 import type { IColorNoteContainer } from '../../../types/beatmap/container/v4.ts';
-import type { DeepPartial } from '../../../types/utils.ts';
+import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
+import type { IWrapColorNoteAttribute } from '../../../types/beatmap/wrapper/colorNote.ts';
+import { deepCopy } from '../../../utils/misc.ts';
 
 /**
  * Schema serialization for v4 `Color Note`.
@@ -26,16 +25,16 @@ export const colorNote: ISchemaContainer<IWrapColorNoteAttribute, IColorNoteCont
          },
       };
    },
-   deserialize(data: DeepPartial<IColorNoteContainer> = {}): Partial<IWrapColorNoteAttribute> {
+   deserialize(data) {
       return {
-         time: data.object?.b,
-         laneRotation: data.object?.r,
-         posX: data.data?.x,
-         posY: data.data?.y,
-         color: data.data?.c,
-         direction: data.data?.d,
-         angleOffset: data.data?.a,
-         customData: data.data?.customData,
+         time: data.object?.b ?? 0,
+         laneRotation: data.object?.r ?? 0,
+         posX: data.data?.x ?? 0,
+         posY: data.data?.y ?? 0,
+         color: data.data?.c ?? 0,
+         direction: data.data?.d ?? 0,
+         angleOffset: data.data?.a ?? 0,
+         customData: data.data?.customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v4/colorNote.ts
+++ b/src/beatmap/schema/v4/colorNote.ts
@@ -2,12 +2,13 @@ import type { IColorNoteContainer } from '../../../types/beatmap/container/v4.ts
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IWrapColorNoteAttribute } from '../../../types/beatmap/wrapper/colorNote.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createColorNote } from '../../core/colorNote.ts';
 
 /**
  * Schema serialization for v4 `Color Note`.
  */
 export const colorNote: ISchemaContainer<IWrapColorNoteAttribute, IColorNoteContainer> = {
-   serialize(data: IWrapColorNoteAttribute): IColorNoteContainer {
+   serialize(data) {
       return {
          object: {
             b: data.time,
@@ -26,15 +27,15 @@ export const colorNote: ISchemaContainer<IWrapColorNoteAttribute, IColorNoteCont
       };
    },
    deserialize(data) {
-      return {
-         time: data.object?.b ?? 0,
-         laneRotation: data.object?.r ?? 0,
-         posX: data.data?.x ?? 0,
-         posY: data.data?.y ?? 0,
-         color: data.data?.c ?? 0,
-         direction: data.data?.d ?? 0,
-         angleOffset: data.data?.a ?? 0,
-         customData: data.data?.customData ?? {},
-      };
+      return createColorNote({
+         time: data.object?.b,
+         laneRotation: data.object?.r,
+         posX: data.data?.x,
+         posY: data.data?.y,
+         color: data.data?.c,
+         direction: data.data?.d,
+         angleOffset: data.data?.a,
+         customData: data.data?.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v4/compat/audioData.ts
+++ b/src/beatmap/schema/v4/compat/audioData.ts
@@ -1,10 +1,10 @@
 import type { ICompatibilityOptions } from '../../../../types/beatmap/options/compatibility.ts';
-import type { IWrapAudioData } from '../../../../types/beatmap/wrapper/audioData.ts';
+import type { IWrapAudioDataAttribute } from '../../../../types/beatmap/wrapper/audioData.ts';
 
 /**
  * Check if beatmap audio data is compatible with v4 `Audio Data` schema.
  */
-export function compatAudioData(
-   _data: IWrapAudioData,
+export function compatAudioData<T extends IWrapAudioDataAttribute>(
+   _data: T,
    _options: ICompatibilityOptions,
 ) {}

--- a/src/beatmap/schema/v4/compat/difficulty.ts
+++ b/src/beatmap/schema/v4/compat/difficulty.ts
@@ -1,27 +1,27 @@
-import type { IWrapBeatmap } from '../../../../types/beatmap/wrapper/beatmap.ts';
+import { logger } from '../../../../logger.ts';
 import type { ICompatibilityOptions } from '../../../../types/beatmap/options/compatibility.ts';
+import type { IWrapBeatmapAttribute } from '../../../../types/beatmap/wrapper/beatmap.ts';
 import {
+   hasMappingExtensionsArc,
    hasMappingExtensionsBombNote,
+   hasMappingExtensionsChain,
    hasMappingExtensionsNote,
    hasMappingExtensionsObstacleV3,
 } from '../../../helpers/modded/has.ts';
-import { logger } from '../../../../logger.ts';
 import { tag } from './_common.ts';
-import { hasMappingExtensionsArc } from '../../../helpers/modded/has.ts';
-import { hasMappingExtensionsChain } from '../../../helpers/modded/has.ts';
 
 /**
  * Checks if beatmap data is compatible with v4 `Difficulty` schema.
  */
-export function compatDifficulty(
-   bm: IWrapBeatmap,
+export function compatDifficulty<T extends IWrapBeatmapAttribute>(
+   bm: T,
    options: ICompatibilityOptions,
 ) {
-   const hasME = bm.colorNotes.some(hasMappingExtensionsNote) ||
-      bm.bombNotes.some(hasMappingExtensionsBombNote) ||
-      bm.arcs.some(hasMappingExtensionsArc) ||
-      bm.chains.some(hasMappingExtensionsChain) ||
-      bm.obstacles.some(hasMappingExtensionsObstacleV3);
+   const hasME = bm.difficulty.colorNotes.some(hasMappingExtensionsNote) ||
+      bm.difficulty.bombNotes.some(hasMappingExtensionsBombNote) ||
+      bm.difficulty.arcs.some(hasMappingExtensionsArc) ||
+      bm.difficulty.chains.some(hasMappingExtensionsChain) ||
+      bm.difficulty.obstacles.some(hasMappingExtensionsObstacleV3);
 
    if (hasME) {
       if (options.throwOn.mappingExtensions) {

--- a/src/beatmap/schema/v4/compat/info.ts
+++ b/src/beatmap/schema/v4/compat/info.ts
@@ -1,12 +1,12 @@
 import { logger } from '../../../../logger.ts';
 import type { ICompatibilityOptions } from '../../../../types/beatmap/options/compatibility.ts';
-import type { IWrapInfo } from '../../../../types/beatmap/wrapper/info.ts';
+import type { IWrapInfoAttribute } from '../../../../types/beatmap/wrapper/info.ts';
 import { tag } from './_common.ts';
 
 /**
  * Check if beatmap info is compatible with v4 `Info` schema.
  */
-export function compatInfo(info: IWrapInfo, options: ICompatibilityOptions) {
+export function compatInfo<T extends IWrapInfoAttribute>(info: T, options: ICompatibilityOptions) {
    const hasIncompat = info.audio.shufflePeriod !== 0.5 ||
       info.audio.shuffle !== 0 ||
       info.audio.audioOffset !== 0;

--- a/src/beatmap/schema/v4/compat/lightshow.ts
+++ b/src/beatmap/schema/v4/compat/lightshow.ts
@@ -1,11 +1,11 @@
-import type { IWrapBeatmap } from '../../../../types/beatmap/wrapper/beatmap.ts';
 import type { ICompatibilityOptions } from '../../../../types/beatmap/options/compatibility.ts';
+import type { IWrapBeatmapAttribute } from '../../../../types/beatmap/wrapper/beatmap.ts';
 
 /**
  * Checks if beatmap data is compatible with v4 `Lightshow` schema.
  */
-export function compatLightshow(
-   _bm: IWrapBeatmap,
+export function compatLightshow<T extends IWrapBeatmapAttribute>(
+   _bm: T,
    _options: ICompatibilityOptions,
 ) {
 }

--- a/src/beatmap/schema/v4/difficulty.ts
+++ b/src/beatmap/schema/v4/difficulty.ts
@@ -1,21 +1,26 @@
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IDifficulty } from '../../../types/beatmap/v4/difficulty.ts';
+import type { IWrapBeatmapAttribute } from '../../../types/beatmap/wrapper/beatmap.ts';
+import { deepCopy } from '../../../utils/misc.ts';
+import { arc } from './arc.ts';
 import { bombNote } from './bombNote.ts';
 import { chain } from './chain.ts';
 import { colorNote } from './colorNote.ts';
-import { obstacle } from './obstacle.ts';
-import { arc } from './arc.ts';
-import { rotationEvent } from './rotationEvent.ts';
-import { deepCopy } from '../../../utils/misc.ts';
-import type { IWrapBeatmapAttribute } from '../../../types/beatmap/wrapper/beatmap.ts';
-import type { DeepPartial } from '../../../types/utils.ts';
 import { njsEvent } from './njsEvent.ts';
+import { obstacle } from './obstacle.ts';
+import { rotationEvent } from './rotationEvent.ts';
+
+type DifficultyPolyfills = Pick<IWrapBeatmapAttribute, 'filename' | 'lightshowFilename'>;
 
 /**
  * Schema serialization for v4 `Difficulty`.
  */
-export const difficulty: ISchemaContainer<IWrapBeatmapAttribute, IDifficulty> = {
-   serialize(data: IWrapBeatmapAttribute): IDifficulty {
+export const difficulty: ISchemaContainer<
+   IWrapBeatmapAttribute,
+   IDifficulty,
+   DifficultyPolyfills
+> = {
+   serialize(data) {
       const json: Required<IDifficulty> = {
          version: '4.1.0',
          colorNotes: [],
@@ -35,33 +40,37 @@ export const difficulty: ISchemaContainer<IWrapBeatmapAttribute, IDifficulty> = 
          customData: deepCopy(data.difficulty.customData),
       };
       for (
-         const jsonObj of data.difficulty.colorNotes.map(
-            colorNote.serialize,
-         )
+         const jsonObj of data.difficulty.colorNotes.map((x) => {
+            return colorNote.serialize(x);
+         })
       ) {
          json.colorNotes.push(jsonObj.object);
          jsonObj.object.i = json.colorNotesData.length;
          json.colorNotesData.push(jsonObj.data);
       }
       for (
-         const jsonObj of data.difficulty.bombNotes.map(
-            bombNote.serialize,
-         )
+         const jsonObj of data.difficulty.bombNotes.map((x) => {
+            return bombNote.serialize(x);
+         })
       ) {
          json.bombNotes.push(jsonObj.object);
          jsonObj.object.i = json.bombNotesData.length;
          json.bombNotesData.push(jsonObj.data);
       }
       for (
-         const jsonObj of data.difficulty.obstacles.map(
-            obstacle.serialize,
-         )
+         const jsonObj of data.difficulty.obstacles.map((x) => {
+            return obstacle.serialize(x);
+         })
       ) {
          json.obstacles.push(jsonObj.object);
          jsonObj.object.i = json.obstaclesData.length;
          json.obstaclesData.push(jsonObj.data);
       }
-      for (const jsonObj of data.difficulty.arcs.map(arc.serialize)) {
+      for (
+         const jsonObj of data.difficulty.arcs.map((x) => {
+            return arc.serialize(x);
+         })
+      ) {
          json.arcs.push(jsonObj.object);
          jsonObj.object.ai = json.arcsData.length;
          json.arcsData.push(jsonObj.data);
@@ -70,7 +79,11 @@ export const difficulty: ISchemaContainer<IWrapBeatmapAttribute, IDifficulty> = 
          jsonObj.object.ti = json.colorNotesData.length;
          json.colorNotesData.push(jsonObj.tailData);
       }
-      for (const jsonObj of data.difficulty.chains.map(chain.serialize)) {
+      for (
+         const jsonObj of data.difficulty.chains.map((x) => {
+            return chain.serialize(x);
+         })
+      ) {
          json.chains.push(jsonObj.object);
          jsonObj.object.i = json.colorNotesData.length;
          json.colorNotesData.push(jsonObj.data);
@@ -78,18 +91,18 @@ export const difficulty: ISchemaContainer<IWrapBeatmapAttribute, IDifficulty> = 
          json.chainsData.push(jsonObj.chainData);
       }
       for (
-         const jsonObj of data.difficulty.rotationEvents.map(
-            rotationEvent.serialize,
-         )
+         const jsonObj of data.difficulty.rotationEvents.map((x) => {
+            return rotationEvent.serialize(x);
+         })
       ) {
          json.spawnRotations.push(jsonObj.object);
          jsonObj.object.i = json.spawnRotationsData.length;
          json.spawnRotationsData.push(jsonObj.data);
       }
       for (
-         const jsonObj of data.difficulty.njsEvents.map(
-            njsEvent.serialize,
-         )
+         const jsonObj of data.difficulty.njsEvents.map((x) => {
+            return njsEvent.serialize(x);
+         })
       ) {
          json.njsEvents.push(jsonObj.object);
          jsonObj.object.i = json.njsEventData.length;
@@ -97,30 +110,30 @@ export const difficulty: ISchemaContainer<IWrapBeatmapAttribute, IDifficulty> = 
       }
       return json;
    },
-   deserialize(
-      data: DeepPartial<IDifficulty> = {},
-   ): DeepPartial<IWrapBeatmapAttribute> {
+   deserialize(data, options) {
       return {
          version: 4,
+         filename: options?.filename ?? 'Easy.beatmap.dat',
+         lightshowFilename: options?.lightshowFilename ?? 'Easy.lightshow.dat',
          difficulty: {
             colorNotes: data.colorNotes?.map((obj) =>
                colorNote.deserialize({
                   object: obj,
                   data: data.colorNotesData?.[obj?.i || 0],
                })
-            ),
+            ) ?? [],
             bombNotes: data.bombNotes?.map((obj) =>
                bombNote.deserialize({
                   object: obj,
                   data: data.bombNotesData?.[obj?.i || 0],
                })
-            ),
+            ) ?? [],
             obstacles: data.obstacles?.map((obj) =>
                obstacle.deserialize({
                   object: obj,
                   data: data.obstaclesData?.[obj?.i || 0],
                })
-            ),
+            ) ?? [],
             arcs: data.arcs?.map((obj) =>
                arc.deserialize({
                   object: obj,
@@ -128,30 +141,42 @@ export const difficulty: ISchemaContainer<IWrapBeatmapAttribute, IDifficulty> = 
                   headData: data.colorNotesData?.[obj?.hi || 0],
                   tailData: data.colorNotesData?.[obj?.ti || 0],
                })
-            ),
+            ) ?? [],
             chains: data.chains?.map((obj) =>
                chain.deserialize({
                   object: obj,
                   data: data.colorNotesData?.[obj?.i || 0],
                   chainData: data.chainsData?.[obj?.ci || 0],
                })
-            ),
+            ) ?? [],
             rotationEvents: data.spawnRotations?.map((obj) =>
                rotationEvent.deserialize({
                   object: obj,
-                  data: data.spawnRotationsData?.[obj?.i || 0],
+                  data: data.spawnRotationsData?.[obj?.i || 0] ?? {},
                })
-            ),
+            ) ?? [],
+            bpmEvents: [],
             njsEvents: data.njsEvents?.map((obj) =>
-               this.deserialize(
-                  njsEvent.deserialize({
-                     object: obj,
-                     data: data.njsEventData?.[obj?.i || 0],
-                  }),
-               )
-            ) || [],
-            customData: data.customData,
+               njsEvent.deserialize({
+                  object: obj,
+                  data: data.njsEventData?.[obj?.i || 0] ?? {},
+               })
+            ) ?? [],
+            customData: data.customData ?? {},
          },
+         lightshow: {
+            waypoints: [],
+            basicEvents: [],
+            colorBoostEvents: [],
+            lightColorEventBoxGroups: [],
+            lightRotationEventBoxGroups: [],
+            lightTranslationEventBoxGroups: [],
+            fxEventBoxGroups: [],
+            basicEventTypesWithKeywords: { list: [] },
+            useNormalEventsAsCompatibleEvents: false,
+            customData: {},
+         },
+         customData: {},
       };
    },
 };

--- a/src/beatmap/schema/v4/fxEventBox.ts
+++ b/src/beatmap/schema/v4/fxEventBox.ts
@@ -2,6 +2,7 @@ import type { IFxEventFloatBoxContainer } from '../../../types/beatmap/container
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IWrapFxEventBoxAttribute } from '../../../types/beatmap/wrapper/fxEventBox.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createFxEventBox } from '../../core/fxEventBox.ts';
 import { fxEventFloat } from './fxEventFloat.ts';
 import { indexFilter } from './indexFilter.ts';
 
@@ -27,18 +28,18 @@ export const fxEventBox: ISchemaContainer<IWrapFxEventBoxAttribute, IFxEventFloa
       };
    },
    deserialize(data) {
-      return {
+      return createFxEventBox({
          filter: indexFilter.deserialize(data.filterData ?? {}),
-         beatDistribution: data.data?.w ?? 0,
-         beatDistributionType: data.data?.d ?? 1,
-         fxDistribution: data.data?.s ?? 0,
-         fxDistributionType: data.data?.t ?? 1,
-         affectFirst: data.data?.b ?? 0,
-         easing: data.data?.e ?? 0,
+         beatDistribution: data.data?.w,
+         beatDistributionType: data.data?.d,
+         fxDistribution: data.data?.s,
+         fxDistributionType: data.data?.t,
+         affectFirst: data.data?.b,
+         easing: data.data?.e,
          events: data.eventData?.map((x) => {
             return fxEventFloat.deserialize(x);
          }),
-         customData: data.data?.customData ?? {},
-      };
+         customData: data.data?.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v4/fxEventBox.ts
+++ b/src/beatmap/schema/v4/fxEventBox.ts
@@ -1,16 +1,15 @@
-import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IFxEventFloatBoxContainer } from '../../../types/beatmap/container/v4.ts';
+import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IWrapFxEventBoxAttribute } from '../../../types/beatmap/wrapper/fxEventBox.ts';
-import type { DeepPartial } from '../../../types/utils.ts';
 import { deepCopy } from '../../../utils/misc.ts';
-import { indexFilter } from './indexFilter.ts';
 import { fxEventFloat } from './fxEventFloat.ts';
+import { indexFilter } from './indexFilter.ts';
 
 /**
  * Schema serialization for v4 `FX Event Box`.
  */
 export const fxEventBox: ISchemaContainer<IWrapFxEventBoxAttribute, IFxEventFloatBoxContainer> = {
-   serialize(data: IWrapFxEventBoxAttribute): IFxEventFloatBoxContainer {
+   serialize(data) {
       return {
          data: {
             w: data.beatDistribution,
@@ -21,23 +20,25 @@ export const fxEventBox: ISchemaContainer<IWrapFxEventBoxAttribute, IFxEventFloa
             e: data.easing,
             customData: deepCopy(data.customData),
          },
-         eventData: data.events.map(fxEventFloat.serialize),
+         eventData: data.events.map((x) => {
+            return fxEventFloat.serialize(x);
+         }),
          filterData: indexFilter.serialize(data.filter),
       };
    },
-   deserialize(
-      data: DeepPartial<IFxEventFloatBoxContainer> = {},
-   ): DeepPartial<IWrapFxEventBoxAttribute> {
+   deserialize(data) {
       return {
-         filter: indexFilter.deserialize(data.filterData),
-         beatDistribution: data.data?.w,
-         beatDistributionType: data.data?.d,
-         fxDistribution: data.data?.s,
-         fxDistributionType: data.data?.t,
-         affectFirst: data.data?.b,
-         easing: data.data?.e,
-         events: data.eventData?.map(fxEventFloat.deserialize),
-         customData: data.data?.customData,
+         filter: indexFilter.deserialize(data.filterData ?? {}),
+         beatDistribution: data.data?.w ?? 0,
+         beatDistributionType: data.data?.d ?? 1,
+         fxDistribution: data.data?.s ?? 0,
+         fxDistributionType: data.data?.t ?? 1,
+         affectFirst: data.data?.b ?? 0,
+         easing: data.data?.e ?? 0,
+         events: data.eventData?.map((x) => {
+            return fxEventFloat.deserialize(x);
+         }),
+         customData: data.data?.customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v4/fxEventBoxGroup.ts
+++ b/src/beatmap/schema/v4/fxEventBoxGroup.ts
@@ -1,11 +1,12 @@
-import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
-import type { DeepPartial } from '../../../types/utils.ts';
-import { fxEventBox } from './fxEventBox.ts';
-import { deepCopy } from '../../../utils/misc.ts';
-import type { IWrapFxEventBoxGroupAttribute } from '../../../types/beatmap/wrapper/fxEventBoxGroup.ts';
-import type { IEventBoxGroupContainer } from '../../../types/beatmap/container/v4.ts';
+import type {
+   IEventBoxGroupContainer,
+   IFxEventFloatBoxContainer,
+} from '../../../types/beatmap/container/v4.ts';
 import { EventBoxType } from '../../../types/beatmap/shared/constants.ts';
-import type { IFxEventFloatBoxContainer } from '../../../types/beatmap/container/v4.ts';
+import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
+import type { IWrapFxEventBoxGroupAttribute } from '../../../types/beatmap/wrapper/fxEventBoxGroup.ts';
+import { deepCopy } from '../../../utils/misc.ts';
+import { fxEventBox } from './fxEventBox.ts';
 
 /**
  * Schema serialization for v4 `FX Event Box Group`.
@@ -14,9 +15,7 @@ export const fxEventBoxGroup: ISchemaContainer<
    IWrapFxEventBoxGroupAttribute,
    IEventBoxGroupContainer<IFxEventFloatBoxContainer>
 > = {
-   serialize(
-      data: IWrapFxEventBoxGroupAttribute,
-   ): IEventBoxGroupContainer<IFxEventFloatBoxContainer> {
+   serialize(data) {
       return {
          object: {
             t: EventBoxType.FX_FLOAT,
@@ -25,17 +24,19 @@ export const fxEventBoxGroup: ISchemaContainer<
             e: [],
             customData: deepCopy(data.customData),
          },
-         boxData: data.boxes.map(fxEventBox.serialize),
+         boxData: data.boxes.map((x) => {
+            return fxEventBox.serialize(x);
+         }),
       };
    },
-   deserialize(
-      data: DeepPartial<IEventBoxGroupContainer<IFxEventFloatBoxContainer>> = {},
-   ): DeepPartial<IWrapFxEventBoxGroupAttribute> {
+   deserialize(data) {
       return {
-         time: data.object?.b,
-         id: data.object?.g,
-         boxes: data.boxData?.map(fxEventBox.deserialize),
-         customData: data.object?.customData,
+         time: data.object?.b ?? 0,
+         id: data.object?.g ?? 0,
+         boxes: data.boxData?.map((x) => {
+            return fxEventBox.deserialize(x);
+         }),
+         customData: data.object?.customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v4/fxEventBoxGroup.ts
+++ b/src/beatmap/schema/v4/fxEventBoxGroup.ts
@@ -6,6 +6,7 @@ import { EventBoxType } from '../../../types/beatmap/shared/constants.ts';
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IWrapFxEventBoxGroupAttribute } from '../../../types/beatmap/wrapper/fxEventBoxGroup.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createFxEventBoxGroup } from '../../core/fxEventBoxGroup.ts';
 import { fxEventBox } from './fxEventBox.ts';
 
 /**
@@ -30,13 +31,13 @@ export const fxEventBoxGroup: ISchemaContainer<
       };
    },
    deserialize(data) {
-      return {
-         time: data.object?.b ?? 0,
-         id: data.object?.g ?? 0,
+      return createFxEventBoxGroup({
+         time: data.object?.b,
+         id: data.object?.g,
          boxes: data.boxData?.map((x) => {
             return fxEventBox.deserialize(x);
          }),
-         customData: data.object?.customData ?? {},
-      };
+         customData: data.object?.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v4/fxEventFloat.ts
+++ b/src/beatmap/schema/v4/fxEventFloat.ts
@@ -1,14 +1,13 @@
-import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IFxEventFloatContainer } from '../../../types/beatmap/container/v4.ts';
+import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IWrapFxEventFloatAttribute } from '../../../types/beatmap/wrapper/fxEventFloat.ts';
-import type { DeepPartial } from '../../../types/utils.ts';
 import { deepCopy } from '../../../utils/misc.ts';
 
 /**
  * Schema serialization for v4 `FX Event Float`.
  */
 export const fxEventFloat: ISchemaContainer<IWrapFxEventFloatAttribute, IFxEventFloatContainer> = {
-   serialize(data: IWrapFxEventFloatAttribute): IFxEventFloatContainer {
+   serialize(data) {
       return {
          data: {
             p: data.previous,
@@ -19,15 +18,13 @@ export const fxEventFloat: ISchemaContainer<IWrapFxEventFloatAttribute, IFxEvent
          time: data.time,
       };
    },
-   deserialize(
-      data: DeepPartial<IFxEventFloatContainer> = {},
-   ): Partial<IWrapFxEventFloatAttribute> {
+   deserialize(data) {
       return {
-         time: data.time,
-         previous: data.data?.p,
-         easing: data.data?.e,
-         value: data.data?.v,
-         customData: data.data?.customData,
+         time: data.time ?? 0,
+         previous: data.data?.p ?? 0,
+         easing: data.data?.e ?? 0,
+         value: data.data?.v ?? 0,
+         customData: data.data?.customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v4/fxEventFloat.ts
+++ b/src/beatmap/schema/v4/fxEventFloat.ts
@@ -2,6 +2,7 @@ import type { IFxEventFloatContainer } from '../../../types/beatmap/container/v4
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IWrapFxEventFloatAttribute } from '../../../types/beatmap/wrapper/fxEventFloat.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createFxEventFloat } from '../../core/fxEventFloat.ts';
 
 /**
  * Schema serialization for v4 `FX Event Float`.
@@ -19,12 +20,12 @@ export const fxEventFloat: ISchemaContainer<IWrapFxEventFloatAttribute, IFxEvent
       };
    },
    deserialize(data) {
-      return {
-         time: data.time ?? 0,
-         previous: data.data?.p ?? 0,
-         easing: data.data?.e ?? 0,
-         value: data.data?.v ?? 0,
-         customData: data.data?.customData ?? {},
-      };
+      return createFxEventFloat({
+         time: data.time,
+         previous: data.data?.p,
+         easing: data.data?.e,
+         value: data.data?.v,
+         customData: data.data?.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v4/indexFilter.ts
+++ b/src/beatmap/schema/v4/indexFilter.ts
@@ -2,6 +2,7 @@ import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IIndexFilter } from '../../../types/beatmap/v4/indexFilter.ts';
 import type { IWrapIndexFilterAttribute } from '../../../types/beatmap/wrapper/indexFilter.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createIndexFilter } from '../../core/indexFilter.ts';
 
 /**
  * Schema serialization for v4 `Index Filter`.
@@ -22,17 +23,17 @@ export const indexFilter: ISchemaContainer<IWrapIndexFilterAttribute, IIndexFilt
       };
    },
    deserialize(data) {
-      return {
-         type: data.f ?? 1,
-         p0: data.p ?? 0,
-         p1: data.t ?? 0,
-         reverse: data.r ?? 0,
-         chunks: data.c ?? 0,
-         random: data.n ?? 0,
-         seed: data.s ?? 0,
-         limit: data.l ?? 0,
-         limitAffectsType: data.d ?? 0,
-         customData: data.customData ?? {},
-      };
+      return createIndexFilter({
+         type: data.f,
+         p0: data.p,
+         p1: data.t,
+         reverse: data.r,
+         chunks: data.c,
+         random: data.n,
+         seed: data.s,
+         limit: data.l,
+         limitAffectsType: data.d,
+         customData: data.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v4/indexFilter.ts
+++ b/src/beatmap/schema/v4/indexFilter.ts
@@ -7,7 +7,7 @@ import { deepCopy } from '../../../utils/misc.ts';
  * Schema serialization for v4 `Index Filter`.
  */
 export const indexFilter: ISchemaContainer<IWrapIndexFilterAttribute, IIndexFilter> = {
-   serialize(data: IWrapIndexFilterAttribute): IIndexFilter {
+   serialize(data) {
       return {
          f: data.type,
          p: data.p0,
@@ -21,18 +21,18 @@ export const indexFilter: ISchemaContainer<IWrapIndexFilterAttribute, IIndexFilt
          customData: deepCopy(data.customData),
       };
    },
-   deserialize(data: Partial<IIndexFilter> = {}): Partial<IWrapIndexFilterAttribute> {
+   deserialize(data) {
       return {
-         type: data.f,
-         p0: data.p,
-         p1: data.t,
-         reverse: data.r,
-         chunks: data.c,
-         random: data.n,
-         seed: data.s,
-         limit: data.l,
-         limitAffectsType: data.d,
-         customData: data.customData,
+         type: data.f ?? 1,
+         p0: data.p ?? 0,
+         p1: data.t ?? 0,
+         reverse: data.r ?? 0,
+         chunks: data.c ?? 0,
+         random: data.n ?? 0,
+         seed: data.s ?? 0,
+         limit: data.l ?? 0,
+         limitAffectsType: data.d ?? 0,
+         customData: data.customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v4/infoBeatmap.ts
+++ b/src/beatmap/schema/v4/infoBeatmap.ts
@@ -2,6 +2,7 @@ import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IInfoBeatmap } from '../../../types/beatmap/v4/info.ts';
 import type { IWrapInfoBeatmapAttribute } from '../../../types/beatmap/wrapper/info.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createInfoBeatmap } from '../../core/infoBeatmap.ts';
 
 /**
  * Schema serialization for v4 `Info Beatmap`.
@@ -25,20 +26,20 @@ export const infoBeatmap: ISchemaContainer<IWrapInfoBeatmapAttribute, IInfoBeatm
       };
    },
    deserialize(data) {
-      return {
-         characteristic: data.characteristic ?? 'Standard',
-         difficulty: data.difficulty ?? 'Easy',
+      return createInfoBeatmap({
+         characteristic: data.characteristic,
+         difficulty: data.difficulty,
          authors: {
-            mappers: data.beatmapAuthors?.mappers?.map((s) => s),
-            lighters: data.beatmapAuthors?.lighters?.map((s) => s),
+            mappers: data.beatmapAuthors?.mappers,
+            lighters: data.beatmapAuthors?.lighters,
          },
-         filename: data.beatmapDataFilename ?? 'Easy.beatmap.dat',
-         lightshowFilename: data.lightshowDataFilename ?? 'Easy.lightshow.dat',
-         njs: data.noteJumpMovementSpeed ?? 0,
-         njsOffset: data.noteJumpStartBeatOffset ?? 0,
-         colorSchemeId: data.beatmapColorSchemeIdx ?? -1,
-         environmentId: data.environmentNameIdx ?? 0,
-         customData: data.customData ?? {},
-      };
+         filename: data.beatmapDataFilename,
+         lightshowFilename: data.lightshowDataFilename,
+         njs: data.noteJumpMovementSpeed,
+         njsOffset: data.noteJumpStartBeatOffset,
+         colorSchemeId: data.beatmapColorSchemeIdx,
+         environmentId: data.environmentNameIdx,
+         customData: data.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v4/infoBeatmap.ts
+++ b/src/beatmap/schema/v4/infoBeatmap.ts
@@ -1,14 +1,13 @@
-import type { IInfoBeatmap } from '../../../types/beatmap/v4/info.ts';
-import { deepCopy } from '../../../utils/misc.ts';
-import type { IWrapInfoBeatmapAttribute } from '../../../types/beatmap/wrapper/info.ts';
-import type { DeepPartial } from '../../../types/utils.ts';
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
+import type { IInfoBeatmap } from '../../../types/beatmap/v4/info.ts';
+import type { IWrapInfoBeatmapAttribute } from '../../../types/beatmap/wrapper/info.ts';
+import { deepCopy } from '../../../utils/misc.ts';
 
 /**
  * Schema serialization for v4 `Info Beatmap`.
  */
 export const infoBeatmap: ISchemaContainer<IWrapInfoBeatmapAttribute, IInfoBeatmap> = {
-   serialize(data: IWrapInfoBeatmapAttribute): IInfoBeatmap {
+   serialize(data) {
       return {
          characteristic: data.characteristic,
          difficulty: data.difficulty,
@@ -25,21 +24,21 @@ export const infoBeatmap: ISchemaContainer<IWrapInfoBeatmapAttribute, IInfoBeatm
          customData: deepCopy(data.customData),
       };
    },
-   deserialize(data: DeepPartial<IInfoBeatmap> = {}): DeepPartial<IWrapInfoBeatmapAttribute> {
+   deserialize(data) {
       return {
-         characteristic: data.characteristic,
-         difficulty: data.difficulty,
+         characteristic: data.characteristic ?? 'Standard',
+         difficulty: data.difficulty ?? 'Easy',
          authors: {
             mappers: data.beatmapAuthors?.mappers?.map((s) => s),
             lighters: data.beatmapAuthors?.lighters?.map((s) => s),
          },
-         filename: data.beatmapDataFilename,
-         lightshowFilename: data.lightshowDataFilename,
-         njs: data.noteJumpMovementSpeed,
-         njsOffset: data.noteJumpStartBeatOffset,
-         colorSchemeId: data.beatmapColorSchemeIdx,
-         environmentId: data.environmentNameIdx,
-         customData: data.customData,
+         filename: data.beatmapDataFilename ?? 'Easy.beatmap.dat',
+         lightshowFilename: data.lightshowDataFilename ?? 'Easy.lightshow.dat',
+         njs: data.noteJumpMovementSpeed ?? 0,
+         njsOffset: data.noteJumpStartBeatOffset ?? 0,
+         colorSchemeId: data.beatmapColorSchemeIdx ?? -1,
+         environmentId: data.environmentNameIdx ?? 0,
+         customData: data.customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v4/lightColorEvent.ts
+++ b/src/beatmap/schema/v4/lightColorEvent.ts
@@ -1,8 +1,7 @@
-import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { ILightColorEventContainer } from '../../../types/beatmap/container/v4.ts';
+import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IWrapLightColorEventAttribute } from '../../../types/beatmap/wrapper/lightColorEvent.ts';
 import { deepCopy } from '../../../utils/misc.ts';
-import type { DeepPartial } from '../../../types/utils.ts';
 
 /**
  * Schema serialization for v4 `Light Color Event`.
@@ -11,7 +10,7 @@ export const lightColorEvent: ISchemaContainer<
    IWrapLightColorEventAttribute,
    ILightColorEventContainer
 > = {
-   serialize(data: IWrapLightColorEventAttribute): ILightColorEventContainer {
+   serialize(data) {
       return {
          data: {
             p: data.previous,
@@ -26,19 +25,17 @@ export const lightColorEvent: ISchemaContainer<
          time: data.time,
       };
    },
-   deserialize(
-      data: DeepPartial<ILightColorEventContainer> = {},
-   ): Partial<IWrapLightColorEventAttribute> {
+   deserialize(data) {
       return {
-         time: data.time,
-         previous: data.data?.p,
-         color: data.data?.c,
-         frequency: data.data?.f,
-         easing: data.data?.e,
-         brightness: data.data?.b,
-         strobeBrightness: data.data?.sb,
-         strobeFade: data.data?.sf,
-         customData: data.data?.customData,
+         time: data.time ?? 0,
+         previous: data.data?.p ?? 0,
+         color: data.data?.c ?? 0,
+         frequency: data.data?.f ?? 0,
+         easing: data.data?.e ?? 0,
+         brightness: data.data?.b ?? 0,
+         strobeBrightness: data.data?.sb ?? 0,
+         strobeFade: data.data?.sf ?? 0,
+         customData: data.data?.customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v4/lightColorEvent.ts
+++ b/src/beatmap/schema/v4/lightColorEvent.ts
@@ -2,6 +2,7 @@ import type { ILightColorEventContainer } from '../../../types/beatmap/container
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IWrapLightColorEventAttribute } from '../../../types/beatmap/wrapper/lightColorEvent.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createLightColorEvent } from '../../core/lightColorEvent.ts';
 
 /**
  * Schema serialization for v4 `Light Color Event`.
@@ -26,16 +27,16 @@ export const lightColorEvent: ISchemaContainer<
       };
    },
    deserialize(data) {
-      return {
-         time: data.time ?? 0,
-         previous: data.data?.p ?? 0,
-         color: data.data?.c ?? 0,
-         frequency: data.data?.f ?? 0,
-         easing: data.data?.e ?? 0,
-         brightness: data.data?.b ?? 0,
-         strobeBrightness: data.data?.sb ?? 0,
-         strobeFade: data.data?.sf ?? 0,
-         customData: data.data?.customData ?? {},
-      };
+      return createLightColorEvent({
+         time: data.time,
+         previous: data.data?.p,
+         color: data.data?.c,
+         frequency: data.data?.f,
+         easing: data.data?.e,
+         brightness: data.data?.b,
+         strobeBrightness: data.data?.sb,
+         strobeFade: data.data?.sf,
+         customData: data.data?.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v4/lightColorEventBox.ts
+++ b/src/beatmap/schema/v4/lightColorEventBox.ts
@@ -1,7 +1,6 @@
-import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { ILightColorBoxContainer } from '../../../types/beatmap/container/v4.ts';
+import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IWrapLightColorEventBoxAttribute } from '../../../types/beatmap/wrapper/lightColorEventBox.ts';
-import type { DeepPartial } from '../../../types/utils.ts';
 import { deepCopy } from '../../../utils/misc.ts';
 import { indexFilter } from './indexFilter.ts';
 import { lightColorEvent } from './lightColorEvent.ts';
@@ -13,7 +12,7 @@ export const lightColorEventBox: ISchemaContainer<
    IWrapLightColorEventBoxAttribute,
    ILightColorBoxContainer
 > = {
-   serialize(data: IWrapLightColorEventBoxAttribute): ILightColorBoxContainer {
+   serialize(data) {
       return {
          data: {
             w: data.beatDistribution,
@@ -24,23 +23,25 @@ export const lightColorEventBox: ISchemaContainer<
             e: data.easing,
             customData: deepCopy(data.customData),
          },
-         eventData: data.events.map(lightColorEvent.serialize),
+         eventData: data.events.map((x) => {
+            return lightColorEvent.serialize(x);
+         }),
          filterData: indexFilter.serialize(data.filter),
       };
    },
-   deserialize(
-      data: DeepPartial<ILightColorBoxContainer> = {},
-   ): DeepPartial<IWrapLightColorEventBoxAttribute> {
+   deserialize(data) {
       return {
-         filter: indexFilter.deserialize(data.filterData),
-         beatDistribution: data.data?.w,
-         beatDistributionType: data.data?.d,
-         brightnessDistribution: data.data?.s,
-         brightnessDistributionType: data.data?.t,
-         affectFirst: data.data?.b,
-         easing: data.data?.e,
-         events: data.eventData?.map(lightColorEvent.deserialize),
-         customData: data.data?.customData,
+         filter: indexFilter.deserialize(data.filterData ?? {}),
+         beatDistribution: data.data?.w ?? 0,
+         beatDistributionType: data.data?.d ?? 1,
+         brightnessDistribution: data.data?.s ?? 0,
+         brightnessDistributionType: data.data?.t ?? 1,
+         affectFirst: data.data?.b ?? 0,
+         easing: data.data?.e ?? 0,
+         events: data.eventData?.map((x) => {
+            return lightColorEvent.deserialize(x);
+         }) ?? [],
+         customData: data.data?.customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v4/lightColorEventBox.ts
+++ b/src/beatmap/schema/v4/lightColorEventBox.ts
@@ -2,6 +2,7 @@ import type { ILightColorBoxContainer } from '../../../types/beatmap/container/v
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IWrapLightColorEventBoxAttribute } from '../../../types/beatmap/wrapper/lightColorEventBox.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createLightColorEventBox } from '../../core/lightColorEventBox.ts';
 import { indexFilter } from './indexFilter.ts';
 import { lightColorEvent } from './lightColorEvent.ts';
 
@@ -30,18 +31,18 @@ export const lightColorEventBox: ISchemaContainer<
       };
    },
    deserialize(data) {
-      return {
+      return createLightColorEventBox({
          filter: indexFilter.deserialize(data.filterData ?? {}),
-         beatDistribution: data.data?.w ?? 0,
-         beatDistributionType: data.data?.d ?? 1,
-         brightnessDistribution: data.data?.s ?? 0,
-         brightnessDistributionType: data.data?.t ?? 1,
-         affectFirst: data.data?.b ?? 0,
-         easing: data.data?.e ?? 0,
+         beatDistribution: data.data?.w,
+         beatDistributionType: data.data?.d,
+         brightnessDistribution: data.data?.s,
+         brightnessDistributionType: data.data?.t,
+         affectFirst: data.data?.b,
+         easing: data.data?.e,
          events: data.eventData?.map((x) => {
             return lightColorEvent.deserialize(x);
-         }) ?? [],
-         customData: data.data?.customData ?? {},
-      };
+         }),
+         customData: data.data?.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v4/lightColorEventBoxGroup.ts
+++ b/src/beatmap/schema/v4/lightColorEventBoxGroup.ts
@@ -6,6 +6,7 @@ import { EventBoxType } from '../../../types/beatmap/shared/constants.ts';
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IWrapLightColorEventBoxGroupAttribute } from '../../../types/beatmap/wrapper/lightColorEventBoxGroup.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createLightColorEventBoxGroup } from '../../core/lightColorEventBoxGroup.ts';
 import { lightColorEventBox } from './lightColorEventBox.ts';
 
 /**
@@ -30,13 +31,13 @@ export const lightColorEventBoxGroup: ISchemaContainer<
       };
    },
    deserialize(data) {
-      return {
-         time: data.object?.b ?? 0,
-         id: data.object?.g ?? 0,
+      return createLightColorEventBoxGroup({
+         time: data.object?.b,
+         id: data.object?.g,
          boxes: data.boxData?.map((x) => {
             return lightColorEventBox.deserialize(x);
-         }) ?? [],
-         customData: data.object?.customData ?? {},
-      };
+         }),
+         customData: data.object?.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v4/lightColorEventBoxGroup.ts
+++ b/src/beatmap/schema/v4/lightColorEventBoxGroup.ts
@@ -1,11 +1,12 @@
-import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
-import type { DeepPartial } from '../../../types/utils.ts';
-import { lightColorEventBox } from './lightColorEventBox.ts';
-import { deepCopy } from '../../../utils/misc.ts';
-import type { IWrapLightColorEventBoxGroupAttribute } from '../../../types/beatmap/wrapper/lightColorEventBoxGroup.ts';
-import type { IEventBoxGroupContainer } from '../../../types/beatmap/container/v4.ts';
+import type {
+   IEventBoxGroupContainer,
+   ILightColorBoxContainer,
+} from '../../../types/beatmap/container/v4.ts';
 import { EventBoxType } from '../../../types/beatmap/shared/constants.ts';
-import type { ILightColorBoxContainer } from '../../../types/beatmap/container/v4.ts';
+import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
+import type { IWrapLightColorEventBoxGroupAttribute } from '../../../types/beatmap/wrapper/lightColorEventBoxGroup.ts';
+import { deepCopy } from '../../../utils/misc.ts';
+import { lightColorEventBox } from './lightColorEventBox.ts';
 
 /**
  * Schema serialization for v4 `Light Color Event Box Group`.
@@ -14,9 +15,7 @@ export const lightColorEventBoxGroup: ISchemaContainer<
    IWrapLightColorEventBoxGroupAttribute,
    IEventBoxGroupContainer<ILightColorBoxContainer>
 > = {
-   serialize(
-      data: IWrapLightColorEventBoxGroupAttribute,
-   ): IEventBoxGroupContainer<ILightColorBoxContainer> {
+   serialize(data) {
       return {
          object: {
             t: EventBoxType.COLOR,
@@ -25,17 +24,19 @@ export const lightColorEventBoxGroup: ISchemaContainer<
             e: [],
             customData: deepCopy(data.customData),
          },
-         boxData: data.boxes.map(lightColorEventBox.serialize),
+         boxData: data.boxes.map((x) => {
+            return lightColorEventBox.serialize(x);
+         }),
       };
    },
-   deserialize(
-      data: DeepPartial<IEventBoxGroupContainer<ILightColorBoxContainer>> = {},
-   ): DeepPartial<IWrapLightColorEventBoxGroupAttribute> {
+   deserialize(data) {
       return {
-         time: data.object?.b,
-         id: data.object?.g,
-         boxes: data.boxData?.map(lightColorEventBox.deserialize),
-         customData: data.object?.customData,
+         time: data.object?.b ?? 0,
+         id: data.object?.g ?? 0,
+         boxes: data.boxData?.map((x) => {
+            return lightColorEventBox.deserialize(x);
+         }) ?? [],
+         customData: data.object?.customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v4/lightRotationEvent.ts
+++ b/src/beatmap/schema/v4/lightRotationEvent.ts
@@ -2,6 +2,7 @@ import type { ILightRotationEventContainer } from '../../../types/beatmap/contai
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IWrapLightRotationEventAttribute } from '../../../types/beatmap/wrapper/lightRotationEvent.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createLightRotationEvent } from '../../core/lightRotationEvent.ts';
 
 /**
  * Schema serialization for v4 `Light Rotation Event`.
@@ -24,14 +25,14 @@ export const lightRotationEvent: ISchemaContainer<
       };
    },
    deserialize(data) {
-      return {
-         time: data.time ?? 0,
-         previous: data.data?.p ?? 0,
-         easing: data.data?.e ?? 0,
-         loop: data.data?.l ?? 0,
-         rotation: data.data?.r ?? 0,
-         direction: data.data?.d ?? 0,
-         customData: data.data?.customData ?? {},
-      };
+      return createLightRotationEvent({
+         time: data.time,
+         previous: data.data?.p,
+         easing: data.data?.e,
+         loop: data.data?.l,
+         rotation: data.data?.r,
+         direction: data.data?.d,
+         customData: data.data?.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v4/lightRotationEvent.ts
+++ b/src/beatmap/schema/v4/lightRotationEvent.ts
@@ -1,7 +1,6 @@
-import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { ILightRotationEventContainer } from '../../../types/beatmap/container/v4.ts';
+import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IWrapLightRotationEventAttribute } from '../../../types/beatmap/wrapper/lightRotationEvent.ts';
-import type { DeepPartial } from '../../../types/utils.ts';
 import { deepCopy } from '../../../utils/misc.ts';
 
 /**
@@ -11,7 +10,7 @@ export const lightRotationEvent: ISchemaContainer<
    IWrapLightRotationEventAttribute,
    ILightRotationEventContainer
 > = {
-   serialize(data: IWrapLightRotationEventAttribute): ILightRotationEventContainer {
+   serialize(data) {
       return {
          data: {
             p: data.previous,
@@ -24,17 +23,15 @@ export const lightRotationEvent: ISchemaContainer<
          time: data.time,
       };
    },
-   deserialize(
-      data: DeepPartial<ILightRotationEventContainer> = {},
-   ): Partial<IWrapLightRotationEventAttribute> {
+   deserialize(data) {
       return {
-         time: data.time,
-         previous: data.data?.p,
-         easing: data.data?.e,
-         loop: data.data?.l,
-         rotation: data.data?.r,
-         direction: data.data?.d,
-         customData: data.data?.customData,
+         time: data.time ?? 0,
+         previous: data.data?.p ?? 0,
+         easing: data.data?.e ?? 0,
+         loop: data.data?.l ?? 0,
+         rotation: data.data?.r ?? 0,
+         direction: data.data?.d ?? 0,
+         customData: data.data?.customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v4/lightRotationEventBox.ts
+++ b/src/beatmap/schema/v4/lightRotationEventBox.ts
@@ -2,6 +2,7 @@ import type { ILightRotationBoxContainer } from '../../../types/beatmap/containe
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IWrapLightRotationEventBoxAttribute } from '../../../types/beatmap/wrapper/lightRotationEventBox.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createLightRotationEventBox } from '../../core/lightRotationEventBox.ts';
 import { indexFilter } from './indexFilter.ts';
 import { lightRotationEvent } from './lightRotationEvent.ts';
 
@@ -32,20 +33,20 @@ export const lightRotationEventBox: ISchemaContainer<
       };
    },
    deserialize(data) {
-      return {
+      return createLightRotationEventBox({
          filter: indexFilter.deserialize(data.filterData ?? {}),
-         beatDistribution: data.data?.w ?? 0,
-         beatDistributionType: data.data?.d ?? 1,
-         rotationDistribution: data.data?.s ?? 0,
-         rotationDistributionType: data.data?.t ?? 1,
-         affectFirst: data.data?.b ?? 0,
-         easing: data.data?.e ?? 0,
-         axis: data.data?.a ?? 0,
-         flip: data.data?.f ?? 0,
+         beatDistribution: data.data?.w,
+         beatDistributionType: data.data?.d,
+         rotationDistribution: data.data?.s,
+         rotationDistributionType: data.data?.t,
+         affectFirst: data.data?.b,
+         easing: data.data?.e,
+         axis: data.data?.a,
+         flip: data.data?.f,
          events: data.eventData?.map((x) => {
             return lightRotationEvent.deserialize(x);
-         }) ?? [],
-         customData: data.data?.customData ?? {},
-      };
+         }),
+         customData: data.data?.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v4/lightRotationEventBox.ts
+++ b/src/beatmap/schema/v4/lightRotationEventBox.ts
@@ -1,7 +1,6 @@
-import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { ILightRotationBoxContainer } from '../../../types/beatmap/container/v4.ts';
+import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IWrapLightRotationEventBoxAttribute } from '../../../types/beatmap/wrapper/lightRotationEventBox.ts';
-import type { DeepPartial } from '../../../types/utils.ts';
 import { deepCopy } from '../../../utils/misc.ts';
 import { indexFilter } from './indexFilter.ts';
 import { lightRotationEvent } from './lightRotationEvent.ts';
@@ -13,7 +12,7 @@ export const lightRotationEventBox: ISchemaContainer<
    IWrapLightRotationEventBoxAttribute,
    ILightRotationBoxContainer
 > = {
-   serialize(data: IWrapLightRotationEventBoxAttribute): ILightRotationBoxContainer {
+   serialize(data) {
       return {
          data: {
             w: data.beatDistribution,
@@ -26,25 +25,27 @@ export const lightRotationEventBox: ISchemaContainer<
             f: data.flip,
             customData: deepCopy(data.customData),
          },
-         eventData: data.events.map(lightRotationEvent.serialize),
+         eventData: data.events.map((x) => {
+            return lightRotationEvent.serialize(x);
+         }),
          filterData: indexFilter.serialize(data.filter),
       };
    },
-   deserialize(
-      data: DeepPartial<ILightRotationBoxContainer> = {},
-   ): DeepPartial<IWrapLightRotationEventBoxAttribute> {
+   deserialize(data) {
       return {
-         filter: indexFilter.deserialize(data.filterData),
-         beatDistribution: data.data?.w,
-         beatDistributionType: data.data?.d,
-         rotationDistribution: data.data?.s,
-         rotationDistributionType: data.data?.t,
-         affectFirst: data.data?.b,
-         easing: data.data?.e,
-         axis: data.data?.a,
-         flip: data.data?.f,
-         events: data.eventData?.map(lightRotationEvent.deserialize),
-         customData: data.data?.customData,
+         filter: indexFilter.deserialize(data.filterData ?? {}),
+         beatDistribution: data.data?.w ?? 0,
+         beatDistributionType: data.data?.d ?? 1,
+         rotationDistribution: data.data?.s ?? 0,
+         rotationDistributionType: data.data?.t ?? 1,
+         affectFirst: data.data?.b ?? 0,
+         easing: data.data?.e ?? 0,
+         axis: data.data?.a ?? 0,
+         flip: data.data?.f ?? 0,
+         events: data.eventData?.map((x) => {
+            return lightRotationEvent.deserialize(x);
+         }) ?? [],
+         customData: data.data?.customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v4/lightRotationEventBoxGroup.ts
+++ b/src/beatmap/schema/v4/lightRotationEventBoxGroup.ts
@@ -6,6 +6,7 @@ import { EventBoxType } from '../../../types/beatmap/shared/constants.ts';
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IWrapLightRotationEventBoxGroupAttribute } from '../../../types/beatmap/wrapper/lightRotationEventBoxGroup.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createLightRotationEventBoxGroup } from '../../core/lightRotationEventBoxGroup.ts';
 import { lightRotationEventBox } from './lightRotationEventBox.ts';
 
 /**
@@ -15,9 +16,7 @@ export const lightRotationEventBoxGroup: ISchemaContainer<
    IWrapLightRotationEventBoxGroupAttribute,
    IEventBoxGroupContainer<ILightRotationBoxContainer>
 > = {
-   serialize(
-      data,
-   ) {
+   serialize(data) {
       return {
          object: {
             t: EventBoxType.ROTATION,
@@ -32,13 +31,13 @@ export const lightRotationEventBoxGroup: ISchemaContainer<
       };
    },
    deserialize(data) {
-      return {
-         time: data.object?.b ?? 0,
-         id: data.object?.g ?? 0,
+      return createLightRotationEventBoxGroup({
+         time: data.object?.b,
+         id: data.object?.g,
          boxes: data.boxData?.map((x) => {
             return lightRotationEventBox.deserialize(x);
-         }) ?? [],
-         customData: data.object?.customData ?? {},
-      };
+         }),
+         customData: data.object?.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v4/lightRotationEventBoxGroup.ts
+++ b/src/beatmap/schema/v4/lightRotationEventBoxGroup.ts
@@ -1,11 +1,12 @@
-import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
-import type { DeepPartial } from '../../../types/utils.ts';
-import { lightRotationEventBox } from './lightRotationEventBox.ts';
-import { deepCopy } from '../../../utils/misc.ts';
-import type { IWrapLightRotationEventBoxGroupAttribute } from '../../../types/beatmap/wrapper/lightRotationEventBoxGroup.ts';
-import type { IEventBoxGroupContainer } from '../../../types/beatmap/container/v4.ts';
+import type {
+   IEventBoxGroupContainer,
+   ILightRotationBoxContainer,
+} from '../../../types/beatmap/container/v4.ts';
 import { EventBoxType } from '../../../types/beatmap/shared/constants.ts';
-import type { ILightRotationBoxContainer } from '../../../types/beatmap/container/v4.ts';
+import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
+import type { IWrapLightRotationEventBoxGroupAttribute } from '../../../types/beatmap/wrapper/lightRotationEventBoxGroup.ts';
+import { deepCopy } from '../../../utils/misc.ts';
+import { lightRotationEventBox } from './lightRotationEventBox.ts';
 
 /**
  * Schema serialization for v4 `Light Rotation Event Box Group`.
@@ -15,8 +16,8 @@ export const lightRotationEventBoxGroup: ISchemaContainer<
    IEventBoxGroupContainer<ILightRotationBoxContainer>
 > = {
    serialize(
-      data: IWrapLightRotationEventBoxGroupAttribute,
-   ): IEventBoxGroupContainer<ILightRotationBoxContainer> {
+      data,
+   ) {
       return {
          object: {
             t: EventBoxType.ROTATION,
@@ -25,17 +26,19 @@ export const lightRotationEventBoxGroup: ISchemaContainer<
             e: [],
             customData: deepCopy(data.customData),
          },
-         boxData: data.boxes.map(lightRotationEventBox.serialize),
+         boxData: data.boxes.map((x) => {
+            return lightRotationEventBox.serialize(x);
+         }),
       };
    },
-   deserialize(
-      data: DeepPartial<IEventBoxGroupContainer<ILightRotationBoxContainer>> = {},
-   ): DeepPartial<IWrapLightRotationEventBoxGroupAttribute> {
+   deserialize(data) {
       return {
-         time: data.object?.b,
-         id: data.object?.g,
-         boxes: data.boxData?.map(lightRotationEventBox.deserialize),
-         customData: data.object?.customData,
+         time: data.object?.b ?? 0,
+         id: data.object?.g ?? 0,
+         boxes: data.boxData?.map((x) => {
+            return lightRotationEventBox.deserialize(x);
+         }) ?? [],
+         customData: data.object?.customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v4/lightTranslationEvent.ts
+++ b/src/beatmap/schema/v4/lightTranslationEvent.ts
@@ -1,7 +1,6 @@
-import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { ILightTranslationEventContainer } from '../../../types/beatmap/container/v4.ts';
+import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IWrapLightTranslationEventAttribute } from '../../../types/beatmap/wrapper/lightTranslationEvent.ts';
-import type { DeepPartial } from '../../../types/utils.ts';
 import { deepCopy } from '../../../utils/misc.ts';
 
 /**
@@ -11,7 +10,7 @@ export const lightTranslationEvent: ISchemaContainer<
    IWrapLightTranslationEventAttribute,
    ILightTranslationEventContainer
 > = {
-   serialize(data: IWrapLightTranslationEventAttribute): ILightTranslationEventContainer {
+   serialize(data) {
       return {
          data: {
             p: data.previous,
@@ -22,15 +21,13 @@ export const lightTranslationEvent: ISchemaContainer<
          time: data.time,
       };
    },
-   deserialize(
-      data: DeepPartial<ILightTranslationEventContainer> = {},
-   ): Partial<IWrapLightTranslationEventAttribute> {
+   deserialize(data) {
       return {
-         time: data.time,
-         previous: data.data?.p,
-         easing: data.data?.e,
-         translation: data.data?.t,
-         customData: data.data?.customData,
+         time: data.time ?? 0,
+         previous: data.data?.p ?? 0,
+         easing: data.data?.e ?? 0,
+         translation: data.data?.t ?? 0,
+         customData: data.data?.customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v4/lightTranslationEvent.ts
+++ b/src/beatmap/schema/v4/lightTranslationEvent.ts
@@ -2,6 +2,7 @@ import type { ILightTranslationEventContainer } from '../../../types/beatmap/con
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IWrapLightTranslationEventAttribute } from '../../../types/beatmap/wrapper/lightTranslationEvent.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createLightTranslationEvent } from '../../core/lightTranslationEvent.ts';
 
 /**
  * Schema serialization for v4 `Light Translation Event`.
@@ -22,12 +23,12 @@ export const lightTranslationEvent: ISchemaContainer<
       };
    },
    deserialize(data) {
-      return {
-         time: data.time ?? 0,
-         previous: data.data?.p ?? 0,
-         easing: data.data?.e ?? 0,
-         translation: data.data?.t ?? 0,
-         customData: data.data?.customData ?? {},
-      };
+      return createLightTranslationEvent({
+         time: data.time,
+         previous: data.data?.p,
+         easing: data.data?.e,
+         translation: data.data?.t,
+         customData: data.data?.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v4/lightTranslationEventBox.ts
+++ b/src/beatmap/schema/v4/lightTranslationEventBox.ts
@@ -1,7 +1,6 @@
-import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { ILightTranslationBoxContainer } from '../../../types/beatmap/container/v4.ts';
+import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IWrapLightTranslationEventBoxAttribute } from '../../../types/beatmap/wrapper/lightTranslationEventBox.ts';
-import type { DeepPartial } from '../../../types/utils.ts';
 import { deepCopy } from '../../../utils/misc.ts';
 import { indexFilter } from './indexFilter.ts';
 import { lightTranslationEvent } from './lightTranslationEvent.ts';
@@ -13,7 +12,7 @@ export const lightTranslationEventBox: ISchemaContainer<
    IWrapLightTranslationEventBoxAttribute,
    ILightTranslationBoxContainer
 > = {
-   serialize(data: IWrapLightTranslationEventBoxAttribute): ILightTranslationBoxContainer {
+   serialize(data) {
       return {
          data: {
             w: data.beatDistribution,
@@ -26,25 +25,27 @@ export const lightTranslationEventBox: ISchemaContainer<
             f: data.flip,
             customData: deepCopy(data.customData),
          },
-         eventData: data.events.map(lightTranslationEvent.serialize),
+         eventData: data.events.map((x) => {
+            return lightTranslationEvent.serialize(x);
+         }),
          filterData: indexFilter.serialize(data.filter),
       };
    },
-   deserialize(
-      data: DeepPartial<ILightTranslationBoxContainer> = {},
-   ): DeepPartial<IWrapLightTranslationEventBoxAttribute> {
+   deserialize(data) {
       return {
-         filter: indexFilter.deserialize(data.filterData),
-         beatDistribution: data.data?.w,
-         beatDistributionType: data.data?.d,
-         gapDistribution: data.data?.s,
-         gapDistributionType: data.data?.t,
-         affectFirst: data.data?.b,
-         easing: data.data?.e,
-         axis: data.data?.a,
-         flip: data.data?.f,
-         events: data.eventData?.map(lightTranslationEvent.deserialize),
-         customData: data.data?.customData,
+         filter: indexFilter.deserialize(data.filterData ?? {}),
+         beatDistribution: data.data?.w ?? 0,
+         beatDistributionType: data.data?.d ?? 1,
+         gapDistribution: data.data?.s ?? 0,
+         gapDistributionType: data.data?.t ?? 1,
+         affectFirst: data.data?.b ?? 0,
+         easing: data.data?.e ?? 0,
+         axis: data.data?.a ?? 0,
+         flip: data.data?.f ?? 0,
+         events: data.eventData?.map((x) => {
+            return lightTranslationEvent.deserialize(x);
+         }) ?? [],
+         customData: data.data?.customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v4/lightTranslationEventBox.ts
+++ b/src/beatmap/schema/v4/lightTranslationEventBox.ts
@@ -2,6 +2,7 @@ import type { ILightTranslationBoxContainer } from '../../../types/beatmap/conta
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IWrapLightTranslationEventBoxAttribute } from '../../../types/beatmap/wrapper/lightTranslationEventBox.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createLightTranslationEventBox } from '../../core/lightTranslationEventBox.ts';
 import { indexFilter } from './indexFilter.ts';
 import { lightTranslationEvent } from './lightTranslationEvent.ts';
 
@@ -32,20 +33,20 @@ export const lightTranslationEventBox: ISchemaContainer<
       };
    },
    deserialize(data) {
-      return {
+      return createLightTranslationEventBox({
          filter: indexFilter.deserialize(data.filterData ?? {}),
-         beatDistribution: data.data?.w ?? 0,
-         beatDistributionType: data.data?.d ?? 1,
-         gapDistribution: data.data?.s ?? 0,
-         gapDistributionType: data.data?.t ?? 1,
-         affectFirst: data.data?.b ?? 0,
-         easing: data.data?.e ?? 0,
-         axis: data.data?.a ?? 0,
-         flip: data.data?.f ?? 0,
+         beatDistribution: data.data?.w,
+         beatDistributionType: data.data?.d,
+         gapDistribution: data.data?.s,
+         gapDistributionType: data.data?.t,
+         affectFirst: data.data?.b,
+         easing: data.data?.e,
+         axis: data.data?.a,
+         flip: data.data?.f,
          events: data.eventData?.map((x) => {
             return lightTranslationEvent.deserialize(x);
-         }) ?? [],
-         customData: data.data?.customData ?? {},
-      };
+         }),
+         customData: data.data?.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v4/lightTranslationEventBoxGroup.ts
+++ b/src/beatmap/schema/v4/lightTranslationEventBoxGroup.ts
@@ -1,11 +1,12 @@
-import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
-import type { DeepPartial } from '../../../types/utils.ts';
-import { lightTranslationEventBox } from './lightTranslationEventBox.ts';
-import { deepCopy } from '../../../utils/misc.ts';
-import type { IWrapLightTranslationEventBoxGroupAttribute } from '../../../types/beatmap/wrapper/lightTranslationEventBoxGroup.ts';
-import type { IEventBoxGroupContainer } from '../../../types/beatmap/container/v4.ts';
+import type {
+   IEventBoxGroupContainer,
+   ILightTranslationBoxContainer,
+} from '../../../types/beatmap/container/v4.ts';
 import { EventBoxType } from '../../../types/beatmap/shared/constants.ts';
-import type { ILightTranslationBoxContainer } from '../../../types/beatmap/container/v4.ts';
+import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
+import type { IWrapLightTranslationEventBoxGroupAttribute } from '../../../types/beatmap/wrapper/lightTranslationEventBoxGroup.ts';
+import { deepCopy } from '../../../utils/misc.ts';
+import { lightTranslationEventBox } from './lightTranslationEventBox.ts';
 
 /**
  * Schema serialization for v4 `Light Translation Event Box Group`.
@@ -14,9 +15,7 @@ export const lightTranslationEventBoxGroup: ISchemaContainer<
    IWrapLightTranslationEventBoxGroupAttribute,
    IEventBoxGroupContainer<ILightTranslationBoxContainer>
 > = {
-   serialize(
-      data: IWrapLightTranslationEventBoxGroupAttribute,
-   ): IEventBoxGroupContainer<ILightTranslationBoxContainer> {
+   serialize(data) {
       return {
          object: {
             t: EventBoxType.TRANSLATION,
@@ -25,17 +24,19 @@ export const lightTranslationEventBoxGroup: ISchemaContainer<
             e: [],
             customData: deepCopy(data.customData),
          },
-         boxData: data.boxes.map(lightTranslationEventBox.serialize),
+         boxData: data.boxes.map((x) => {
+            return lightTranslationEventBox.serialize(x);
+         }),
       };
    },
-   deserialize(
-      data: DeepPartial<IEventBoxGroupContainer<ILightTranslationBoxContainer>> = {},
-   ): DeepPartial<IWrapLightTranslationEventBoxGroupAttribute> {
+   deserialize(data) {
       return {
-         time: data.object?.b,
-         id: data.object?.g,
-         boxes: data.boxData?.map(lightTranslationEventBox.deserialize),
-         customData: data.object?.customData,
+         time: data.object?.b ?? 0,
+         id: data.object?.g ?? 0,
+         boxes: data.boxData?.map((x) => {
+            return lightTranslationEventBox.deserialize(x);
+         }) ?? [],
+         customData: data.object?.customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v4/lightTranslationEventBoxGroup.ts
+++ b/src/beatmap/schema/v4/lightTranslationEventBoxGroup.ts
@@ -6,6 +6,7 @@ import { EventBoxType } from '../../../types/beatmap/shared/constants.ts';
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IWrapLightTranslationEventBoxGroupAttribute } from '../../../types/beatmap/wrapper/lightTranslationEventBoxGroup.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createLightTranslationEventBoxGroup } from '../../core/lightTranslationEventBoxGroup.ts';
 import { lightTranslationEventBox } from './lightTranslationEventBox.ts';
 
 /**
@@ -30,13 +31,13 @@ export const lightTranslationEventBoxGroup: ISchemaContainer<
       };
    },
    deserialize(data) {
-      return {
-         time: data.object?.b ?? 0,
-         id: data.object?.g ?? 0,
+      return createLightTranslationEventBoxGroup({
+         time: data.object?.b,
+         id: data.object?.g,
          boxes: data.boxData?.map((x) => {
             return lightTranslationEventBox.deserialize(x);
-         }) ?? [],
-         customData: data.object?.customData ?? {},
-      };
+         }),
+         customData: data.object?.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v4/lightshow.ts
+++ b/src/beatmap/schema/v4/lightshow.ts
@@ -1,24 +1,29 @@
+import { EventBoxType } from '../../../types/beatmap/shared/constants.ts';
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { ILightshow } from '../../../types/beatmap/v4/lightshow.ts';
-import { waypoint } from './waypoint.ts';
+import type { IObject } from '../../../types/beatmap/v4/object.ts';
+import type { IWrapBeatmapAttribute } from '../../../types/beatmap/wrapper/beatmap.ts';
+import { deepCopy } from '../../../utils/misc.ts';
+import { basicEventTypesWithKeywords } from '../v3/basicEventTypesWithKeywords.ts';
 import { basicEvent } from './basicEvent.ts';
 import { colorBoostEvent } from './colorBoostEvent.ts';
+import { fxEventBoxGroup } from './fxEventBoxGroup.ts';
 import { lightColorEventBoxGroup } from './lightColorEventBoxGroup.ts';
 import { lightRotationEventBoxGroup } from './lightRotationEventBoxGroup.ts';
 import { lightTranslationEventBoxGroup } from './lightTranslationEventBoxGroup.ts';
-import { fxEventBoxGroup } from './fxEventBoxGroup.ts';
-import type { DeepPartial } from '../../../types/utils.ts';
-import { deepCopy } from '../../../utils/misc.ts';
-import { EventBoxType } from '../../../types/beatmap/shared/constants.ts';
-import type { IObject } from '../../../types/beatmap/v4/object.ts';
-import type { IWrapBeatmapAttribute } from '../../../types/beatmap/wrapper/beatmap.ts';
-import { basicEventTypesWithKeywords } from '../v3/basicEventTypesWithKeywords.ts';
+import { waypoint } from './waypoint.ts';
+
+type LightshowPolyfills = Pick<IWrapBeatmapAttribute, 'filename' | 'lightshowFilename'>;
 
 /**
  * Schema serialization for v4 `Lightshow`.
  */
-export const lightshow: ISchemaContainer<IWrapBeatmapAttribute, ILightshow> = {
-   serialize(data: IWrapBeatmapAttribute): ILightshow {
+export const lightshow: ISchemaContainer<
+   IWrapBeatmapAttribute,
+   ILightshow,
+   LightshowPolyfills
+> = {
+   serialize(data) {
       const json: Required<ILightshow> = {
          version: '4.0.0',
          waypoints: [],
@@ -41,27 +46,39 @@ export const lightshow: ISchemaContainer<IWrapBeatmapAttribute, ILightshow> = {
             data.lightshow.basicEventTypesWithKeywords,
          ),
          useNormalEventsAsCompatibleEvents: data.lightshow.useNormalEventsAsCompatibleEvents,
-         customData: deepCopy(data.difficulty.customData),
+         customData: deepCopy(data.lightshow.customData),
       };
-      for (const jsonObj of data.lightshow.waypoints.map(waypoint.serialize)) {
+      for (
+         const jsonObj of data.lightshow.waypoints.map((x) => {
+            return waypoint.serialize(x);
+         })
+      ) {
          json.waypoints.push(jsonObj.object);
          jsonObj.object.i = json.waypointsData.length;
          json.waypointsData.push(jsonObj.data);
       }
-      for (const jsonObj of data.lightshow.basicEvents.map(basicEvent.serialize)) {
+      for (
+         const jsonObj of data.lightshow.basicEvents.map((x) => {
+            return basicEvent.serialize(x);
+         })
+      ) {
          json.basicEvents.push(jsonObj.object);
          jsonObj.object.i = json.basicEventsData.length;
          json.basicEventsData.push(jsonObj.data);
       }
-      for (const jsonObj of data.lightshow.colorBoostEvents.map(colorBoostEvent.serialize)) {
+      for (
+         const jsonObj of data.lightshow.colorBoostEvents.map((x) => {
+            return colorBoostEvent.serialize(x);
+         })
+      ) {
          json.colorBoostEvents.push(jsonObj.object);
          jsonObj.object.i = json.colorBoostEventsData.length;
          json.colorBoostEventsData.push(jsonObj.data);
       }
       for (
-         const obj of data.lightshow.lightColorEventBoxGroups.map(
-            lightColorEventBoxGroup.serialize,
-         )
+         const obj of data.lightshow.lightColorEventBoxGroups.map((x) => {
+            return lightColorEventBoxGroup.serialize(x);
+         })
       ) {
          json.eventBoxGroups.push(obj.object);
          for (const box of obj.boxData) {
@@ -84,9 +101,9 @@ export const lightshow: ISchemaContainer<IWrapBeatmapAttribute, ILightshow> = {
          }
       }
       for (
-         const obj of data.lightshow.lightRotationEventBoxGroups.map(
-            lightRotationEventBoxGroup.serialize,
-         )
+         const obj of data.lightshow.lightRotationEventBoxGroups.map((x) => {
+            return lightRotationEventBoxGroup.serialize(x);
+         })
       ) {
          json.eventBoxGroups.push(obj.object);
          for (const box of obj.boxData) {
@@ -109,9 +126,9 @@ export const lightshow: ISchemaContainer<IWrapBeatmapAttribute, ILightshow> = {
          }
       }
       for (
-         const obj of data.lightshow.lightTranslationEventBoxGroups.map(
-            lightTranslationEventBoxGroup.serialize,
-         )
+         const obj of data.lightshow.lightTranslationEventBoxGroups.map((x) => {
+            return lightTranslationEventBoxGroup.serialize(x);
+         })
       ) {
          json.eventBoxGroups.push(obj.object);
          for (const box of obj.boxData) {
@@ -133,7 +150,11 @@ export const lightshow: ISchemaContainer<IWrapBeatmapAttribute, ILightshow> = {
             json.indexFilters.push(box.filterData);
          }
       }
-      for (const obj of data.lightshow.fxEventBoxGroups.map(fxEventBoxGroup.serialize)) {
+      for (
+         const obj of data.lightshow.fxEventBoxGroups.map((x) => {
+            return fxEventBoxGroup.serialize(x);
+         })
+      ) {
          json.eventBoxGroups.push(obj.object);
          for (const box of obj.boxData) {
             const list: IObject[] = [];
@@ -154,34 +175,36 @@ export const lightshow: ISchemaContainer<IWrapBeatmapAttribute, ILightshow> = {
 
       return json;
    },
-   deserialize(data: DeepPartial<ILightshow> = {}): DeepPartial<IWrapBeatmapAttribute> {
-      const d: DeepPartial<IWrapBeatmapAttribute> = {
-         version: 4,
-         lightshow: {
-            lightColorEventBoxGroups: [],
-            lightRotationEventBoxGroups: [],
-            lightTranslationEventBoxGroups: [],
-            fxEventBoxGroups: [],
-         },
+   deserialize(data, options) {
+      const d: IWrapBeatmapAttribute['lightshow'] = {
+         lightColorEventBoxGroups: [],
+         lightRotationEventBoxGroups: [],
+         lightTranslationEventBoxGroups: [],
+         fxEventBoxGroups: [],
+         waypoints: data.waypoints?.map((obj) =>
+            waypoint.deserialize({
+               object: obj,
+               data: data.waypointsData?.[obj?.i || 0],
+            })
+         ) ?? [],
+         basicEvents: data.basicEvents?.map((obj) =>
+            basicEvent.deserialize({
+               object: obj,
+               data: data.basicEventsData?.[obj?.i || 0],
+            })
+         ) ?? [],
+         colorBoostEvents: data.colorBoostEvents?.map((obj) =>
+            colorBoostEvent.deserialize({
+               object: obj,
+               data: data.colorBoostEventsData?.[obj?.i || 0],
+            })
+         ) ?? [],
+         basicEventTypesWithKeywords: basicEventTypesWithKeywords.deserialize(
+            data.basicEventTypesWithKeywords,
+         ),
+         useNormalEventsAsCompatibleEvents: !!data.useNormalEventsAsCompatibleEvents,
+         customData: data.customData ?? {},
       };
-      d.lightshow!.waypoints = data.waypoints?.map((obj) =>
-         waypoint.deserialize({
-            object: obj,
-            data: data.waypointsData?.[obj?.i || 0],
-         })
-      );
-      d.lightshow!.basicEvents = data.basicEvents?.map((obj) =>
-         basicEvent.deserialize({
-            object: obj,
-            data: data.basicEventsData?.[obj?.i || 0],
-         })
-      );
-      d.lightshow!.colorBoostEvents = data.colorBoostEvents?.map((obj) =>
-         colorBoostEvent.deserialize({
-            object: obj,
-            data: data.colorBoostEventsData?.[obj?.i || 0],
-         })
-      );
       const indFil = data.indexFilters ?? [];
       const lceb = data.lightColorEventBoxes ?? [];
       const lce = data.lightColorEvents ?? [];
@@ -195,72 +218,84 @@ export const lightshow: ISchemaContainer<IWrapBeatmapAttribute, ILightshow> = {
          const t = ebg?.t || 0;
          switch (t) {
             case EventBoxType.COLOR:
-               d.lightshow!.lightColorEventBoxGroups!.push(
+               d.lightColorEventBoxGroups.push(
                   lightColorEventBoxGroup.deserialize({
-                     object: ebg,
+                     object: ebg ?? {},
                      boxData: ebg?.e?.map((e) => ({
                         data: lceb[e.e || 0],
                         filterData: indFil[e.f || 0],
                         eventData: e.l?.map((l) => ({
-                           time: l.b,
+                           time: l.b ?? 0,
                            data: lce[l.i || 0],
-                        })),
-                     })),
+                        })) ?? [],
+                     })) ?? [],
                   }),
                );
                break;
             case EventBoxType.ROTATION:
-               d.lightshow!.lightRotationEventBoxGroups!.push(
+               d.lightRotationEventBoxGroups.push(
                   lightRotationEventBoxGroup.deserialize({
                      object: ebg,
                      boxData: ebg?.e?.map((e) => ({
                         data: lreb[e.e || 0],
                         filterData: indFil[e.f || 0],
                         eventData: e.l?.map((l) => ({
-                           time: l.b,
+                           time: l.b ?? 0,
                            data: lre[l.i || 0],
-                        })),
-                     })),
+                        })) ?? [],
+                     })) ?? [],
                   }),
                );
                break;
             case EventBoxType.TRANSLATION:
-               d.lightshow!.lightTranslationEventBoxGroups!.push(
+               d.lightTranslationEventBoxGroups.push(
                   lightTranslationEventBoxGroup.deserialize({
                      object: ebg,
                      boxData: ebg?.e?.map((e) => ({
                         data: lteb[e.e || 0],
                         filterData: indFil[e.f || 0],
                         eventData: e.l?.map((l) => ({
-                           time: l.b,
+                           time: l.b ?? 0,
                            data: lte[l.i || 0],
-                        })),
-                     })),
+                        })) ?? [],
+                     })) ?? [],
                   }),
                );
                break;
             case EventBoxType.FX_FLOAT:
-               d.lightshow!.fxEventBoxGroups!.push(
+               d.fxEventBoxGroups.push(
                   fxEventBoxGroup.deserialize({
                      object: ebg,
                      boxData: ebg?.e?.map((e) => ({
                         data: fxb[e.e || 0],
                         filterData: indFil[e.f || 0],
                         eventData: e.l?.map((l) => ({
-                           time: l.b,
+                           time: l.b ?? 0,
                            data: fx[l.i || 0],
-                        })),
-                     })),
+                        })) ?? [],
+                     })) ?? [],
                   }),
                );
                break;
          }
       }
-      d.lightshow!.basicEventTypesWithKeywords = basicEventTypesWithKeywords.deserialize(
-         data.basicEventTypesWithKeywords,
-      );
-      d.lightshow!.useNormalEventsAsCompatibleEvents = !!data.useNormalEventsAsCompatibleEvents;
-      d.lightshow!.customData = data.customData;
-      return d;
+      return {
+         version: 4,
+         filename: options?.filename ?? 'Easy.beatmap.dat',
+         lightshowFilename: options?.filename ?? 'Easy.lightshow.dat',
+         difficulty: {
+            colorNotes: [],
+            bombNotes: [],
+            obstacles: [],
+            arcs: [],
+            chains: [],
+            bpmEvents: [],
+            rotationEvents: [],
+            njsEvents: [],
+            customData: {},
+         },
+         lightshow: d,
+         customData: {},
+      };
    },
 };

--- a/src/beatmap/schema/v4/njsEvent.ts
+++ b/src/beatmap/schema/v4/njsEvent.ts
@@ -2,6 +2,7 @@ import type { INjsEventContainer } from '../../../types/beatmap/container/v4.ts'
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IWrapNJSEventAttribute } from '../../../types/beatmap/wrapper/njsEvent.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createNJSEvent } from '../../core/njsEvent.ts';
 
 /**
  * Schema serialization for v4 `Basic Event`.
@@ -23,12 +24,12 @@ export const njsEvent: ISchemaContainer<IWrapNJSEventAttribute, INjsEventContain
       };
    },
    deserialize(data) {
-      return {
-         time: data.object?.b ?? 0,
-         value: data.data?.d ?? 0,
-         previous: data.data?.p ?? 0,
-         easing: data.data?.e ?? 0,
-         customData: data.data?.customData ?? {},
-      };
+      return createNJSEvent({
+         time: data.object?.b,
+         value: data.data?.d,
+         previous: data.data?.p,
+         easing: data.data?.e,
+         customData: data.data?.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v4/njsEvent.ts
+++ b/src/beatmap/schema/v4/njsEvent.ts
@@ -1,14 +1,13 @@
-import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
-import { deepCopy } from '../../../utils/misc.ts';
-import type { IWrapNJSEventAttribute } from '../../../types/beatmap/wrapper/njsEvent.ts';
 import type { INjsEventContainer } from '../../../types/beatmap/container/v4.ts';
-import type { DeepPartial } from '../../../types/utils.ts';
+import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
+import type { IWrapNJSEventAttribute } from '../../../types/beatmap/wrapper/njsEvent.ts';
+import { deepCopy } from '../../../utils/misc.ts';
 
 /**
  * Schema serialization for v4 `Basic Event`.
  */
 export const njsEvent: ISchemaContainer<IWrapNJSEventAttribute, INjsEventContainer> = {
-   serialize(data: IWrapNJSEventAttribute): INjsEventContainer {
+   serialize(data) {
       return {
          object: {
             b: data.time,
@@ -23,15 +22,13 @@ export const njsEvent: ISchemaContainer<IWrapNJSEventAttribute, INjsEventContain
          },
       };
    },
-   deserialize(
-      data: DeepPartial<INjsEventContainer> = {},
-   ): DeepPartial<IWrapNJSEventAttribute> {
+   deserialize(data) {
       return {
-         time: data.object?.b,
-         value: data.data?.d,
-         previous: data.data?.p,
-         easing: data.data?.e,
-         customData: data.data?.customData,
+         time: data.object?.b ?? 0,
+         value: data.data?.d ?? 0,
+         previous: data.data?.p ?? 0,
+         easing: data.data?.e ?? 0,
+         customData: data.data?.customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v4/obstacle.ts
+++ b/src/beatmap/schema/v4/obstacle.ts
@@ -1,14 +1,13 @@
-import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IObstacleContainer } from '../../../types/beatmap/container/v4.ts';
+import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IWrapObstacleAttribute } from '../../../types/beatmap/wrapper/obstacle.ts';
 import { deepCopy } from '../../../utils/misc.ts';
-import type { DeepPartial } from '../../../types/utils.ts';
 
 /**
  * Schema serialization for v4 `Obstacle`.
  */
 export const obstacle: ISchemaContainer<IWrapObstacleAttribute, IObstacleContainer> = {
-   serialize(data: IWrapObstacleAttribute): IObstacleContainer {
+   serialize(data) {
       return {
          object: {
             b: data.time,
@@ -26,16 +25,16 @@ export const obstacle: ISchemaContainer<IWrapObstacleAttribute, IObstacleContain
          },
       };
    },
-   deserialize(data: DeepPartial<IObstacleContainer> = {}): Partial<IWrapObstacleAttribute> {
+   deserialize(data) {
       return {
-         time: data.object?.b,
-         laneRotation: data.object?.r,
-         posX: data.data?.x,
-         posY: data.data?.y,
-         duration: data.data?.d,
-         width: data.data?.w,
-         height: data.data?.h,
-         customData: data.data?.customData,
+         time: data.object?.b ?? 0,
+         laneRotation: data.object?.r ?? 0,
+         posX: data.data?.x ?? 0,
+         posY: data.data?.y ?? 0,
+         duration: data.data?.d ?? 0,
+         width: data.data?.w ?? 0,
+         height: data.data?.h ?? 0,
+         customData: data.data?.customData ?? {},
       };
    },
 };

--- a/src/beatmap/schema/v4/obstacle.ts
+++ b/src/beatmap/schema/v4/obstacle.ts
@@ -2,6 +2,7 @@ import type { IObstacleContainer } from '../../../types/beatmap/container/v4.ts'
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IWrapObstacleAttribute } from '../../../types/beatmap/wrapper/obstacle.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createObstacle } from '../../core/obstacle.ts';
 
 /**
  * Schema serialization for v4 `Obstacle`.
@@ -26,15 +27,15 @@ export const obstacle: ISchemaContainer<IWrapObstacleAttribute, IObstacleContain
       };
    },
    deserialize(data) {
-      return {
-         time: data.object?.b ?? 0,
-         laneRotation: data.object?.r ?? 0,
-         posX: data.data?.x ?? 0,
-         posY: data.data?.y ?? 0,
-         duration: data.data?.d ?? 0,
-         width: data.data?.w ?? 0,
-         height: data.data?.h ?? 0,
-         customData: data.data?.customData ?? {},
-      };
+      return createObstacle({
+         time: data.object?.b,
+         laneRotation: data.object?.r,
+         posX: data.data?.x,
+         posY: data.data?.y,
+         duration: data.data?.d,
+         width: data.data?.w,
+         height: data.data?.h,
+         customData: data.data?.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v4/rotationEvent.ts
+++ b/src/beatmap/schema/v4/rotationEvent.ts
@@ -1,7 +1,6 @@
-import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { ISpawnRotationContainer } from '../../../types/beatmap/container/v4.ts';
+import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IWrapRotationEventAttribute } from '../../../types/beatmap/wrapper/rotationEvent.ts';
-import type { DeepPartial } from '../../../types/utils.ts';
 import { deepCopy } from '../../../utils/misc.ts';
 
 /**
@@ -9,26 +8,26 @@ import { deepCopy } from '../../../utils/misc.ts';
  *
  * @deprecated removed as of 1.39, convert to `r` in object lane
  */
-export const rotationEvent: ISchemaContainer<IWrapRotationEventAttribute, ISpawnRotationContainer> =
-   {
-      serialize(data: IWrapRotationEventAttribute): ISpawnRotationContainer {
-         return {
-            object: { b: data.time },
-            data: {
-               e: data.executionTime,
-               r: data.rotation,
-               customData: deepCopy(data.customData),
-            },
-         };
-      },
-      deserialize(
-         data: DeepPartial<ISpawnRotationContainer> = {},
-      ): Partial<IWrapRotationEventAttribute> {
-         return {
-            time: data.object?.b,
-            executionTime: data.data?.e,
-            rotation: data.data?.r,
-            customData: data.data?.customData,
-         };
-      },
-   };
+export const rotationEvent: ISchemaContainer<
+   IWrapRotationEventAttribute,
+   ISpawnRotationContainer
+> = {
+   serialize(data) {
+      return {
+         object: { b: data.time },
+         data: {
+            e: data.executionTime,
+            r: data.rotation,
+            customData: deepCopy(data.customData),
+         },
+      };
+   },
+   deserialize(data) {
+      return {
+         time: data.object?.b ?? 0,
+         executionTime: data.data?.e ?? 0,
+         rotation: data.data?.r ?? 0,
+         customData: data.data?.customData ?? {},
+      };
+   },
+};

--- a/src/beatmap/schema/v4/rotationEvent.ts
+++ b/src/beatmap/schema/v4/rotationEvent.ts
@@ -2,6 +2,7 @@ import type { ISpawnRotationContainer } from '../../../types/beatmap/container/v
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IWrapRotationEventAttribute } from '../../../types/beatmap/wrapper/rotationEvent.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createRotationEvent } from '../../core/rotationEvent.ts';
 
 /**
  * Schema serialization for v4 `Rotation Event`.
@@ -23,11 +24,11 @@ export const rotationEvent: ISchemaContainer<
       };
    },
    deserialize(data) {
-      return {
-         time: data.object?.b ?? 0,
-         executionTime: data.data?.e ?? 0,
-         rotation: data.data?.r ?? 0,
-         customData: data.data?.customData ?? {},
-      };
+      return createRotationEvent({
+         time: data.object?.b,
+         executionTime: data.data?.e,
+         rotation: data.data?.r,
+         customData: data.data?.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v4/waypoint.ts
+++ b/src/beatmap/schema/v4/waypoint.ts
@@ -2,12 +2,13 @@ import type { IWaypointContainer } from '../../../types/beatmap/container/v4.ts'
 import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IWrapWaypointAttribute } from '../../../types/beatmap/wrapper/waypoint.ts';
 import { deepCopy } from '../../../utils/misc.ts';
+import { createWaypoint } from '../../core/waypoint.ts';
 
 /**
  * Schema serialization for v4 `Waypoint`.
  */
 export const waypoint: ISchemaContainer<IWrapWaypointAttribute, IWaypointContainer> = {
-   serialize(data: IWrapWaypointAttribute): Required<IWaypointContainer> {
+   serialize(data) {
       return {
          object: {
             b: data.time,
@@ -24,13 +25,13 @@ export const waypoint: ISchemaContainer<IWrapWaypointAttribute, IWaypointContain
       };
    },
    deserialize(data) {
-      return {
-         time: data.object?.b ?? 0,
-         laneRotation: data.object?.r ?? 0,
-         posX: data.data?.x ?? 0,
-         posY: data.data?.y ?? 0,
-         direction: data.data?.d ?? 0,
-         customData: data.data?.customData ?? {},
-      };
+      return createWaypoint({
+         time: data.object?.b,
+         laneRotation: data.object?.r,
+         posX: data.data?.x,
+         posY: data.data?.y,
+         direction: data.data?.d,
+         customData: data.data?.customData,
+      });
    },
 };

--- a/src/beatmap/schema/v4/waypoint.ts
+++ b/src/beatmap/schema/v4/waypoint.ts
@@ -1,7 +1,6 @@
-import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IWaypointContainer } from '../../../types/beatmap/container/v4.ts';
+import type { ISchemaContainer } from '../../../types/beatmap/shared/schema.ts';
 import type { IWrapWaypointAttribute } from '../../../types/beatmap/wrapper/waypoint.ts';
-import type { DeepPartial } from '../../../types/utils.ts';
 import { deepCopy } from '../../../utils/misc.ts';
 
 /**
@@ -24,14 +23,14 @@ export const waypoint: ISchemaContainer<IWrapWaypointAttribute, IWaypointContain
          },
       };
    },
-   deserialize(data: DeepPartial<IWaypointContainer> = {}): Partial<IWrapWaypointAttribute> {
+   deserialize(data) {
       return {
-         time: data.object?.b,
-         laneRotation: data.object?.r,
-         posX: data.data?.x,
-         posY: data.data?.y,
-         direction: data.data?.d,
-         customData: data.data?.customData,
+         time: data.object?.b ?? 0,
+         laneRotation: data.object?.r ?? 0,
+         posX: data.data?.x ?? 0,
+         posY: data.data?.y ?? 0,
+         direction: data.data?.d ?? 0,
+         customData: data.data?.customData ?? {},
       };
    },
 };

--- a/src/extensions/chroma/easingColor.ts
+++ b/src/extensions/chroma/easingColor.ts
@@ -2,10 +2,9 @@ import { isLightEventType, isOnEventValue } from '../../beatmap/helpers/core/bas
 import type { IWrapBasicEventAttribute } from '../../types/beatmap/wrapper/basicEvent.ts';
 import type { IApplyEasingsOptions } from './types/colors.ts';
 
-export function applyEasingsTransition(
-   events: IWrapBasicEventAttribute[],
-   options: IApplyEasingsOptions,
-): void {
+export function applyEasingsTransition<
+   T extends Pick<IWrapBasicEventAttribute, 'type' | 'value' | 'customData'>,
+>(events: T[], options: IApplyEasingsOptions): void {
    let filteredEvents = events.filter((ev) =>
       isLightEventType(ev.type) && isOnEventValue(ev.value)
    );

--- a/src/extensions/chroma/easingColor.ts
+++ b/src/extensions/chroma/easingColor.ts
@@ -1,16 +1,18 @@
+import { isLightEventType, isOnEventValue } from '../../beatmap/helpers/core/basicEvent.ts';
+import type { IWrapBasicEventAttribute } from '../../types/beatmap/wrapper/basicEvent.ts';
 import type { IApplyEasingsOptions } from './types/colors.ts';
-import type { BasicEvent } from '../../beatmap/core/basicEvent.ts';
-import type { IChromaEventLight } from '../../types/beatmap/v3/custom/chroma.ts';
 
 export function applyEasingsTransition(
-   events: BasicEvent[],
+   events: IWrapBasicEventAttribute[],
    options: IApplyEasingsOptions,
 ): void {
-   let filteredEvents = events.filter((ev) => ev.isLightEvent() && ev.isOn());
+   let filteredEvents = events.filter((ev) =>
+      isLightEventType(ev.type) && isOnEventValue(ev.value)
+   );
    if (typeof options.type === 'number') {
       filteredEvents = filteredEvents.filter((ev) => ev.type === options.type);
    }
    filteredEvents.forEach((ev) => {
-      (ev.customData as IChromaEventLight).easing = options.easing;
+      ev.customData.easing = options.easing;
    });
 }

--- a/src/extensions/chroma/misc.ts
+++ b/src/extensions/chroma/misc.ts
@@ -1,7 +1,9 @@
 import type { IChromaNote } from './types/colors.ts';
 
 /** Enable look for note from start to end. */
-export function setSpawnEffect<T extends IChromaNote>(objects: T[], bool: boolean): void {
+export function setSpawnEffect<
+   T extends Pick<IChromaNote, 'customData'>,
+>(objects: T[], bool: boolean): void {
    objects.forEach((o) => {
       o.customData.spawnEffect = bool;
    });

--- a/src/extensions/chroma/misc.ts
+++ b/src/extensions/chroma/misc.ts
@@ -1,7 +1,7 @@
 import type { IChromaNote } from './types/colors.ts';
 
 /** Enable look for note from start to end. */
-export function setSpawnEffect(objects: IChromaNote[], bool: boolean): void {
+export function setSpawnEffect<T extends IChromaNote>(objects: T[], bool: boolean): void {
    objects.forEach((o) => {
       o.customData.spawnEffect = bool;
    });

--- a/src/extensions/chroma/removeColor.ts
+++ b/src/extensions/chroma/removeColor.ts
@@ -1,6 +1,6 @@
 import type { IChromaObject } from './types/colors.ts';
 
-export function removeColor(objects: IChromaObject[]): void {
+export function removeColor<T extends IChromaObject>(objects: T[]): void {
    objects.forEach((obj) => {
       const cd = obj.customData;
       if (cd.color) {

--- a/src/extensions/chroma/removeColor.ts
+++ b/src/extensions/chroma/removeColor.ts
@@ -1,6 +1,8 @@
 import type { IChromaObject } from './types/colors.ts';
 
-export function removeColor<T extends IChromaObject>(objects: T[]): void {
+export function removeColor<
+   T extends Pick<IChromaObject, 'customData'>,
+>(objects: T[]): void {
    objects.forEach((obj) => {
       const cd = obj.customData;
       if (cd.color) {

--- a/src/extensions/chroma/setColor.ts
+++ b/src/extensions/chroma/setColor.ts
@@ -13,7 +13,9 @@ function tag(name: string): string[] {
    return ['ext', 'chroma', 'color', name];
 }
 
-export function setColor<T extends IChromaObject>(objects: T[], options: ISetColorOptions): void {
+export function setColor<
+   T extends Pick<IChromaObject, 'customData'>,
+>(objects: T[], options: ISetColorOptions): void {
    const opt: Required<ISetColorOptions> = {
       color: options.color,
       colorType: options.colorType ?? (settings.colorType || 'hsva'),
@@ -24,10 +26,9 @@ export function setColor<T extends IChromaObject>(objects: T[], options: ISetCol
    });
 }
 
-export function setColorGradient<T extends IChromaObject>(
-   objects: T[],
-   options: ISetColorGradientOptions,
-) {
+export function setColorGradient<
+   T extends Pick<IChromaObject, 'time' | 'customData'>,
+>(objects: T[], options: ISetColorGradientOptions) {
    if (!objects.length) {
       logger.tWarn(tag('setColorGradient'), 'No object(s) received.');
       return;
@@ -52,10 +53,9 @@ export function setColorGradient<T extends IChromaObject>(
    });
 }
 
-export function setColorRandom<T extends IChromaObject>(
-   objects: T[],
-   options: ISetColorRangeOptions,
-) {
+export function setColorRandom<
+   T extends Pick<IChromaObject, 'time' | 'customData'>,
+>(objects: T[], options: ISetColorRangeOptions) {
    const opt: Required<ISetColorRangeOptions> = {
       offsetStart: options.offsetStart,
       offsetEnd: options.offsetEnd,

--- a/src/extensions/chroma/setColor.ts
+++ b/src/extensions/chroma/setColor.ts
@@ -1,31 +1,33 @@
+import { logger } from '../../logger.ts';
+import { convertColorType, lerpColor } from '../../utils/colors.ts';
+import { normalize } from '../../utils/math.ts';
+import { settings } from './settings.ts';
 import type {
    IChromaObject,
    ISetColorGradientOptions,
    ISetColorOptions,
    ISetColorRangeOptions,
 } from './types/colors.ts';
-import { convertColorType, lerpColor } from '../../utils/colors.ts';
-import { normalize } from '../../utils/math.ts';
-import type { IChromaEventLight } from '../../types/beatmap/v3/custom/chroma.ts';
-import { settings } from './settings.ts';
-import { logger } from '../../logger.ts';
 
 function tag(name: string): string[] {
    return ['ext', 'chroma', 'color', name];
 }
 
-export function setColor(objects: IChromaObject[], options: ISetColorOptions): void {
+export function setColor<T extends IChromaObject>(objects: T[], options: ISetColorOptions): void {
    const opt: Required<ISetColorOptions> = {
       color: options.color,
       colorType: options.colorType ?? (settings.colorType || 'hsva'),
    };
    const color = convertColorType(opt.color, opt.colorType);
    objects.forEach((obj) => {
-      (obj.customData as IChromaEventLight).color = color;
+      obj.customData.color = color;
    });
 }
 
-export function setColorGradient(objects: IChromaObject[], options: ISetColorGradientOptions) {
+export function setColorGradient<T extends IChromaObject>(
+   objects: T[],
+   options: ISetColorGradientOptions,
+) {
    if (!objects.length) {
       logger.tWarn(tag('setColorGradient'), 'No object(s) received.');
       return;
@@ -46,11 +48,14 @@ export function setColorGradient(objects: IChromaObject[], options: ISetColorGra
    objects.forEach((obj) => {
       const norm = normalize(obj.time, startTime, endTime);
       const color = lerpColor(opt.colorStart, opt.colorEnd, opt.easingColor(norm), opt.colorType);
-      (obj.customData as IChromaEventLight).color = color;
+      obj.customData.color = color;
    });
 }
 
-export function setColorRandom(objects: IChromaObject[], options: ISetColorRangeOptions) {
+export function setColorRandom<T extends IChromaObject>(
+   objects: T[],
+   options: ISetColorRangeOptions,
+) {
    const opt: Required<ISetColorRangeOptions> = {
       offsetStart: options.offsetStart,
       offsetEnd: options.offsetEnd,

--- a/src/extensions/chroma/shiftColor.ts
+++ b/src/extensions/chroma/shiftColor.ts
@@ -3,10 +3,9 @@ import { hsvaToRgba, rgbaToHsva } from '../../utils/colors.ts';
 import { clamp } from '../../utils/math.ts';
 import type { IChromaObject, IShiftColorOptions } from './types/colors.ts';
 
-export function shiftColor<T extends IChromaObject>(
-   objects: T[],
-   options: IShiftColorOptions,
-) {
+export function shiftColor<
+   T extends Pick<IChromaObject, 'customData'>,
+>(objects: T[], options: IShiftColorOptions) {
    const opt: Omit<Required<IShiftColorOptions>, 'type'> = {
       offsetStart: options.offsetStart,
       offsetEnd: options.offsetEnd,

--- a/src/extensions/chroma/shiftColor.ts
+++ b/src/extensions/chroma/shiftColor.ts
@@ -1,11 +1,10 @@
-import { hsvaToRgba, rgbaToHsva } from '../../utils/colors.ts';
 import type { ColorArray } from '../../types/colors.ts';
+import { hsvaToRgba, rgbaToHsva } from '../../utils/colors.ts';
 import { clamp } from '../../utils/math.ts';
 import type { IChromaObject, IShiftColorOptions } from './types/colors.ts';
-import type { IChromaEventLight } from '../../types/beatmap/v3/custom/chroma.ts';
 
-export function shiftColor(
-   objects: IChromaObject[],
+export function shiftColor<T extends IChromaObject>(
+   objects: T[],
    options: IShiftColorOptions,
 ) {
    const opt: Omit<Required<IShiftColorOptions>, 'type'> = {
@@ -69,7 +68,7 @@ export function shiftColor(
       ) as ColorArray;
    };
    objects.forEach((obj) => {
-      const cd = obj.customData as IChromaEventLight;
+      const cd = obj.customData;
       if (cd.color) {
          cd.color = shift(cd.color, hsvaShift, opt);
       }

--- a/src/extensions/noodleExtensions/misc.ts
+++ b/src/extensions/noodleExtensions/misc.ts
@@ -1,11 +1,11 @@
-import type { INENote, INEObject } from './types/object.ts';
+import type { INEObject } from './types/object.ts';
 
 /**
  * Set uninteractible to object from start to end object.
  *
  * This is highly-recommended for any non-interactive object to improve performance.
  */
-export function setUninteractible(objects: INEObject[], bool: boolean): void {
+export function setUninteractible<T extends INEObject>(objects: T[], bool: boolean): void {
    objects.forEach((o) => {
       if (bool) {
          o.customData.uninteractable = bool;
@@ -17,7 +17,7 @@ export function setUninteractible(objects: INEObject[], bool: boolean): void {
 }
 
 /** Enable gravity for note from start to end. */
-export function setNoteGravity(objects: INENote[], bool: boolean): void {
+export function setNoteGravity<T extends INEObject>(objects: T[], bool: boolean): void {
    objects.forEach((o) => {
       if (!bool) {
          o.customData.disableNoteGravity = !bool;
@@ -29,7 +29,7 @@ export function setNoteGravity(objects: INENote[], bool: boolean): void {
 }
 
 /** Enable look for note from start to end. */
-export function setNoteLook(objects: INENote[], bool: boolean): void {
+export function setNoteLook<T extends INEObject>(objects: T[], bool: boolean): void {
    objects.forEach((o) => {
       if (!bool) {
          o.customData.disableNoteLook = !bool;

--- a/src/extensions/noodleExtensions/misc.ts
+++ b/src/extensions/noodleExtensions/misc.ts
@@ -1,11 +1,13 @@
-import type { INEObject } from './types/object.ts';
+import type { INENote, INEObject } from './types/object.ts';
 
 /**
  * Set uninteractible to object from start to end object.
  *
  * This is highly-recommended for any non-interactive object to improve performance.
  */
-export function setUninteractible<T extends INEObject>(objects: T[], bool: boolean): void {
+export function setUninteractible<
+   T extends Pick<INEObject, 'customData'>,
+>(objects: T[], bool: boolean): void {
    objects.forEach((o) => {
       if (bool) {
          o.customData.uninteractable = bool;
@@ -17,7 +19,9 @@ export function setUninteractible<T extends INEObject>(objects: T[], bool: boole
 }
 
 /** Enable gravity for note from start to end. */
-export function setNoteGravity<T extends INEObject>(objects: T[], bool: boolean): void {
+export function setNoteGravity<
+   T extends Pick<INENote, 'customData'>,
+>(objects: T[], bool: boolean): void {
    objects.forEach((o) => {
       if (!bool) {
          o.customData.disableNoteGravity = !bool;
@@ -29,7 +33,9 @@ export function setNoteGravity<T extends INEObject>(objects: T[], bool: boolean)
 }
 
 /** Enable look for note from start to end. */
-export function setNoteLook<T extends INEObject>(objects: T[], bool: boolean): void {
+export function setNoteLook<
+   T extends Pick<INENote, 'customData'>,
+>(objects: T[], bool: boolean): void {
    objects.forEach((o) => {
       if (!bool) {
          o.customData.disableNoteLook = !bool;

--- a/src/extensions/noodleExtensions/njs.ts
+++ b/src/extensions/noodleExtensions/njs.ts
@@ -1,10 +1,10 @@
 import { NoteJumpSpeed } from '../../beatmap/helpers/njs.ts';
-import type { INEObject } from './types/object.ts';
-import { settings } from './settings.ts';
 import { TimeProcessor } from '../../beatmap/helpers/timeProcessor.ts';
+import { logger } from '../../logger.ts';
 import type { EasingFunction } from '../../types/easings.ts';
 import { lerp, normalize } from '../../utils/math.ts';
-import { logger } from '../../logger.ts';
+import { settings } from './settings.ts';
+import type { INEObject } from './types/object.ts';
 
 function tag(name: string): string[] {
    return ['ext', 'NE', 'njs', name];
@@ -15,8 +15,8 @@ function tag(name: string): string[] {
  *
  * **NOTE:** JD input will override NJS offset.
  */
-export function setNjs(
-   objects: INEObject[],
+export function setNjs<T extends INEObject>(
+   objects: T[],
    options: {
       timeProc: TimeProcessor;
       njs: NoteJumpSpeed | number;
@@ -45,8 +45,8 @@ export function setNjs(
  *
  * **NOTE:** JD input will override NJS offset.
  */
-export function simultaneousSpawn(
-   objects: INEObject[],
+export function simultaneousSpawn<T extends INEObject>(
+   objects: T[],
    options: {
       timeProc: TimeProcessor;
       njs: NoteJumpSpeed | number;
@@ -89,8 +89,8 @@ export function simultaneousSpawn(
  *
  * **NOTE:** JD input will override NJS offset.
  */
-export function gradientNjs(
-   objects: INEObject[],
+export function gradientNjs<T extends INEObject>(
+   objects: T[],
    options: {
       timeProc: TimeProcessor | number;
       njsStart: number;

--- a/src/extensions/noodleExtensions/njs.ts
+++ b/src/extensions/noodleExtensions/njs.ts
@@ -15,7 +15,9 @@ function tag(name: string): string[] {
  *
  * **NOTE:** JD input will override NJS offset.
  */
-export function setNjs<T extends INEObject>(
+export function setNjs<
+   T extends Pick<INEObject, 'customData'>,
+>(
    objects: T[],
    options: {
       timeProc: TimeProcessor;
@@ -45,7 +47,9 @@ export function setNjs<T extends INEObject>(
  *
  * **NOTE:** JD input will override NJS offset.
  */
-export function simultaneousSpawn<T extends INEObject>(
+export function simultaneousSpawn<
+   T extends Pick<INEObject, 'time' | 'customData'>,
+>(
    objects: T[],
    options: {
       timeProc: TimeProcessor;
@@ -89,7 +93,9 @@ export function simultaneousSpawn<T extends INEObject>(
  *
  * **NOTE:** JD input will override NJS offset.
  */
-export function gradientNjs<T extends INEObject>(
+export function gradientNjs<
+   T extends Pick<INEObject, 'time' | 'customData'>,
+>(
    objects: T[],
    options: {
       timeProc: TimeProcessor | number;

--- a/src/extensions/noodleExtensions/note/flip.ts
+++ b/src/extensions/noodleExtensions/note/flip.ts
@@ -1,6 +1,6 @@
-import type { IWrapColorNote } from '../../../types/beatmap/wrapper/colorNote.ts';
 import type { Vector2 } from '../../../types/vector.ts';
 import { random } from '../../../utils/math.ts';
+import type { INENote } from '../types/object.ts';
 
 /**
  * Apply random flip to notes.
@@ -8,7 +8,9 @@ import { random } from '../../../utils/math.ts';
  * ne.randomFlip(notes, [[-4, 4], [0, 2]]);
  * ```
  */
-export function randomFlip(notes: IWrapColorNote[], range: [Vector2, Vector2]): void {
+export function randomFlip<
+   T extends Pick<INENote, 'customData'>,
+>(notes: T[], range: [Vector2, Vector2]): void {
    const [xVec, yVec] = range.map((r) => r.sort((a, b) => a - b));
    notes.forEach((n) => {
       n.customData.flip = [random(xVec[0], xVec[1]), random(yVec[0], yVec[1])];

--- a/src/extensions/noodleExtensions/track.ts
+++ b/src/extensions/noodleExtensions/track.ts
@@ -3,10 +3,10 @@ import type { INEObject } from './types/object.ts';
 /**
  * Add track(s) to object(s).
  */
-export function addTrack(objects: INEObject[], track: string | string[]): void;
-export function addTrack(object: INEObject, track: string | string[]): void;
-export function addTrack(
-   objects: INEObject | INEObject[],
+export function addTrack<T extends INEObject>(objects: T[], track: string | string[]): void;
+export function addTrack<T extends INEObject>(object: T, track: string | string[]): void;
+export function addTrack<T extends INEObject>(
+   objects: T | T[],
    track: string | string[],
 ): void {
    if (!Array.isArray(objects)) {
@@ -33,13 +33,13 @@ export function addTrack(
 /**
  * Remove track(s) from object(s).
  */
-export function removeTrack(
-   objects: INEObject[],
+export function removeTrack<T extends INEObject>(
+   objects: T[],
    track: string | string[],
 ): void;
-export function removeTrack(object: INEObject, track: string | string[]): void;
-export function removeTrack(
-   objects: INEObject | INEObject[],
+export function removeTrack<T extends INEObject>(object: T, track: string | string[]): void;
+export function removeTrack<T extends INEObject>(
+   objects: T | T[],
    track: string | string[],
 ): void {
    if (!Array.isArray(objects)) {

--- a/src/extensions/noodleExtensions/track.ts
+++ b/src/extensions/noodleExtensions/track.ts
@@ -3,12 +3,15 @@ import type { INEObject } from './types/object.ts';
 /**
  * Add track(s) to object(s).
  */
-export function addTrack<T extends INEObject>(objects: T[], track: string | string[]): void;
-export function addTrack<T extends INEObject>(object: T, track: string | string[]): void;
-export function addTrack<T extends INEObject>(
-   objects: T | T[],
-   track: string | string[],
-): void {
+export function addTrack<
+   T extends Pick<INEObject, 'customData'>,
+>(objects: T[], track: string | string[]): void;
+export function addTrack<
+   T extends Pick<INEObject, 'customData'>,
+>(object: T, track: string | string[]): void;
+export function addTrack<
+   T extends Pick<INEObject, 'customData'>,
+>(objects: T | T[], track: string | string[]): void {
    if (!Array.isArray(objects)) {
       if (typeof track === 'string') {
          if (!objects.customData.track) {
@@ -33,15 +36,15 @@ export function addTrack<T extends INEObject>(
 /**
  * Remove track(s) from object(s).
  */
-export function removeTrack<T extends INEObject>(
-   objects: T[],
-   track: string | string[],
-): void;
-export function removeTrack<T extends INEObject>(object: T, track: string | string[]): void;
-export function removeTrack<T extends INEObject>(
-   objects: T | T[],
-   track: string | string[],
-): void {
+export function removeTrack<
+   T extends Pick<INEObject, 'customData'>,
+>(objects: T[], track: string | string[]): void;
+export function removeTrack<
+   T extends Pick<INEObject, 'customData'>,
+>(object: T, track: string | string[]): void;
+export function removeTrack<
+   T extends Pick<INEObject, 'customData'>,
+>(objects: T | T[], track: string | string[]): void {
    if (!Array.isArray(objects)) {
       if (typeof track === 'string') {
          if (!objects.customData.track) {

--- a/src/extensions/noodleExtensions/types/object.ts
+++ b/src/extensions/noodleExtensions/types/object.ts
@@ -16,3 +16,7 @@ export type INENote =
    | IWrapBombNoteAttribute
    | IWrapChainAttribute
    | IWrapArcAttribute;
+
+export type INESlider =
+   | IWrapChainAttribute
+   | IWrapArcAttribute;

--- a/src/extensions/noodleExtensions/types/object.ts
+++ b/src/extensions/noodleExtensions/types/object.ts
@@ -1,9 +1,18 @@
-import type { IWrapBombNote } from '../../../types/beatmap/wrapper/bombNote.ts';
-import type { IWrapColorNote } from '../../../types/beatmap/wrapper/colorNote.ts';
-import type { IWrapChain } from '../../../types/beatmap/wrapper/chain.ts';
-import type { IWrapArc } from '../../../types/beatmap/wrapper/arc.ts';
-import type { IWrapObstacle } from '../../../types/beatmap/wrapper/obstacle.ts';
+import type { IWrapArcAttribute } from '../../../types/beatmap/wrapper/arc.ts';
+import type { IWrapBombNoteAttribute } from '../../../types/beatmap/wrapper/bombNote.ts';
+import type { IWrapChainAttribute } from '../../../types/beatmap/wrapper/chain.ts';
+import type { IWrapColorNoteAttribute } from '../../../types/beatmap/wrapper/colorNote.ts';
+import type { IWrapObstacleAttribute } from '../../../types/beatmap/wrapper/obstacle.ts';
 
-export type INEObject = IWrapColorNote | IWrapObstacle | IWrapBombNote | IWrapChain | IWrapArc;
+export type INEObject =
+   | IWrapColorNoteAttribute
+   | IWrapObstacleAttribute
+   | IWrapBombNoteAttribute
+   | IWrapChainAttribute
+   | IWrapArcAttribute;
 
-export type INENote = IWrapColorNote | IWrapBombNote | IWrapChain | IWrapArc;
+export type INENote =
+   | IWrapColorNoteAttribute
+   | IWrapBombNoteAttribute
+   | IWrapChainAttribute
+   | IWrapArcAttribute;

--- a/src/extensions/parity/parity.ts
+++ b/src/extensions/parity/parity.ts
@@ -60,8 +60,14 @@ const noteParityRotation: {
 
 // TODO: probably body class for leaning
 export class Parity<
-   TColorNote extends IWrapColorNoteAttribute,
-   TBombNote extends IWrapBombNoteAttribute,
+   TColorNote extends Pick<
+      IWrapColorNoteAttribute,
+      'time' | 'posX' | 'posY' | 'color' | 'direction'
+   >,
+   TBombNote extends Pick<
+      IWrapBombNoteAttribute,
+      'time' | 'posX' | 'posY' | 'color'
+   >,
 > {
    private state!: ParityState;
    private color!: number;

--- a/src/extensions/placement/note.ts
+++ b/src/extensions/placement/note.ts
@@ -9,11 +9,9 @@ import type { IWrapBaseNoteAttribute } from '../../types/beatmap/wrapper/baseNot
 import { radToDeg, shortRotDistance } from '../../utils/math.ts';
 
 // TODO: update with new position/rotation system
-export function isEnd<T extends IWrapBaseNoteAttribute>(
-   currNote: T,
-   prevNote: T,
-   cd: number,
-): boolean {
+export function isEnd<
+   T extends Pick<IWrapBaseNoteAttribute, 'posX' | 'posY' | 'direction'>,
+>(currNote: T, prevNote: T, cd: number): boolean {
    // fuck u and ur dot note stack
    if (
       currNote.direction === NoteDirection.ANY &&
@@ -145,7 +143,9 @@ export function isEnd<T extends IWrapBaseNoteAttribute>(
  * ```
  */
 // a fkin abomination that's what currNote is
-export function isIntersect<T extends IWrapBaseNoteAttribute>(
+export function isIntersect<
+   T extends Pick<IWrapBaseNoteAttribute, 'posX' | 'posY' | 'direction'>,
+>(
    currNote: T,
    compareTo: T,
    angleDistances: [number, number, number?][],
@@ -190,10 +190,9 @@ export function isIntersect<T extends IWrapBaseNoteAttribute>(
 }
 
 // TODO: update with new position/rotation system
-export function predictDirection<T extends IWrapBaseNoteAttribute>(
-   currNote: T,
-   prevNote: T,
-): number {
+export function predictDirection<
+   T extends Pick<IWrapBaseNoteAttribute, 'time' | 'posX' | 'posY' | 'direction'>,
+>(currNote: T, prevNote: T): number {
    if (isEnd(currNote, prevNote, NoteDirection.ANY)) {
       return currNote.direction === NoteDirection.ANY ? prevNote.direction : currNote.direction;
    }
@@ -249,12 +248,9 @@ export function predictDirection<T extends IWrapBaseNoteAttribute>(
  * @param {boolean} equal - If it should check inner or outer angle
  * @returns {boolean} If condition is met
  */
-export function checkDirection<T extends IWrapBaseNoteAttribute>(
-   n1: T | number | null,
-   n2: T | number | null,
-   angleTol: number,
-   equal: boolean,
-): boolean {
+export function checkDirection<
+   T extends Pick<IWrapBaseNoteAttribute, 'direction'>,
+>(n1: T | number | null, n2: T | number | null, angleTol: number, equal: boolean): boolean {
    let nA1!: number;
    let nA2!: number;
    if (n1 === null || n2 === null) {

--- a/src/extensions/placement/note.ts
+++ b/src/extensions/placement/note.ts
@@ -1,10 +1,19 @@
-import { ColorNote } from '../../beatmap/core/colorNote.ts';
+import { resolveNoteAngle } from '../../beatmap/helpers/core/baseNote.ts';
+import {
+   isHorizontal,
+   isVertical,
+   resolveGridPosition,
+} from '../../beatmap/helpers/core/gridObject.ts';
 import { NoteDirection } from '../../beatmap/shared/constants.ts';
-import type { IWrapBaseNote } from '../../types/beatmap/wrapper/baseNote.ts';
+import type { IWrapBaseNoteAttribute } from '../../types/beatmap/wrapper/baseNote.ts';
 import { radToDeg, shortRotDistance } from '../../utils/math.ts';
 
 // TODO: update with new position/rotation system
-export function isEnd(currNote: IWrapBaseNote, prevNote: IWrapBaseNote, cd: number): boolean {
+export function isEnd<T extends IWrapBaseNoteAttribute>(
+   currNote: T,
+   prevNote: T,
+   cd: number,
+): boolean {
    // fuck u and ur dot note stack
    if (
       currNote.direction === NoteDirection.ANY &&
@@ -136,18 +145,18 @@ export function isEnd(currNote: IWrapBaseNote, prevNote: IWrapBaseNote, cd: numb
  * ```
  */
 // a fkin abomination that's what currNote is
-export function isIntersect(
-   currNote: IWrapBaseNote,
-   compareTo: IWrapBaseNote,
+export function isIntersect<T extends IWrapBaseNoteAttribute>(
+   currNote: T,
+   compareTo: T,
    angleDistances: [number, number, number?][],
    ahead = false,
 ): [boolean, boolean] {
-   const [nX1, nY1] = currNote.getPosition();
-   const [nX2, nY2] = compareTo.getPosition();
+   const [nX1, nY1] = resolveGridPosition(currNote);
+   const [nX2, nY2] = resolveGridPosition(compareTo);
    const angle = ahead ? 540 : 360;
    let resultN1 = false;
    if (currNote.direction !== 8) {
-      const nA1 = currNote.getAngle();
+      const nA1 = resolveNoteAngle(currNote.direction);
       const a = (radToDeg(Math.atan2(nY1 - nY2, nX1 - nX2)) + 450) % 360;
       for (const [angleRange, maxDistance, offsetT] of angleDistances) {
          const offset = offsetT ?? 0;
@@ -162,8 +171,8 @@ export function isIntersect(
       }
    }
    let resultN2 = false;
-   if (compareTo instanceof ColorNote && compareTo.direction !== 8) {
-      const nA2 = compareTo.getAngle();
+   if (compareTo.direction !== 8) {
+      const nA2 = resolveNoteAngle(compareTo.direction);
       const a = (radToDeg(Math.atan2(nY2 - nY1, nX2 - nX1)) + 450) % 360;
       for (const [angleRange, maxDistance, offsetT] of angleDistances) {
          const offset = offsetT ?? 0;
@@ -181,7 +190,10 @@ export function isIntersect(
 }
 
 // TODO: update with new position/rotation system
-export function predictDirection(currNote: IWrapBaseNote, prevNote: IWrapBaseNote): number {
+export function predictDirection<T extends IWrapBaseNoteAttribute>(
+   currNote: T,
+   prevNote: T,
+): number {
    if (isEnd(currNote, prevNote, NoteDirection.ANY)) {
       return currNote.direction === NoteDirection.ANY ? prevNote.direction : currNote.direction;
    }
@@ -191,19 +203,19 @@ export function predictDirection(currNote: IWrapBaseNote, prevNote: IWrapBaseNot
    if (currNote.time > prevNote.time) {
       // if end note on right side
       if (currNote.posX > prevNote.posX) {
-         if (currNote.isHorizontal(prevNote)) {
+         if (isHorizontal(currNote, prevNote)) {
             return NoteDirection.RIGHT;
          }
       }
       // if end note on left side
       if (currNote.posX < prevNote.posX) {
-         if (currNote.isHorizontal(prevNote)) {
+         if (isHorizontal(currNote, prevNote)) {
             return NoteDirection.LEFT;
          }
       }
       // if end note is above
       if (currNote.posY > prevNote.posY) {
-         if (currNote.isVertical(prevNote)) {
+         if (isVertical(currNote, prevNote)) {
             return NoteDirection.UP;
          }
          if (currNote.posX > prevNote.posX) {
@@ -215,7 +227,7 @@ export function predictDirection(currNote: IWrapBaseNote, prevNote: IWrapBaseNot
       }
       // if end note is below
       if (currNote.posY < prevNote.posY) {
-         if (currNote.isVertical(prevNote)) {
+         if (isVertical(currNote, prevNote)) {
             return NoteDirection.DOWN;
          }
          if (currNote.posX > prevNote.posX) {
@@ -231,15 +243,15 @@ export function predictDirection(currNote: IWrapBaseNote, prevNote: IWrapBaseNot
 
 /**
  * Check the angle equality of the two notes.
- * @param {(IWrapBaseNote|number|null)}  - First beatmap note, note `direction`, or null value
- * @param {(IWrapBaseNote|number|null)} n2 - Second beatmap note, note `direction`, or null value
+ * @param {(T|number|null)} n1 - First beatmap note, note `direction`, or null value
+ * @param {(T|number|null)} n2 - Second beatmap note, note `direction`, or null value
  * @param {number} angleTol - Angle tolerance
  * @param {boolean} equal - If it should check inner or outer angle
  * @returns {boolean} If condition is met
  */
-export function checkDirection(
-   n1: IWrapBaseNote | number | null,
-   n2: IWrapBaseNote | number | null,
+export function checkDirection<T extends IWrapBaseNoteAttribute>(
+   n1: T | number | null,
+   n2: T | number | null,
    angleTol: number,
    equal: boolean,
 ): boolean {
@@ -254,7 +266,7 @@ export function checkDirection(
       if (n1.direction === NoteDirection.ANY) {
          return false;
       }
-      nA1 = n1.getAngle();
+      nA1 = resolveNoteAngle(n1.direction);
    }
    if (typeof n2 === 'number') {
       nA2 = n2;
@@ -262,7 +274,7 @@ export function checkDirection(
       if (n2.direction === NoteDirection.ANY) {
          return false;
       }
-      nA2 = n2.getAngle();
+      nA2 = resolveNoteAngle(n2.direction);
    }
    return equal
       ? shortRotDistance(nA1, nA2, 360) <= angleTol

--- a/src/extensions/selector/time.ts
+++ b/src/extensions/selector/time.ts
@@ -1,9 +1,6 @@
 import type { TimeProcessor } from '../../beatmap/helpers/timeProcessor.ts';
+import type { IWrapBaseObjectAttribute } from '../../types/beatmap/wrapper/baseObject.ts';
 import { settings } from './settings.ts';
-import type {
-   IWrapBaseObject,
-   IWrapBaseObjectAttribute,
-} from '../../types/beatmap/wrapper/baseObject.ts';
 
 /**
  * Return objects at given time, adjusted by BPM change if provided.
@@ -54,7 +51,7 @@ export function between<T extends IWrapBaseObjectAttribute>(
  * console.log(...notesBefore);
  * ```
  */
-export function before<T extends IWrapBaseObject>(
+export function before<T extends IWrapBaseObjectAttribute>(
    objects: T[],
    before: number,
    bpm?: TimeProcessor | null,
@@ -70,7 +67,7 @@ export function before<T extends IWrapBaseObject>(
  * console.log(...notesAfter);
  * ```
  */
-export function after<T extends IWrapBaseObject>(
+export function after<T extends IWrapBaseObjectAttribute>(
    objects: T[],
    after: number,
    bpm?: TimeProcessor | null,

--- a/src/extensions/selector/time.ts
+++ b/src/extensions/selector/time.ts
@@ -9,11 +9,9 @@ import { settings } from './settings.ts';
  * console.log(...notesHere);
  * ```
  */
-export function at<T extends IWrapBaseObjectAttribute>(
-   objects: T[],
-   times: number | number[],
-   bpm?: TimeProcessor | null,
-): T[] {
+export function at<
+   T extends Pick<IWrapBaseObjectAttribute, 'time'>,
+>(objects: T[], times: number | number[], bpm?: TimeProcessor | null): T[] {
    bpm = bpm ?? settings.timeProcessor;
    if (Array.isArray(times)) {
       return objects.filter((o) =>
@@ -30,12 +28,9 @@ export function at<T extends IWrapBaseObjectAttribute>(
  * console.log(...notesRange);
  * ```
  */
-export function between<T extends IWrapBaseObjectAttribute>(
-   objects: T[],
-   from: number,
-   to: number,
-   bpm?: TimeProcessor | null,
-): T[] {
+export function between<
+   T extends Pick<IWrapBaseObjectAttribute, 'time'>,
+>(objects: T[], from: number, to: number, bpm?: TimeProcessor | null): T[] {
    bpm = bpm ?? settings.timeProcessor;
    return objects.filter((o) =>
       bpm
@@ -51,11 +46,9 @@ export function between<T extends IWrapBaseObjectAttribute>(
  * console.log(...notesBefore);
  * ```
  */
-export function before<T extends IWrapBaseObjectAttribute>(
-   objects: T[],
-   before: number,
-   bpm?: TimeProcessor | null,
-): T[] {
+export function before<
+   T extends Pick<IWrapBaseObjectAttribute, 'time'>,
+>(objects: T[], before: number, bpm?: TimeProcessor | null): T[] {
    bpm = bpm ?? settings.timeProcessor;
    return objects.filter((o) => (bpm ? bpm.adjustTime(o.time) > before : o.time > before));
 }
@@ -67,11 +60,9 @@ export function before<T extends IWrapBaseObjectAttribute>(
  * console.log(...notesAfter);
  * ```
  */
-export function after<T extends IWrapBaseObjectAttribute>(
-   objects: T[],
-   after: number,
-   bpm?: TimeProcessor | null,
-): T[] {
+export function after<
+   T extends Pick<IWrapBaseObjectAttribute, 'time'>,
+>(objects: T[], after: number, bpm?: TimeProcessor | null): T[] {
    bpm = bpm ?? settings.timeProcessor;
    return objects.filter((o) => (bpm ? bpm.adjustTime(o.time) > after : o.time > after));
 }

--- a/src/extensions/stats/event.ts
+++ b/src/extensions/stats/event.ts
@@ -1,9 +1,11 @@
-import { EventList } from '../../beatmap/shared/environment.ts';
-import type { EnvironmentAllName } from '../../types/beatmap/shared/environment.ts';
-import type { IWrapColorBoostEvent } from '../../types/beatmap/wrapper/colorBoostEvent.ts';
-import type { IWrapBasicEvent } from '../../types/beatmap/wrapper/basicEvent.ts';
-import type { ICountEvent } from './types/stats.ts';
+import { isOldChromaEventValue } from '../../beatmap/helpers/core/basicEvent.ts';
 import { hasChromaEventV2, hasChromaEventV3 } from '../../beatmap/helpers/modded/has.ts';
+import { EventList } from '../../beatmap/shared/environment.ts';
+import { isValidEventType } from '../../mod.ts';
+import type { EnvironmentAllName } from '../../types/beatmap/shared/environment.ts';
+import type { IWrapBasicEventAttribute } from '../../types/beatmap/wrapper/basicEvent.ts';
+import type { IWrapColorBoostEventAttribute } from '../../types/beatmap/wrapper/colorBoostEvent.ts';
+import type { ICountEvent } from './types/stats.ts';
 
 /**
  * Count number of type of events with their properties in given array and return a event count object.
@@ -12,9 +14,12 @@ import { hasChromaEventV2, hasChromaEventV3 } from '../../beatmap/helpers/modded
  * console.log(list);
  * ```
  */
-export function countEvent(
-   events: IWrapBasicEvent[],
-   boost: IWrapColorBoostEvent[],
+export function countEvent<
+   TBasicEvent extends IWrapBasicEventAttribute,
+   TColorBoostEvent extends IWrapColorBoostEventAttribute,
+>(
+   events: TBasicEvent[],
+   boost: TColorBoostEvent[],
    environment: EnvironmentAllName = 'DefaultEnvironment',
    version = 2,
 ): ICountEvent {
@@ -36,7 +41,7 @@ export function countEvent(
    };
 
    for (let i = events.length - 1; i >= 0; i--) {
-      if (events[i].isValidType()) {
+      if (isValidEventType(events[i].type)) {
          if (!eventCount[events[i].type]) {
             eventCount[events[i].type] = {
                total: 0,
@@ -48,7 +53,7 @@ export function countEvent(
          if (hasChroma(events[i])) {
             eventCount[events[i].type].chroma++;
          }
-         if (events[i].isOldChroma()) {
+         if (isOldChromaEventValue(events[i].value)) {
             eventCount[events[i].type].chromaOld++;
          }
       }

--- a/src/extensions/stats/groupEvent.ts
+++ b/src/extensions/stats/groupEvent.ts
@@ -10,8 +10,8 @@ import type { ICountEventBoxGroup } from './types/stats.ts';
  * console.log(list);
  * ```
  */
-export function countEbg(
-   ebg: IWrapEventBoxGroupAttribute[],
+export function countEbg<T extends IWrapEventBoxGroupAttribute>(
+   ebg: T[],
    environment: EnvironmentAllName = 'DefaultEnvironment',
 ): ICountEventBoxGroup {
    const commonEvent = EventList[environment]?.[1] ?? EventList['DefaultEnvironment'][1];

--- a/src/extensions/stats/note.ts
+++ b/src/extensions/stats/note.ts
@@ -1,10 +1,4 @@
-import type { IWrapBombNoteAttribute } from '../../types/beatmap/wrapper/bombNote.ts';
-import type { IWrapColorNoteAttribute } from '../../types/beatmap/wrapper/colorNote.ts';
-import type { IWrapBaseSliderAttribute } from '../../types/beatmap/wrapper/baseSlider.ts';
-import type { ICountNote, ICountStatsNote } from './types/stats.ts';
-import type { IWrapBaseNote } from '../../types/beatmap/wrapper/baseNote.ts';
-import type { IWrapGridObjectAttribute } from '../../types/beatmap/wrapper/gridObject.ts';
-import type { GetAngleFn } from '../../types/beatmap/shared/functions.ts';
+import { resolveNoteAngle } from '../../beatmap/helpers/core/baseNote.ts';
 import {
    hasChromaNoteV2,
    hasChromaNoteV3,
@@ -13,6 +7,13 @@ import {
    hasNoodleExtensionsNoteV2,
    hasNoodleExtensionsNoteV3,
 } from '../../beatmap/helpers/modded/has.ts';
+import type { GetAngleFn } from '../../types/beatmap/shared/functions.ts';
+import type { IWrapBaseNoteAttribute } from '../../types/beatmap/wrapper/baseNote.ts';
+import type { IWrapBaseSliderAttribute } from '../../types/beatmap/wrapper/baseSlider.ts';
+import type { IWrapBombNoteAttribute } from '../../types/beatmap/wrapper/bombNote.ts';
+import type { IWrapColorNoteAttribute } from '../../types/beatmap/wrapper/colorNote.ts';
+import type { IWrapGridObjectAttribute } from '../../types/beatmap/wrapper/gridObject.ts';
+import type { ICountNote, ICountStatsNote } from './types/stats.ts';
 
 /**
  * Count number of red, blue, and bomb notes with their properties in given array and return a note count object.
@@ -22,8 +23,8 @@ import {
  * console.log(list);
  * ```
  */
-export function countNote(
-   notes: (IWrapColorNoteAttribute | IWrapBaseSliderAttribute)[],
+export function countNote<T extends IWrapColorNoteAttribute | IWrapBaseSliderAttribute>(
+   notes: T[],
    version = 2,
 ): ICountNote {
    const noteCount: ICountNote = {
@@ -60,8 +61,8 @@ export function countNote(
    return noteCount;
 }
 
-export function countBomb(
-   bombs: IWrapBombNoteAttribute[],
+export function countBomb<T extends IWrapBombNoteAttribute>(
+   bombs: T[],
    version = 2,
 ): ICountStatsNote {
    const bombCount: ICountStatsNote = {
@@ -95,7 +96,7 @@ export function countBomb(
  * const xCount = countX(notes, 0);
  * ```
  */
-export function countX(objs: IWrapGridObjectAttribute[], x: number): number {
+export function countX<T extends IWrapGridObjectAttribute>(objs: T[], x: number): number {
    return objs.filter((n) => n.posX === x).length;
 }
 
@@ -106,7 +107,7 @@ export function countX(objs: IWrapGridObjectAttribute[], x: number): number {
  * const yCount = countY(notes, 0);
  * ```
  */
-export function countY(objs: IWrapGridObjectAttribute[], y: number): number {
+export function countY<T extends IWrapGridObjectAttribute>(objs: T[], y: number): number {
    return objs.filter((n) => n.posY === y).length;
 }
 
@@ -117,8 +118,8 @@ export function countY(objs: IWrapGridObjectAttribute[], y: number): number {
  * const xyCount = countXY(notes, 0, 0);
  * ```
  */
-export function countXY(
-   objs: IWrapGridObjectAttribute[],
+export function countXY<T extends IWrapGridObjectAttribute>(
+   objs: T[],
    x: number,
    y: number,
 ): number {
@@ -131,7 +132,7 @@ export function countXY(
  * const cdCount = countDirection(notes, 0);
  * ```
  */
-export function countDirection(notes: IWrapBaseNote[], cd: number): number {
+export function countDirection<T extends IWrapBaseNoteAttribute>(notes: T[], cd: number): number {
    return notes.filter((n) => n.direction === cd).length;
 }
 
@@ -142,10 +143,10 @@ export function countDirection(notes: IWrapBaseNote[], cd: number): number {
  * const angleCount = countAngle(notes, 0);
  * ```
  */
-export function countAngle(
-   notes: IWrapBaseNote[],
+export function countAngle<T extends IWrapBaseNoteAttribute>(
+   notes: T[],
    angle: number,
-   fn?: GetAngleFn<IWrapBaseNote>,
+   fn?: GetAngleFn<T>,
 ): number {
-   return notes.filter((n) => n.getAngle(fn) === angle).length;
+   return notes.filter((n) => (fn?.(n) ?? resolveNoteAngle(n.direction)) === angle).length;
 }

--- a/src/extensions/stats/obstacle.ts
+++ b/src/extensions/stats/obstacle.ts
@@ -1,12 +1,13 @@
-import { hasMappingExtensionsObstacleV2 } from '../../beatmap/helpers/modded/has.ts';
+import { isInteractiveObstacle } from '../../beatmap/helpers/core/obstacle.ts';
 import {
    hasChromaObstacleV2,
    hasChromaObstacleV3,
+   hasMappingExtensionsObstacleV2,
    hasMappingExtensionsObstacleV3,
    hasNoodleExtensionsObstacleV2,
    hasNoodleExtensionsObstacleV3,
 } from '../../beatmap/helpers/modded/has.ts';
-import type { IWrapObstacle } from '../../types/beatmap/wrapper/obstacle.ts';
+import type { IWrapObstacleAttribute } from '../../types/beatmap/wrapper/obstacle.ts';
 import type { IObstacleCount } from './types/stats.ts';
 
 /**
@@ -16,8 +17,8 @@ import type { IObstacleCount } from './types/stats.ts';
  * console.log(list);
  * ```
  */
-export function countObstacle(
-   obstacles: IWrapObstacle[],
+export function countObstacle<T extends IWrapObstacleAttribute>(
+   obstacles: T[],
    version = 2,
 ): IObstacleCount {
    const obstacleCount: IObstacleCount = {
@@ -33,7 +34,7 @@ export function countObstacle(
 
    for (let i = obstacles.length - 1; i > -1; i--) {
       obstacleCount.total++;
-      if (obstacles[i].isInteractive()) {
+      if (isInteractiveObstacle(obstacles[i])) {
          obstacleCount.interactive++;
       }
       if (hasChroma(obstacles[i])) {

--- a/src/extensions/swing/ebpm.ts
+++ b/src/extensions/swing/ebpm.ts
@@ -1,15 +1,19 @@
-import type { ISwingContainer } from './types/swing.ts';
+import type { ISwingAnalysisBaseNoteAttribute, ISwingContainer } from './types/swing.ts';
 
 /**
  * Get maximum effective bpm.
  */
-export function getMaxEffectiveBpm(swings: ISwingContainer[]): number {
+export function getMaxEffectiveBpm<
+   T extends ISwingAnalysisBaseNoteAttribute,
+>(swings: ISwingContainer<T>[]): number {
    return Math.max(...swings.map((s) => s.ebpm), 0);
 }
 
 /**
  * Get maximum effective bpm swing.
  */
-export function getMaxEffectiveBpmSwing(swings: ISwingContainer[]): number {
+export function getMaxEffectiveBpmSwing<
+   T extends ISwingAnalysisBaseNoteAttribute,
+>(swings: ISwingContainer<T>[]): number {
    return Math.max(...swings.map((s) => s.ebpmSwing), 0);
 }

--- a/src/extensions/swing/info.ts
+++ b/src/extensions/swing/info.ts
@@ -2,12 +2,14 @@ import { getFirstInteractiveTime, getLastInteractiveTime } from '../../beatmap/h
 import type { TimeProcessor } from '../../beatmap/helpers/timeProcessor.ts';
 import type { CharacteristicName } from '../../types/beatmap/shared/characteristic.ts';
 import type { DifficultyName } from '../../types/beatmap/shared/difficulty.ts';
-import type { IWrapBeatmapAttributeSubset } from '../../types/beatmap/wrapper/beatmap.ts';
-import type { IWrapColorNoteAttribute } from '../../types/beatmap/wrapper/colorNote.ts';
-import type { DeepWritable } from '../../types/utils.ts';
 import { median } from '../../utils/math.ts';
 import { generate, next } from './swing.ts';
-import type { ISwingAnalysis, ISwingCount } from './types/swing.ts';
+import type {
+   ISwingAnalysis,
+   ISwingAnalysisBaseNoteAttribute,
+   ISwingAnalysisBeatmapAttribute,
+   ISwingCount,
+} from './types/swing.ts';
 
 // derived from Uninstaller's Swings Per Second tool
 // some variable or function may have been modified
@@ -16,11 +18,9 @@ import type { ISwingAnalysis, ISwingCount } from './types/swing.ts';
 /**
  * Count the number of swings in period.
  */
-export function count<T extends IWrapColorNoteAttribute>(
-   colorNotes: T[],
-   duration: number,
-   timeProc: TimeProcessor,
-): ISwingCount {
+export function count<
+   T extends ISwingAnalysisBaseNoteAttribute,
+>(colorNotes: T[], duration: number, timeProc: TimeProcessor): ISwingCount {
    const swingCount: ISwingCount = {
       left: new Array(Math.floor(duration + 1)).fill(0),
       right: new Array(Math.floor(duration + 1)).fill(0),
@@ -74,14 +74,12 @@ function calcMaxRollingSps(swingArray: number[], x: number): number {
  *
  * Port from Uninstaller's Swings Per Second tool
  */
-export function info<
-   T extends IWrapBeatmapAttributeSubset<'colorNotes' | 'bombNotes' | 'obstacles' | 'chains'>,
->(
+export function info<T extends ISwingAnalysisBeatmapAttribute>(
    beatmap: T,
    timeProc: TimeProcessor,
    characteristic: CharacteristicName,
    difficulty: DifficultyName,
-): ISwingAnalysis {
+): ISwingAnalysis<ISwingAnalysisBaseNoteAttribute> {
    const interval = 10;
    const spsInfo = {
       characteristic: characteristic,
@@ -90,7 +88,7 @@ export function info<
       blue: { perSecond: 0, peak: 0, median: 0, total: 0 },
       total: { perSecond: 0, peak: 0, median: 0, total: 0 },
       container: generate(beatmap.difficulty.colorNotes, timeProc),
-   } as DeepWritable<ISwingAnalysis>;
+   };
    const duration = Math.max(
       timeProc.toRealTime(getLastInteractiveTime(beatmap) - getFirstInteractiveTime(beatmap)),
       0,
@@ -99,7 +97,7 @@ export function info<
    const swing = count(beatmap.difficulty.colorNotes, mapDuration, timeProc);
    const swingTotal = swing.left.map((num, i) => num + swing.right[i]);
    if (swingTotal.reduce((a, b) => a + b) === 0) {
-      return spsInfo as ISwingAnalysis;
+      return spsInfo as ISwingAnalysis<T['difficulty']['colorNotes'][number]>;
    }
    const swingIntervalRed = [];
    const swingIntervalBlue = [];
@@ -132,16 +130,16 @@ export function info<
    spsInfo.total.peak = calcMaxRollingSps(swingTotal, interval);
    spsInfo.total.median = median(swingIntervalTotal);
 
-   return spsInfo as ISwingAnalysis;
+   return spsInfo as ISwingAnalysis<T['difficulty']['colorNotes'][number]>;
 }
 
 /**
  * Get first swings analysis that exceeds 40% progression drop.
  */
-export function getProgressionMax(
-   spsArray: ISwingAnalysis[],
+export function getProgressionMax<T extends ISwingAnalysisBaseNoteAttribute>(
+   spsArray: ISwingAnalysis<T>[],
    minThreshold: number,
-): { result: ISwingAnalysis; comparedTo?: ISwingAnalysis } | null {
+): { result: ISwingAnalysis<T>; comparedTo?: ISwingAnalysis<T> } | null {
    let prevPerc = 0;
    let currPerc = 0;
    let comparedTo;
@@ -162,10 +160,10 @@ export function getProgressionMax(
 /**
  * Get first swings analysis that does not reach 10% progression drop.
  */
-export function getProgressionMin(
-   spsArray: ISwingAnalysis[],
+export function getProgressionMin<T extends ISwingAnalysisBaseNoteAttribute>(
+   spsArray: ISwingAnalysis<T>[],
    minThreshold: number,
-): { result: ISwingAnalysis; comparedTo?: ISwingAnalysis } | null {
+): { result: ISwingAnalysis<T>; comparedTo?: ISwingAnalysis<T> } | null {
    let prevPerc = Number.MAX_SAFE_INTEGER;
    let currPerc = 0;
    let comparedTo;
@@ -186,7 +184,9 @@ export function getProgressionMin(
 /**
  * Calculate total percentage drop from highest to lowest swings analysis.
  */
-export function calcSpsTotalPercDrop(spsArray: ISwingAnalysis[]): number {
+export function calcSpsTotalPercDrop<T extends ISwingAnalysisBaseNoteAttribute>(
+   spsArray: ISwingAnalysis<T>[],
+): number {
    let highest = 0;
    let lowest = Number.MAX_SAFE_INTEGER;
    spsArray.forEach((spsMap) => {
@@ -202,13 +202,17 @@ export function calcSpsTotalPercDrop(spsArray: ISwingAnalysis[]): number {
 /**
  * Get lowest SPS.
  */
-export function getSpsLowest(spsArray: ISwingAnalysis[]): number {
+export function getSpsLowest<T extends ISwingAnalysisBaseNoteAttribute>(
+   spsArray: ISwingAnalysis<T>[],
+): number {
    return Math.min(...spsArray.map((e) => e.total.perSecond), Number.MAX_SAFE_INTEGER);
 }
 
 /**
  * Get highest SPS.
  */
-export function getSpsHighest(spsArray: ISwingAnalysis[]): number {
+export function getSpsHighest<T extends ISwingAnalysisBaseNoteAttribute>(
+   spsArray: ISwingAnalysis<T>[],
+): number {
    return Math.max(...spsArray.map((e) => e.total.perSecond), 0);
 }

--- a/src/extensions/swing/slider.ts
+++ b/src/extensions/swing/slider.ts
@@ -1,12 +1,16 @@
-import type { ISwingContainer } from './types/swing.ts';
+import type { ISwingAnalysisBaseNoteAttribute, ISwingContainer } from './types/swing.ts';
 
 /** Get minimum value of slider speed from swings. */
-export function getMinSliderSpeed(swings: ISwingContainer[]): number {
+export function getMinSliderSpeed<
+   T extends ISwingAnalysisBaseNoteAttribute,
+>(swings: ISwingContainer<T>[]): number {
    return Math.max(...swings.map((s) => s.minSpeed), 0);
 }
 
 /** Get maximum value of slider speed from swings. */
-export function getMaxSliderSpeed(swings: ISwingContainer[]): number {
+export function getMaxSliderSpeed<
+   T extends ISwingAnalysisBaseNoteAttribute,
+>(swings: ISwingContainer<T>[]): number {
    const arr = swings.map((s) => s.maxSpeed).filter((n) => n !== 0);
    return arr.length ? Math.min(...arr) : 0;
 }

--- a/src/extensions/swing/swing.ts
+++ b/src/extensions/swing/swing.ts
@@ -9,19 +9,19 @@ import {
 } from '../../beatmap/helpers/core/gridObject.ts';
 import type { TimeProcessor } from '../../beatmap/helpers/timeProcessor.ts';
 import { NoteDirection } from '../../beatmap/shared/constants.ts';
+import type { IWrapBaseNoteAttribute } from '../../types/beatmap/wrapper/baseNote.ts';
 import type { IWrapBaseObjectAttribute } from '../../types/beatmap/wrapper/baseObject.ts';
-import type { IWrapColorNoteAttribute } from '../../types/beatmap/wrapper/colorNote.ts';
 import { checkDirection } from '../placement/note.ts';
-import type { ISwingContainer } from './types/swing.ts';
+import type { ISwingAnalysisBaseNoteAttribute, ISwingContainer } from './types/swing.ts';
 
 /**
  * Generate swings from beatmap notes.
  */
-export function generate<T extends IWrapColorNoteAttribute>(
+export function generate<T extends ISwingAnalysisBaseNoteAttribute>(
    notes: T[],
    timeProc: TimeProcessor,
-): ISwingContainer[] {
-   const sc: ISwingContainer[] = [];
+): ISwingContainer<T>[] {
+   const sc: ISwingContainer<T>[] = [];
    let ebpm = 0;
    let ebpmSwing = 0;
    let minSpeed: number;
@@ -89,12 +89,9 @@ export function generate<T extends IWrapColorNoteAttribute>(
 /**
  * Check if next swing happen from `prevNote` to `currNote`.
  */
-export function next<T extends IWrapColorNoteAttribute>(
-   currNote: T,
-   prevNote: T,
-   timeProc: TimeProcessor,
-   context?: T[],
-): boolean {
+export function next<
+   T extends Pick<IWrapBaseNoteAttribute, 'time' | 'posX' | 'posY' | 'direction'>,
+>(currNote: T, prevNote: T, timeProc: TimeProcessor, context?: T[]): boolean {
    if (
       context &&
       context.length > 0 &&
@@ -126,11 +123,9 @@ export function next<T extends IWrapColorNoteAttribute>(
 }
 
 /** Calculate effective BPM between `currObj` and `prevObj`. */
-export function calcEBPMBetweenObject<T extends IWrapBaseObjectAttribute>(
-   currObj: T,
-   prevObj: T,
-   timeProc: TimeProcessor,
-): number {
+export function calcEBPMBetweenObject<
+   T extends Pick<IWrapBaseObjectAttribute, 'time'>,
+>(currObj: T, prevObj: T, timeProc: TimeProcessor): number {
    return (
       timeProc.bpm /
       (timeProc.toBeatTime(
@@ -146,10 +141,9 @@ export function calcEBPMBetweenObject<T extends IWrapBaseObjectAttribute>(
  *
  * Higher value is slower.
  */
-function calcMinSliderSpeed<T extends IWrapColorNoteAttribute>(
-   notes: T[],
-   timeProc: TimeProcessor,
-): number {
+function calcMinSliderSpeed<
+   T extends Pick<IWrapBaseNoteAttribute, 'time' | 'posX' | 'posY'>,
+>(notes: T[], timeProc: TimeProcessor): number {
    let hasStraight = false;
    let hasDiagonal = false;
    let curvedSpeed = 0;
@@ -185,10 +179,9 @@ function calcMinSliderSpeed<T extends IWrapColorNoteAttribute>(
  *
  * Lower value is faster.
  */
-function calcMaxSliderSpeed<T extends IWrapColorNoteAttribute>(
-   notes: T[],
-   timeProc: TimeProcessor,
-): number {
+function calcMaxSliderSpeed<
+   T extends Pick<IWrapBaseNoteAttribute, 'time' | 'posX' | 'posY'>,
+>(notes: T[], timeProc: TimeProcessor): number {
    let hasStraight = false;
    let hasDiagonal = false;
    let curvedSpeed = Number.MAX_SAFE_INTEGER;

--- a/src/extensions/swing/types/swing.ts
+++ b/src/extensions/swing/types/swing.ts
@@ -1,6 +1,6 @@
 import type { CharacteristicName } from '../../../types/beatmap/shared/characteristic.ts';
 import type { DifficultyName } from '../../../types/beatmap/shared/difficulty.ts';
-import type { IWrapColorNote } from '../../../types/beatmap/wrapper/colorNote.ts';
+import type { IWrapColorNoteAttribute } from '../../../types/beatmap/wrapper/colorNote.ts';
 
 export interface ISwingContainer {
    readonly time: number;
@@ -9,7 +9,7 @@ export interface ISwingContainer {
    readonly maxSpeed: number;
    readonly ebpm: number;
    readonly ebpmSwing: number;
-   readonly data: IWrapColorNote[];
+   readonly data: IWrapColorNoteAttribute[];
 }
 
 export interface ISwingCount {

--- a/src/extensions/swing/types/swing.ts
+++ b/src/extensions/swing/types/swing.ts
@@ -1,15 +1,31 @@
 import type { CharacteristicName } from '../../../types/beatmap/shared/characteristic.ts';
 import type { DifficultyName } from '../../../types/beatmap/shared/difficulty.ts';
-import type { IWrapColorNoteAttribute } from '../../../types/beatmap/wrapper/colorNote.ts';
+import type { IWrapBaseNoteAttribute } from '../../../types/beatmap/wrapper/baseNote.ts';
+import type { IWrapBeatmapAttributeSubset } from '../../../types/beatmap/wrapper/beatmap.ts';
 
-export interface ISwingContainer {
+export type ISwingAnalysisBeatmapAttribute =
+   & IWrapBeatmapAttributeSubset<
+      'colorNotes' | 'bombNotes' | 'chains',
+      'time' | 'posX' | 'posY' | 'color' | 'direction' | 'customData'
+   >
+   & IWrapBeatmapAttributeSubset<
+      'obstacles',
+      'time' | 'posX' | 'duration' | 'width' | 'customData'
+   >;
+
+export type ISwingAnalysisBaseNoteAttribute = Pick<
+   IWrapBaseNoteAttribute,
+   'time' | 'posX' | 'posY' | 'color' | 'direction'
+>;
+
+export interface ISwingContainer<T extends ISwingAnalysisBaseNoteAttribute> {
    readonly time: number;
    readonly duration: number;
    readonly minSpeed: number;
    readonly maxSpeed: number;
    readonly ebpm: number;
    readonly ebpmSwing: number;
-   readonly data: IWrapColorNoteAttribute[];
+   readonly data: T[];
 }
 
 export interface ISwingCount {
@@ -24,10 +40,10 @@ export interface ISwingPerSecond {
    readonly median: number;
 }
 
-export interface ISwingAnalysis {
+export interface ISwingAnalysis<T extends ISwingAnalysisBaseNoteAttribute> {
    readonly characteristic: CharacteristicName;
    readonly difficulty: DifficultyName;
-   readonly container: ISwingContainer[];
+   readonly container: ISwingContainer<T>[];
    readonly red: ISwingPerSecond;
    readonly blue: ISwingPerSecond;
    readonly total: ISwingPerSecond;

--- a/src/patch/customDataUpdate.ts
+++ b/src/patch/customDataUpdate.ts
@@ -2,32 +2,33 @@ import eventToV2 from '../beatmap/converter/customData/eventToV2.ts';
 import eventToV3 from '../beatmap/converter/customData/eventToV3.ts';
 import objectToV2 from '../beatmap/converter/customData/objectToV2.ts';
 import objectToV3 from '../beatmap/converter/customData/objectToV3.ts';
+import { isLaserRotationEventType } from '../beatmap/helpers/core/basicEvent.ts';
 import { logger } from '../logger.ts';
 import type { IPointDefinition } from '../types/beatmap/v3/custom/pointDefinition.ts';
+import type { IWrapBeatmapAttribute } from '../types/beatmap/wrapper/beatmap.ts';
 import type { ColorArray } from '../types/colors.ts';
 import { colorFrom } from '../utils/colors.ts';
-import type { IWrapBeatmap } from '../types/beatmap/wrapper/beatmap.ts';
 
 function tag(name: string): string[] {
    return ['patch', 'customDataUpdate', name];
 }
 
-function v2(data: IWrapBeatmap): void {
+function v2<T extends IWrapBeatmapAttribute>(data: T): void {
    logger.tDebug(tag('v2'), ' Patching notes');
-   data.colorNotes.forEach((n) => {
+   data.difficulty.colorNotes.forEach((n) => {
       n.customData = objectToV2(n.customData);
    });
-   data.bombNotes.forEach((n) => {
+   data.difficulty.bombNotes.forEach((n) => {
       n.customData = objectToV2(n.customData);
    });
    logger.tDebug(tag('v2'), ' Patching obstacles');
-   data.obstacles.forEach((o) => {
+   data.difficulty.obstacles.forEach((o) => {
       o.customData = objectToV2(o.customData);
    });
    logger.tDebug(tag('v2'), ' Patching events');
-   data.basicEvents.forEach((e) => {
+   data.lightshow.basicEvents.forEach((e) => {
       e.customData = eventToV2(e.customData);
-      if (e.isLaserRotationEvent()) {
+      if (isLaserRotationEventType(e.type)) {
          if (typeof e.customData._preciseSpeed !== 'number') {
             delete e.customData._speed;
          }
@@ -37,17 +38,17 @@ function v2(data: IWrapBeatmap): void {
    });
 }
 
-function v3(data: IWrapBeatmap): void {
+function v3<T extends IWrapBeatmapAttribute>(data: T): void {
    logger.tDebug(tag('v3'), ' Patching color notes');
-   data.colorNotes.forEach((n) => {
+   data.difficulty.colorNotes.forEach((n) => {
       n.customData = objectToV3(n.customData);
    });
    logger.tDebug(tag('v3'), ' Patching bomb notes');
-   data.bombNotes.forEach((b) => {
+   data.difficulty.bombNotes.forEach((b) => {
       b.customData = objectToV3(b.customData);
    });
    logger.tDebug(tag('v3'), ' Patching obstacles');
-   data.obstacles.forEach((o) => {
+   data.difficulty.obstacles.forEach((o) => {
       o.customData = objectToV3(o.customData);
    });
    logger.tDebug(tag('v3'), ' Patching fake color notes');
@@ -63,7 +64,7 @@ function v3(data: IWrapBeatmap): void {
       o.customData = objectToV3(o.customData);
    });
    logger.tDebug(tag('v3'), ' Patching basic events');
-   data.basicEvents.forEach((e) => {
+   data.lightshow.basicEvents.forEach((e) => {
       e.customData = eventToV3(e.customData);
    });
    logger.tDebug(tag('v3'), ' Patching bookmarks');
@@ -136,7 +137,7 @@ function v3(data: IWrapBeatmap): void {
 /**
  * Update custom data for beatmap given version.
  */
-export function customDataUpdate(data: IWrapBeatmap, version: number) {
+export function customDataUpdate<T extends IWrapBeatmapAttribute>(data: T, version: number) {
    logger.tInfo(
       ['patch', 'customDataUpdate'],
       'Patching custom data for beatmap v' + version + '...',

--- a/src/patch/dataCorrection/beatmap.ts
+++ b/src/patch/dataCorrection/beatmap.ts
@@ -1,40 +1,14 @@
-import { logger } from '../../logger.ts';
-import { fixBoolean, fixFloat, fixInt } from './helpers.ts';
-import type { IWrapBeatmap } from '../../types/beatmap/wrapper/beatmap.ts';
-import type { IWrapColorNoteAttribute } from '../../types/beatmap/wrapper/colorNote.ts';
-import type { IWrapObstacleAttribute } from '../../types/beatmap/wrapper/obstacle.ts';
-import type { IWrapBasicEventAttribute } from '../../types/beatmap/wrapper/basicEvent.ts';
-import type { IWrapWaypointAttribute } from '../../types/beatmap/wrapper/waypoint.ts';
-import type { IWrapArcAttribute } from '../../types/beatmap/wrapper/arc.ts';
-import type { IWrapRotationEventAttribute } from '../../types/beatmap/wrapper/rotationEvent.ts';
-import type { IWrapBPMEventAttribute } from '../../types/beatmap/wrapper/bpmEvent.ts';
-import type { IWrapBombNoteAttribute } from '../../types/beatmap/wrapper/bombNote.ts';
-import { ColorNote } from '../../beatmap/core/colorNote.ts';
-import { Obstacle } from '../../beatmap/core/obstacle.ts';
-import { BasicEvent } from '../../beatmap/core/basicEvent.ts';
-import { Waypoint } from '../../beatmap/core/waypoint.ts';
 import { Arc } from '../../beatmap/core/arc.ts';
-import { RotationEvent } from '../../beatmap/core/rotationEvent.ts';
-import { BPMEvent } from '../../beatmap/core/bpmEvent.ts';
+import { BasicEvent } from '../../beatmap/core/basicEvent.ts';
 import { BombNote } from '../../beatmap/core/bombNote.ts';
-import type { IBombNote } from '../../types/beatmap/v3/bombNote.ts';
-import type { IColorNote } from '../../types/beatmap/v3/colorNote.ts';
-import type { IObstacle } from '../../types/beatmap/v3/obstacle.ts';
-import type { IChain } from '../../types/beatmap/v3/chain.ts';
-import type { IWrapChainAttribute } from '../../types/beatmap/wrapper/chain.ts';
-import type { IWrapColorBoostEventAttribute } from '../../types/beatmap/wrapper/colorBoostEvent.ts';
-import type { IWrapIndexFilterAttribute } from '../../types/beatmap/wrapper/indexFilter.ts';
-import type { IWrapLightColorEventAttribute } from '../../types/beatmap/wrapper/lightColorEvent.ts';
-import type { IWrapLightColorEventBoxAttribute } from '../../types/beatmap/wrapper/lightColorEventBox.ts';
-import type { IWrapLightColorEventBoxGroupAttribute } from '../../types/beatmap/wrapper/lightColorEventBoxGroup.ts';
-import type { IWrapLightRotationEventAttribute } from '../../types/beatmap/wrapper/lightRotationEvent.ts';
-import type { IWrapLightRotationEventBoxAttribute } from '../../types/beatmap/wrapper/lightRotationEventBox.ts';
-import type { IWrapLightRotationEventBoxGroupAttribute } from '../../types/beatmap/wrapper/lightRotationEventBoxGroup.ts';
-import type { IWrapLightTranslationEventAttribute } from '../../types/beatmap/wrapper/lightTranslationEvent.ts';
-import type { IWrapLightTranslationEventBoxAttribute } from '../../types/beatmap/wrapper/lightTranslationEventBox.ts';
-import type { IWrapLightTranslationEventBoxGroupAttribute } from '../../types/beatmap/wrapper/lightTranslationEventBoxGroup.ts';
+import { BPMEvent } from '../../beatmap/core/bpmEvent.ts';
 import { Chain } from '../../beatmap/core/chain.ts';
 import { ColorBoostEvent } from '../../beatmap/core/colorBoostEvent.ts';
+import { ColorNote } from '../../beatmap/core/colorNote.ts';
+import { FxEventBox } from '../../beatmap/core/fxEventBox.ts';
+import { FxEventBoxGroup } from '../../beatmap/core/fxEventBoxGroup.ts';
+import { FxEventFloat } from '../../beatmap/core/fxEventFloat.ts';
+import { FxEventInt } from '../../beatmap/core/fxEventInt.ts';
 import { IndexFilter } from '../../beatmap/core/indexFilter.ts';
 import { LightColorEvent } from '../../beatmap/core/lightColorEvent.ts';
 import { LightColorEventBox } from '../../beatmap/core/lightColorEventBox.ts';
@@ -45,20 +19,50 @@ import { LightRotationEventBoxGroup } from '../../beatmap/core/lightRotationEven
 import { LightTranslationEvent } from '../../beatmap/core/lightTranslationEvent.ts';
 import { LightTranslationEventBox } from '../../beatmap/core/lightTranslationEventBox.ts';
 import { LightTranslationEventBoxGroup } from '../../beatmap/core/lightTranslationEventBoxGroup.ts';
+import { Obstacle } from '../../beatmap/core/obstacle.ts';
+import { RotationEvent } from '../../beatmap/core/rotationEvent.ts';
+import { Waypoint } from '../../beatmap/core/waypoint.ts';
+import {
+   isColorBoostEventType,
+   isLaneRotationEventType,
+} from '../../beatmap/helpers/core/basicEvent.ts';
+import { EventLaneRotationValue } from '../../beatmap/shared/constants.ts';
+import { logger } from '../../logger.ts';
+import type { IBombNote } from '../../types/beatmap/v3/bombNote.ts';
+import type { IChain } from '../../types/beatmap/v3/chain.ts';
+import type { IColorNote } from '../../types/beatmap/v3/colorNote.ts';
+import type { IFxEventBox } from '../../types/beatmap/v3/fxEventBox.ts';
 import type { ILightColorEventBox } from '../../types/beatmap/v3/lightColorEventBox.ts';
 import type { ILightRotationEventBox } from '../../types/beatmap/v3/lightRotationEventBox.ts';
 import type { ILightTranslationEventBox } from '../../types/beatmap/v3/lightTranslationEventBox.ts';
-import type { IFxEventBox } from '../../types/beatmap/v3/fxEventBox.ts';
-import { fixCustomDataEvent } from './customDataEvent.ts';
-import { fixCustomDataObject } from './customDataObject.ts';
-import { EventLaneRotationValue } from '../../beatmap/shared/constants.ts';
-import { FxEventFloat } from '../../beatmap/core/fxEventFloat.ts';
-import { FxEventInt } from '../../beatmap/core/fxEventInt.ts';
-import { FxEventBox } from '../../beatmap/core/fxEventBox.ts';
-import { FxEventBoxGroup } from '../../beatmap/core/fxEventBoxGroup.ts';
+import type { IObstacle } from '../../types/beatmap/v3/obstacle.ts';
+import type { IWrapArcAttribute } from '../../types/beatmap/wrapper/arc.ts';
+import type { IWrapBasicEventAttribute } from '../../types/beatmap/wrapper/basicEvent.ts';
+import type { IWrapBeatmapAttribute } from '../../types/beatmap/wrapper/beatmap.ts';
+import type { IWrapBombNoteAttribute } from '../../types/beatmap/wrapper/bombNote.ts';
+import type { IWrapBPMEventAttribute } from '../../types/beatmap/wrapper/bpmEvent.ts';
+import type { IWrapChainAttribute } from '../../types/beatmap/wrapper/chain.ts';
+import type { IWrapColorBoostEventAttribute } from '../../types/beatmap/wrapper/colorBoostEvent.ts';
+import type { IWrapColorNoteAttribute } from '../../types/beatmap/wrapper/colorNote.ts';
+import type { IWrapFxEventBoxAttribute } from '../../types/beatmap/wrapper/fxEventBox.ts';
 import type { IWrapFxEventBoxGroupAttribute } from '../../types/beatmap/wrapper/fxEventBoxGroup.ts';
 import type { IWrapFxEventFloatAttribute } from '../../types/beatmap/wrapper/fxEventFloat.ts';
-import type { IWrapFxEventBoxAttribute } from '../../types/beatmap/wrapper/fxEventBox.ts';
+import type { IWrapIndexFilterAttribute } from '../../types/beatmap/wrapper/indexFilter.ts';
+import type { IWrapLightColorEventAttribute } from '../../types/beatmap/wrapper/lightColorEvent.ts';
+import type { IWrapLightColorEventBoxAttribute } from '../../types/beatmap/wrapper/lightColorEventBox.ts';
+import type { IWrapLightColorEventBoxGroupAttribute } from '../../types/beatmap/wrapper/lightColorEventBoxGroup.ts';
+import type { IWrapLightRotationEventAttribute } from '../../types/beatmap/wrapper/lightRotationEvent.ts';
+import type { IWrapLightRotationEventBoxAttribute } from '../../types/beatmap/wrapper/lightRotationEventBox.ts';
+import type { IWrapLightRotationEventBoxGroupAttribute } from '../../types/beatmap/wrapper/lightRotationEventBoxGroup.ts';
+import type { IWrapLightTranslationEventAttribute } from '../../types/beatmap/wrapper/lightTranslationEvent.ts';
+import type { IWrapLightTranslationEventBoxAttribute } from '../../types/beatmap/wrapper/lightTranslationEventBox.ts';
+import type { IWrapLightTranslationEventBoxGroupAttribute } from '../../types/beatmap/wrapper/lightTranslationEventBoxGroup.ts';
+import type { IWrapObstacleAttribute } from '../../types/beatmap/wrapper/obstacle.ts';
+import type { IWrapRotationEventAttribute } from '../../types/beatmap/wrapper/rotationEvent.ts';
+import type { IWrapWaypointAttribute } from '../../types/beatmap/wrapper/waypoint.ts';
+import { fixCustomDataEvent } from './customDataEvent.ts';
+import { fixCustomDataObject } from './customDataObject.ts';
+import { fixBoolean, fixFloat, fixInt } from './helpers.ts';
 
 function fixBpmEvent(obj: IWrapBPMEventAttribute): void {
    obj.time = fixFloat(obj.time, BPMEvent.defaultValue.time);
@@ -492,63 +496,63 @@ function fixFxEventFloat(obj: IWrapFxEventFloatAttribute): void {
 /**
  * Verifies and corrects data type for beatmap data.
  */
-export function beatmap(data: IWrapBeatmap): void {
+export function beatmap<T extends IWrapBeatmapAttribute>(data: T): void {
    logger.tInfo(
       ['patch', 'dataCorrection', 'beatmap', 'main'],
       'Verifying and correcting data type...',
    );
 
-   data.bpmEvents.forEach(fixBpmEvent);
-   data.rotationEvents.forEach(fixRotationEvent);
-   data.colorNotes.forEach(fixColorNote);
-   data.bombNotes.forEach(fixBombNote);
-   data.obstacles.forEach(fixObstacle);
-   data.arcs.forEach(fixSlider);
-   data.chains.forEach(fixChain);
-   data.waypoints.forEach(fixWaypoint);
+   data.difficulty.bpmEvents.forEach(fixBpmEvent);
+   data.difficulty.rotationEvents.forEach(fixRotationEvent);
+   data.difficulty.colorNotes.forEach(fixColorNote);
+   data.difficulty.bombNotes.forEach(fixBombNote);
+   data.difficulty.obstacles.forEach(fixObstacle);
+   data.difficulty.arcs.forEach(fixSlider);
+   data.difficulty.chains.forEach(fixChain);
+   data.lightshow.waypoints.forEach(fixWaypoint);
    data.difficulty.customData.fakeColorNotes?.forEach(fixFakeColorNote);
    data.difficulty.customData.fakeBombNotes?.forEach(fixFakeBombNote);
    data.difficulty.customData.fakeObstacles?.forEach(fixFakeObstacle);
    data.difficulty.customData.fakeChains?.forEach(fixFakeChain);
-   data.basicEvents.forEach(fixBasicEvent);
-   data.colorBoostEvents.forEach(fixColorBoostEvent);
-   data.lightColorEventBoxGroups.forEach(fixLightColorEventBoxGroup);
-   data.lightRotationEventBoxGroups.forEach(fixLightRotationEventBoxGroup);
-   data.lightTranslationEventBoxGroups.forEach(
+   data.lightshow.basicEvents.forEach(fixBasicEvent);
+   data.lightshow.colorBoostEvents.forEach(fixColorBoostEvent);
+   data.lightshow.lightColorEventBoxGroups.forEach(fixLightColorEventBoxGroup);
+   data.lightshow.lightRotationEventBoxGroups.forEach(fixLightRotationEventBoxGroup);
+   data.lightshow.lightTranslationEventBoxGroups.forEach(
       fixLightTranslationEventBoxGroup,
    );
-   data.fxEventBoxGroups.forEach(fixFxEventBoxGroup);
+   data.lightshow.fxEventBoxGroups.forEach(fixFxEventBoxGroup);
    data.lightshow.useNormalEventsAsCompatibleEvents = fixBoolean(
       data.lightshow.useNormalEventsAsCompatibleEvents,
    );
 
-   const boost = data.basicEvents.filter((ev) => ev.isLaneRotationEvent());
-   const laneRotation = data.basicEvents.filter((ev) => ev.isColorBoost());
-   data.basicEvents = data.basicEvents.filter(
-      (ev) => !(ev.isColorBoost() || ev.isLaneRotationEvent()),
+   const boost = data.lightshow.basicEvents.filter((ev) => isColorBoostEventType(ev.type));
+   const laneRotation = data.lightshow.basicEvents.filter((ev) => isLaneRotationEventType(ev.type));
+   data.lightshow.basicEvents = data.lightshow.basicEvents.filter(
+      (ev) => !(isColorBoostEventType(ev.type) || isLaneRotationEventType(ev.type)),
    );
-   data.colorBoostEvents.push(
+   data.lightshow.colorBoostEvents.push(
       ...boost.map(
-         (ev) =>
-            new ColorBoostEvent({
-               time: ev.time,
-               toggle: ev.value ? true : false,
-            }),
+         (ev) => ({
+            time: ev.time,
+            toggle: ev.value ? true : false,
+            customData: {},
+         }),
       ),
    );
-   data.rotationEvents.push(
+   data.difficulty.rotationEvents.push(
       ...laneRotation.map(
-         (ev) =>
-            new RotationEvent({
-               time: ev.time,
-               executionTime: ev.type == 15 ? 1 : 0,
-               rotation: ev.customData._rotation ??
-                  (ev.value >= 1000 && ev.value <= 1720
-                     ? ev.value - 1360
-                     : ev.value >= 0 && ev.value <= 7
-                     ? EventLaneRotationValue[ev.value]
-                     : 0),
-            }),
+         (ev) => ({
+            time: ev.time,
+            executionTime: ev.type == 15 ? 1 : 0,
+            rotation: ev.customData._rotation ??
+               (ev.value >= 1000 && ev.value <= 1720
+                  ? ev.value - 1360
+                  : ev.value >= 0 && ev.value <= 7
+                  ? EventLaneRotationValue[ev.value]
+                  : 0),
+            customData: {},
+         }),
       ),
    );
 }

--- a/src/patch/dataCorrection/info.ts
+++ b/src/patch/dataCorrection/info.ts
@@ -1,11 +1,11 @@
-import { fixBoolean, fixFloat, fixInt, fixString } from './helpers.ts';
-import type { IWrapInfo } from '../../types/beatmap/wrapper/info.ts';
-import { EnvironmentRename } from '../../beatmap/shared/environment.ts';
-import type { IColor } from '../../types/colors.ts';
-import { logger } from '../../logger.ts';
-import { clamp } from '../../utils/math.ts';
-import type { EnvironmentName } from '../../types/beatmap/shared/environment.ts';
 import { is360Environment } from '../../beatmap/helpers/environment.ts';
+import { EnvironmentRename } from '../../beatmap/shared/environment.ts';
+import { logger } from '../../logger.ts';
+import type { EnvironmentName } from '../../types/beatmap/shared/environment.ts';
+import type { IWrapInfoAttribute } from '../../types/beatmap/wrapper/info.ts';
+import type { IColor } from '../../types/colors.ts';
+import { clamp } from '../../utils/math.ts';
+import { fixBoolean, fixFloat, fixInt, fixString } from './helpers.ts';
 
 function fixEnvironment(str: unknown, all = false): EnvironmentName {
    if (typeof str === 'string') {
@@ -47,7 +47,7 @@ function fixColorObject(val: unknown, req?: boolean) {
 /**
  * Verifies and corrects data type for beatmap info.
  */
-export function info(data: IWrapInfo): void {
+export function info<T extends IWrapInfoAttribute>(data: T): void {
    logger.tInfo(
       ['patch', 'dataCorrection', 'info'],
       'Verifying and correcting data type for beatmap info...',

--- a/src/patch/removeOutsidePlayable.ts
+++ b/src/patch/removeOutsidePlayable.ts
@@ -1,41 +1,41 @@
-import { logger } from '../logger.ts';
 import type { TimeProcessor } from '../beatmap/helpers/timeProcessor.ts';
-import type { IWrapBaseObject } from '../types/beatmap/wrapper/baseObject.ts';
-import type { IWrapBeatmap } from '../types/beatmap/wrapper/beatmap.ts';
+import { logger } from '../logger.ts';
+import type { IWrapBaseObjectAttribute } from '../types/beatmap/wrapper/baseObject.ts';
+import type { IWrapBeatmapAttribute } from '../types/beatmap/wrapper/beatmap.ts';
 
 function tag(): string[] {
    return ['patch', 'removeOutsidePlayable'];
 }
 
 let duration = 0;
-const filterTime = <T extends IWrapBaseObject>(obj: T) =>
+const filterTime = <T extends IWrapBaseObjectAttribute>(obj: T) =>
    duration ? !(obj.time < 0 || obj.time > duration) : !(obj.time < 0);
 
 /**
  * Removes outside playable objects from beatmap given duration (seconds).
  */
-export function removeOutsidePlayable(
-   data: IWrapBeatmap,
+export function removeOutsidePlayable<T extends IWrapBeatmapAttribute>(
+   data: T,
    timeProc: TimeProcessor,
    audioLength: number,
 ) {
    duration = timeProc.toBeatTime(audioLength, true);
    logger.tDebug(tag(), 'Removing outside playable BPM events');
-   data.bpmEvents = data.bpmEvents.filter(filterTime);
+   data.difficulty.bpmEvents = data.difficulty.bpmEvents.filter(filterTime);
    logger.tDebug(tag(), 'Removing outside playable rotation events');
-   data.rotationEvents = data.rotationEvents.filter(filterTime);
+   data.difficulty.rotationEvents = data.difficulty.rotationEvents.filter(filterTime);
    logger.tDebug(tag(), 'Removing outside playable color notes');
-   data.colorNotes = data.colorNotes.filter(filterTime);
+   data.difficulty.colorNotes = data.difficulty.colorNotes.filter(filterTime);
    logger.tDebug(tag(), 'Removing outside playable bomb notes');
-   data.bombNotes = data.bombNotes.filter(filterTime);
+   data.difficulty.bombNotes = data.difficulty.bombNotes.filter(filterTime);
    logger.tDebug(tag(), 'Removing outside playable obstacles');
-   data.obstacles = data.obstacles.filter(filterTime);
+   data.difficulty.obstacles = data.difficulty.obstacles.filter(filterTime);
    logger.tDebug(tag(), 'Removing outside playable arcs');
-   data.arcs = data.arcs.filter(filterTime);
+   data.difficulty.arcs = data.difficulty.arcs.filter(filterTime);
    logger.tDebug(tag(), 'Removing outside playable chains');
-   data.chains = data.chains.filter(filterTime);
+   data.difficulty.chains = data.difficulty.chains.filter(filterTime);
    logger.tDebug(tag(), 'Removing outside playable waypoints');
-   data.waypoints = data.waypoints.filter(filterTime);
+   data.lightshow.waypoints = data.lightshow.waypoints.filter(filterTime);
    logger.tDebug(tag(), 'Removing outside playable fake color notes');
    if (data.difficulty.customData.fakeColorNotes) {
       data.difficulty.customData.fakeColorNotes = data.difficulty.customData.fakeColorNotes.filter((
@@ -60,17 +60,21 @@ export function removeOutsidePlayable(
          .filter((obj) => duration ? !(obj.b! < 0 || obj.b! > duration) : !(obj.b! < 0));
    }
    logger.tDebug(tag(), 'Removing outside playable basic events');
-   data.basicEvents = data.basicEvents.filter(filterTime);
+   data.lightshow.basicEvents = data.lightshow.basicEvents.filter(filterTime);
    logger.tDebug(tag(), 'Removing outside playable color boost beatmap events');
-   data.colorBoostEvents = data.colorBoostEvents.filter(filterTime);
+   data.lightshow.colorBoostEvents = data.lightshow.colorBoostEvents.filter(filterTime);
    logger.tDebug(
       tag(),
       'Removing outside playable light color event box groups',
    );
-   data.lightColorEventBoxGroups = data.lightColorEventBoxGroups.filter(filterTime);
+   data.lightshow.lightColorEventBoxGroups = data.lightshow.lightColorEventBoxGroups.filter(
+      filterTime,
+   );
    logger.tDebug(
       tag(),
       'Removing outside playable light rotation event box groups',
    );
-   data.lightRotationEventBoxGroups = data.lightRotationEventBoxGroups.filter(filterTime);
+   data.lightshow.lightRotationEventBoxGroups = data.lightshow.lightRotationEventBoxGroups.filter(
+      filterTime,
+   );
 }

--- a/src/read/_main.ts
+++ b/src/read/_main.ts
@@ -1,9 +1,10 @@
 // deno-lint-ignore-file no-explicit-any
 import { loadBeatmap } from '../beatmap/loader/_main.ts';
-import { path } from '../shims/path.ts';
-import { readJSONFile, readJSONFileSync } from '../shims/_json.ts';
 import { globals } from '../globals.ts';
+import { readJSONFile, readJSONFileSync } from '../shims/_json.ts';
+import { path } from '../shims/path.ts';
 import type { BeatmapFileType } from '../types/beatmap/shared/schema.ts';
+import { IWrapBeatmapAttribute } from '../types/beatmap/wrapper/beatmap.ts';
 import type { IReadOptions } from '../types/bsmap/reader.ts';
 
 const defaultOptions: Required<IReadOptions> = {
@@ -28,11 +29,12 @@ export function handleRead<T extends Record<string, any>>(
       src,
    );
    return readJSONFile(p)
-      .then((data) => loadBeatmap(type, data, ver, opt.load))
+      .then((data) => loadBeatmap(type, data, ver, opt.load) as unknown as IWrapBeatmapAttribute)
       .then((d) => {
-         if (type === 'lightshow') d.setLightshowFilename(path.basename(p));
-         else d.setFilename(path.basename(p));
-         return d;
+         if (type === 'lightshow' && 'lightshowFilename' in d) {
+            d.lightshowFilename = path.basename(p);
+         } else d.filename = path.basename(p);
+         return d as unknown as T;
       });
 }
 
@@ -53,8 +55,8 @@ export function handleReadSync<T extends Record<string, any>>(
       readJSONFileSync(p),
       ver,
       opt.load,
-   ).setFilename(path.basename(p));
-   if (type === 'lightshow') d.setLightshowFilename(path.basename(p));
-   else d.setFilename(path.basename(p));
-   return d;
+   ) as unknown as IWrapBeatmapAttribute;
+   if (type === 'lightshow' && 'lightshowFilename' in d) d.lightshowFilename = path.basename(p);
+   else d.filename = path.basename(p);
+   return d as unknown as T;
 }

--- a/src/read/_main.ts
+++ b/src/read/_main.ts
@@ -3,60 +3,87 @@ import { loadBeatmap } from '../beatmap/loader/_main.ts';
 import { globals } from '../globals.ts';
 import { readJSONFile, readJSONFileSync } from '../shims/_json.ts';
 import { path } from '../shims/path.ts';
+import type { MirrorFn } from '../types/beatmap/shared/functions.ts';
+import type {
+   InferBeatmapAttribute,
+   InferBeatmapSerial,
+   InferBeatmapVersion,
+} from '../types/beatmap/shared/infer.ts';
 import type { BeatmapFileType } from '../types/beatmap/shared/schema.ts';
-import { IWrapBeatmapAttribute } from '../types/beatmap/wrapper/beatmap.ts';
 import type { IReadOptions } from '../types/bsmap/reader.ts';
 
-const defaultOptions: Required<IReadOptions> = {
+const defaultOptions = {
    directory: '',
    load: {},
-};
+} as const;
 
 export function tag(name: string): string[] {
    return ['reader', name];
 }
 
-export function handleRead<T extends Record<string, any>>(
-   type: BeatmapFileType,
+export function handleRead<
+   TFileType extends BeatmapFileType,
+   TVersion extends InferBeatmapVersion<TFileType>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<TFileType>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<TFileType, TVersion>,
+>(
+   type: TFileType,
    src: string,
-   version?: number | null | IReadOptions<T>,
-   options: IReadOptions<T> = {},
-): Promise<T> {
+   version?: TVersion | null | IReadOptions<TFileType, TVersion, TWrapper, TSerial>,
+   options: IReadOptions<TFileType, TVersion, TWrapper, TSerial> = {},
+): Promise<TWrapper> {
    const ver = typeof version === 'number' ? version : null;
    const opt = (typeof version !== 'number' ? version : options) ?? {};
    const p = path.resolve(
       opt.directory ?? (defaultOptions.directory || globals.directory),
       src,
    );
-   return readJSONFile(p)
-      .then((data) => loadBeatmap(type, data, ver, opt.load) as unknown as IWrapBeatmapAttribute)
-      .then((d) => {
-         if (type === 'lightshow' && 'lightshowFilename' in d) {
-            d.lightshowFilename = path.basename(p);
-         } else d.filename = path.basename(p);
-         return d as unknown as T;
+   const [posttransformer, ...postprocesses] = (opt.load?.postprocess?.toReversed() ?? []) as [
+      (data: InferBeatmapAttribute<TFileType>) => TWrapper,
+      ...MirrorFn<InferBeatmapAttribute<TFileType>>[],
+   ];
+   return (readJSONFile(p) as Promise<TSerial>).then((data) => {
+      return loadBeatmap(type, data, ver, {
+         ...opt.load,
+         postprocess: [...postprocesses, (x) => {
+            if (type === 'lightshow' && 'lightshowFilename' in x) {
+               x.lightshowFilename = path.basename(p);
+            } else x.filename = path.basename(p);
+            return posttransformer ? posttransformer(x) : x as TWrapper;
+         }],
       });
+   });
 }
 
-export function handleReadSync<T extends Record<string, any>>(
-   type: BeatmapFileType,
+export function handleReadSync<
+   TFileType extends BeatmapFileType,
+   TVersion extends InferBeatmapVersion<TFileType>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<TFileType>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<TFileType, TVersion>,
+>(
+   type: TFileType,
    src: string,
-   version?: number | null | IReadOptions<T>,
-   options: IReadOptions<T> = {},
-): T {
+   version?: TVersion | null | IReadOptions<TFileType, TVersion, TWrapper, TSerial>,
+   options: IReadOptions<TFileType, TVersion, TWrapper, TSerial> = {},
+): TWrapper {
    const ver = typeof version === 'number' ? version : null;
    const opt = (typeof version !== 'number' ? version : options) ?? {};
    const p = path.resolve(
       opt.directory ?? (defaultOptions.directory || globals.directory),
       src,
    );
-   const d = loadBeatmap(
-      type,
-      readJSONFileSync(p),
-      ver,
-      opt.load,
-   ) as unknown as IWrapBeatmapAttribute;
-   if (type === 'lightshow' && 'lightshowFilename' in d) d.lightshowFilename = path.basename(p);
-   else d.filename = path.basename(p);
-   return d as unknown as T;
+   const [posttransformer, ...postprocesses] = (opt.load?.postprocess?.toReversed() ?? []) as [
+      (data: InferBeatmapAttribute<TFileType>) => TWrapper,
+      ...MirrorFn<InferBeatmapAttribute<TFileType>>[],
+   ];
+   const d = loadBeatmap(type, readJSONFileSync(p) as TSerial, ver, {
+      ...opt.load,
+      postprocess: [...postprocesses, (x) => {
+         if (type === 'lightshow' && 'lightshowFilename' in x) {
+            x.lightshowFilename = path.basename(p);
+         } else x.filename = path.basename(p);
+         return posttransformer ? posttransformer(x) : x as TWrapper;
+      }],
+   });
+   return d;
 }

--- a/src/read/audioData.ts
+++ b/src/read/audioData.ts
@@ -1,8 +1,13 @@
-import type { GenericAudioDataFilename } from '../types/beatmap/shared/filename.ts';
+// deno-lint-ignore-file no-explicit-any
 import { logger } from '../logger.ts';
-import type { LooseAutocomplete } from '../types/utils.ts';
-import type { IWrapAudioData } from '../types/beatmap/wrapper/audioData.ts';
+import type { GenericAudioDataFilename } from '../types/beatmap/shared/filename.ts';
+import type {
+   InferBeatmapAttribute,
+   InferBeatmapSerial,
+   InferBeatmapVersion,
+} from '../types/beatmap/shared/infer.ts';
 import type { IReadOptions } from '../types/bsmap/reader.ts';
+import type { LooseAutocomplete } from '../types/utils.ts';
 import { handleRead, handleReadSync, tag } from './_main.ts';
 
 /**
@@ -13,22 +18,34 @@ import { handleRead, handleReadSync, tag } from './_main.ts';
  *
  * Mismatched beatmap version will be automatically converted, unspecified will leave the version as is but not known.
  */
-export function readAudioDataFile(
+export function readAudioDataFile<
+   TVersion extends InferBeatmapVersion<'audioData'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'audioData'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'audioData', TVersion>,
+>(
    path: LooseAutocomplete<GenericAudioDataFilename>,
-   version?: number | null,
-   options?: IReadOptions<IWrapAudioData>,
-): Promise<IWrapAudioData>;
-export function readAudioDataFile(
+   version?: TVersion | null,
+   options?: IReadOptions<'audioData', TVersion, TWrapper, TSerial>,
+): Promise<TWrapper>;
+export function readAudioDataFile<
+   TVersion extends InferBeatmapVersion<'audioData'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'audioData'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'audioData', TVersion>,
+>(
    path: LooseAutocomplete<GenericAudioDataFilename>,
-   options?: IReadOptions<IWrapAudioData>,
-): Promise<IWrapAudioData>;
-export function readAudioDataFile(
+   options?: IReadOptions<'audioData', TVersion, TWrapper, TSerial>,
+): Promise<TWrapper>;
+export function readAudioDataFile<
+   TVersion extends InferBeatmapVersion<'audioData'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'audioData'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'audioData', TVersion>,
+>(
    path: LooseAutocomplete<GenericAudioDataFilename>,
-   version?: number | null | IReadOptions<IWrapAudioData>,
-   options?: IReadOptions<IWrapAudioData>,
-): Promise<IWrapAudioData> {
+   version?: TVersion | null | IReadOptions<'audioData', TVersion, TWrapper, TSerial>,
+   options?: IReadOptions<'audioData', TVersion, TWrapper, TSerial>,
+): Promise<TWrapper> {
    logger.tInfo(tag('readAudioDataFile'), 'Async reading audio data file');
-   return handleRead('audioData', path, version, options);
+   return handleRead<'audioData', TVersion, TWrapper, TSerial>('audioData', path, version, options);
 }
 
 /**
@@ -40,20 +57,37 @@ export function readAudioDataFile(
  *
  * Mismatched beatmap version will be automatically converted, unspecified will leave the version as is but not known.
  */
-export function readAudioDataFileSync(
+export function readAudioDataFileSync<
+   TVersion extends InferBeatmapVersion<'audioData'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'audioData'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'audioData', TVersion>,
+>(
    path: LooseAutocomplete<GenericAudioDataFilename>,
-   version?: number | null,
-   options?: IReadOptions<IWrapAudioData>,
-): IWrapAudioData;
-export function readAudioDataFileSync(
+   version?: TVersion | null,
+   options?: IReadOptions<'audioData', TVersion, TWrapper, TSerial>,
+): TWrapper;
+export function readAudioDataFileSync<
+   TVersion extends InferBeatmapVersion<'audioData'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'audioData'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'audioData', TVersion>,
+>(
    path: LooseAutocomplete<GenericAudioDataFilename>,
-   options?: IReadOptions<IWrapAudioData>,
-): IWrapAudioData;
-export function readAudioDataFileSync(
+   options?: IReadOptions<'audioData', TVersion, TWrapper, TSerial>,
+): TWrapper;
+export function readAudioDataFileSync<
+   TVersion extends InferBeatmapVersion<'audioData'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'audioData'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'audioData', TVersion>,
+>(
    path: LooseAutocomplete<GenericAudioDataFilename>,
-   version?: number | null | IReadOptions<IWrapAudioData>,
-   options?: IReadOptions<IWrapAudioData>,
-): IWrapAudioData {
+   version?: TVersion | null | IReadOptions<'audioData', TVersion, TWrapper, TSerial>,
+   options?: IReadOptions<'audioData', TVersion, TWrapper, TSerial>,
+): TWrapper {
    logger.tInfo(tag('readAudioDataFileSync'), 'Sync reading audio data file');
-   return handleReadSync('audioData', path, version, options);
+   return handleReadSync<'audioData', TVersion, TWrapper, TSerial>(
+      'audioData',
+      path,
+      version,
+      options,
+   );
 }

--- a/src/read/difficulty.ts
+++ b/src/read/difficulty.ts
@@ -1,8 +1,13 @@
-import type { GenericBeatmapFilename } from '../types/beatmap/shared/filename.ts';
+// deno-lint-ignore-file no-explicit-any
 import { logger } from '../logger.ts';
-import type { LooseAutocomplete } from '../types/utils.ts';
-import type { IWrapBeatmap } from '../types/beatmap/wrapper/beatmap.ts';
+import type { GenericBeatmapFilename } from '../types/beatmap/shared/filename.ts';
+import type {
+   InferBeatmapAttribute,
+   InferBeatmapSerial,
+   InferBeatmapVersion,
+} from '../types/beatmap/shared/infer.ts';
 import type { IReadOptions } from '../types/bsmap/reader.ts';
+import type { LooseAutocomplete } from '../types/utils.ts';
 import { handleRead, handleReadSync, tag } from './_main.ts';
 
 /**
@@ -13,22 +18,39 @@ import { handleRead, handleReadSync, tag } from './_main.ts';
  *
  * Mismatched beatmap version will be automatically converted, unspecified will leave the version as is but not known.
  */
-export function readDifficultyFile(
+export function readDifficultyFile<
+   TVersion extends InferBeatmapVersion<'difficulty'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'difficulty'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'difficulty', TVersion>,
+>(
    path: LooseAutocomplete<GenericBeatmapFilename>,
-   version?: number | null,
-   options?: IReadOptions<IWrapBeatmap>,
-): Promise<IWrapBeatmap>;
-export function readDifficultyFile(
+   version?: TVersion | null,
+   options?: IReadOptions<'difficulty', TVersion, TWrapper, TSerial>,
+): Promise<TWrapper>;
+export function readDifficultyFile<
+   TVersion extends InferBeatmapVersion<'difficulty'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'difficulty'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'difficulty', TVersion>,
+>(
    path: LooseAutocomplete<GenericBeatmapFilename>,
-   options?: IReadOptions<IWrapBeatmap>,
-): Promise<IWrapBeatmap>;
-export function readDifficultyFile(
+   options?: IReadOptions<'difficulty', TVersion, TWrapper, TSerial>,
+): Promise<TWrapper>;
+export function readDifficultyFile<
+   TVersion extends InferBeatmapVersion<'difficulty'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'difficulty'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'difficulty', TVersion>,
+>(
    path: LooseAutocomplete<GenericBeatmapFilename>,
-   version?: number | null | IReadOptions<IWrapBeatmap>,
-   options?: IReadOptions<IWrapBeatmap>,
-): Promise<IWrapBeatmap> {
+   version?: TVersion | null | IReadOptions<'difficulty', TVersion, TWrapper, TSerial>,
+   options?: IReadOptions<'difficulty', TVersion, TWrapper, TSerial>,
+): Promise<TWrapper> {
    logger.tInfo(tag('readDifficultyFile'), 'Async reading difficulty file');
-   return handleRead('difficulty', path, version, options);
+   return handleRead<'difficulty', TVersion, TWrapper, TSerial>(
+      'difficulty',
+      path,
+      version,
+      options,
+   );
 }
 
 /**
@@ -40,20 +62,37 @@ export function readDifficultyFile(
  *
  * Mismatched beatmap version will be automatically converted, unspecified will leave the version as is but not known.
  */
-export function readDifficultyFileSync(
+export function readDifficultyFileSync<
+   TVersion extends InferBeatmapVersion<'difficulty'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'difficulty'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'difficulty', TVersion>,
+>(
    path: LooseAutocomplete<GenericBeatmapFilename>,
-   version?: number | null,
-   options?: IReadOptions<IWrapBeatmap>,
-): IWrapBeatmap;
-export function readDifficultyFileSync(
+   version?: TVersion | null,
+   options?: IReadOptions<'difficulty', TVersion, TWrapper, TSerial>,
+): TWrapper;
+export function readDifficultyFileSync<
+   TVersion extends InferBeatmapVersion<'difficulty'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'difficulty'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'difficulty', TVersion>,
+>(
    path: LooseAutocomplete<GenericBeatmapFilename>,
-   options?: IReadOptions<IWrapBeatmap>,
-): IWrapBeatmap;
-export function readDifficultyFileSync(
+   options?: IReadOptions<'difficulty', TVersion, TWrapper, TSerial>,
+): TWrapper;
+export function readDifficultyFileSync<
+   TVersion extends InferBeatmapVersion<'difficulty'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'difficulty'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'difficulty', TVersion>,
+>(
    path: LooseAutocomplete<GenericBeatmapFilename>,
-   version?: number | null | IReadOptions<IWrapBeatmap>,
-   options?: IReadOptions<IWrapBeatmap>,
-): IWrapBeatmap {
+   version?: TVersion | null | IReadOptions<'difficulty', TVersion, TWrapper, TSerial>,
+   options?: IReadOptions<'difficulty', TVersion, TWrapper, TSerial>,
+): TWrapper {
    logger.tInfo(tag('readDifficultyFileSync'), 'Sync reading difficulty file');
-   return handleReadSync('difficulty', path, version, options);
+   return handleReadSync<'difficulty', TVersion, TWrapper, TSerial>(
+      'difficulty',
+      path,
+      version,
+      options,
+   );
 }

--- a/src/read/fromInfo.ts
+++ b/src/read/fromInfo.ts
@@ -1,50 +1,83 @@
-import type { IWrapBeatmap } from '../types/beatmap/wrapper/beatmap.ts';
-import type { IWrapInfoAttribute } from '../types/beatmap/wrapper/info.ts';
+// deno-lint-ignore-file no-explicit-any
+import type { MirrorFn } from '../types/beatmap/shared/functions.ts';
+import type {
+   InferBeatmapAttribute,
+   InferBeatmapSerial,
+   InferBeatmapVersion,
+} from '../types/beatmap/shared/infer.ts';
 import type { IBeatmapInfoData } from '../types/bsmap/fromInfo.ts';
 import type { IReadOptions } from '../types/bsmap/reader.ts';
 import { readDifficultyFile, readDifficultyFileSync } from './difficulty.ts';
-import { readLightshowFile, readLightshowFileSync } from './lightshow.ts';
+import { readLightshowFileSync } from './lightshow.ts';
 
-export async function readFromInfo(
-   info: IWrapInfoAttribute,
-   options: IReadOptions<IWrapBeatmap> = {},
-): Promise<IBeatmapInfoData[]> {
-   const ary: IBeatmapInfoData[] = [];
+export async function readFromInfo<
+   T extends Pick<InferBeatmapAttribute<'info'>, 'difficulties'>,
+   TVersion extends InferBeatmapVersion<'difficulty'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'difficulty'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'difficulty', TVersion>,
+>(
+   info: T,
+   options: IReadOptions<'difficulty', TVersion, TWrapper, TSerial> = {},
+): Promise<IBeatmapInfoData<TWrapper>[]> {
+   const ary: IBeatmapInfoData<TWrapper>[] = [];
    for (const d of info.difficulties) {
-      const beatmap = await readDifficultyFile(d.filename, options);
-      if (beatmap.version === 4) {
-         const light = await readLightshowFile(d.lightshowFilename, options);
-         beatmap.lightshow = light.lightshow;
-         beatmap.lightshowFilename = light.lightshowFilename;
-      }
-
-      ary.push({
-         info: d,
-         beatmap,
+      const [posttransformer, ...postprocesses] =
+         (options.load?.postprocess?.toReversed() ?? []) as [
+            (data: InferBeatmapAttribute<'difficulty'>) => TWrapper,
+            ...MirrorFn<InferBeatmapAttribute<'difficulty'>>[],
+         ];
+      const beatmap = await readDifficultyFile(d.filename, {
+         ...options,
+         load: {
+            postprocess: [...postprocesses, (x) => {
+               if (x.version === 4) {
+                  const light = readLightshowFileSync(d.lightshowFilename, {
+                     directory: options.directory ?? options.directory,
+                  });
+                  x.lightshow = light.lightshow;
+                  x.lightshowFilename = light.lightshowFilename;
+               }
+               return x;
+            }, posttransformer],
+         },
       });
+      ary.push({ info: d, beatmap });
    }
-
    return ary;
 }
 
-export function readFromInfoSync(
-   info: IWrapInfoAttribute,
-   options: IReadOptions<IWrapBeatmap> = {},
-): IBeatmapInfoData[] {
-   const ary: IBeatmapInfoData[] = [];
+export function readFromInfoSync<
+   T extends Pick<InferBeatmapAttribute<'info'>, 'difficulties'>,
+   TVersion extends InferBeatmapVersion<'difficulty'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'difficulty'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'difficulty', TVersion>,
+>(
+   info: T,
+   options: IReadOptions<'difficulty', TVersion, TWrapper, TSerial> = {},
+): IBeatmapInfoData<TWrapper>[] {
+   const ary: IBeatmapInfoData<TWrapper>[] = [];
    for (const d of info.difficulties) {
-      const beatmap = readDifficultyFileSync(d.filename, options);
-      if (beatmap.version === 4) {
-         const light = readLightshowFileSync(d.lightshowFilename, options);
-         beatmap.lightshow = light.lightshow;
-         beatmap.lightshowFilename = light.lightshowFilename;
-      }
-
-      ary.push({
-         info: d,
-         beatmap,
+      const [posttransformer, ...postprocesses] =
+         (options.load?.postprocess?.toReversed() ?? []) as [
+            (data: InferBeatmapAttribute<'difficulty'>) => TWrapper,
+            ...MirrorFn<InferBeatmapAttribute<'difficulty'>>[],
+         ];
+      const beatmap = readDifficultyFileSync(d.filename, {
+         ...options,
+         load: {
+            postprocess: [...postprocesses, (x) => {
+               if (x.version === 4) {
+                  const light = readLightshowFileSync(d.lightshowFilename, {
+                     directory: options.directory,
+                  });
+                  x.lightshow = light.lightshow;
+                  x.lightshowFilename = light.lightshowFilename;
+               }
+               return x;
+            }, posttransformer],
+         },
       });
+      ary.push({ info: d, beatmap });
    }
-
    return ary;
 }

--- a/src/read/info.ts
+++ b/src/read/info.ts
@@ -1,7 +1,12 @@
+// deno-lint-ignore-file no-explicit-any
 import { logger } from '../logger.ts';
-import type { LooseAutocomplete } from '../types/utils.ts';
-import type { IWrapInfo } from '../types/beatmap/wrapper/info.ts';
+import type {
+   InferBeatmapAttribute,
+   InferBeatmapSerial,
+   InferBeatmapVersion,
+} from '../types/beatmap/shared/infer.ts';
 import type { IReadOptions } from '../types/bsmap/reader.ts';
+import type { LooseAutocomplete } from '../types/utils.ts';
 import { handleRead, handleReadSync, tag } from './_main.ts';
 
 /**
@@ -16,22 +21,34 @@ import { handleRead, handleReadSync, tag } from './_main.ts';
  *
  * Mismatched beatmap version will be automatically converted, unspecified will leave the version as is but not known.
  */
-export function readInfoFile(
+export function readInfoFile<
+   TVersion extends InferBeatmapVersion<'info'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'info'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'info', TVersion>,
+>(
    path?: LooseAutocomplete<'Info.dat' | 'info.dat'>,
-   version?: number | null,
-   options?: IReadOptions<IWrapInfo>,
-): Promise<IWrapInfo>;
-export function readInfoFile(
+   version?: TVersion | null,
+   options?: IReadOptions<'info', TVersion, TWrapper, TSerial>,
+): Promise<TWrapper>;
+export function readInfoFile<
+   TVersion extends InferBeatmapVersion<'info'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'info'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'info', TVersion>,
+>(
    path?: LooseAutocomplete<'Info.dat' | 'info.dat'>,
-   options?: IReadOptions<IWrapInfo>,
-): Promise<IWrapInfo>;
-export function readInfoFile(
+   options?: IReadOptions<'info', TVersion, TWrapper, TSerial>,
+): Promise<TWrapper>;
+export function readInfoFile<
+   TVersion extends InferBeatmapVersion<'info'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'info'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'info', TVersion>,
+>(
    path: LooseAutocomplete<'Info.dat' | 'info.dat'> = 'Info.dat',
-   version?: number | null | IReadOptions<IWrapInfo>,
-   options?: IReadOptions<IWrapInfo>,
-): Promise<IWrapInfo> {
+   version?: TVersion | null | IReadOptions<'info', TVersion, TWrapper, TSerial>,
+   options?: IReadOptions<'info', TVersion, TWrapper, TSerial>,
+): Promise<TWrapper> {
    logger.tInfo(tag('readInfoFile'), 'Async reading info file');
-   return handleRead('info', path, version, options);
+   return handleRead<'info', TVersion, TWrapper, TSerial>('info', path, version, options);
 }
 
 /**
@@ -47,20 +64,32 @@ export function readInfoFile(
  *
  * Mismatched beatmap version will be automatically converted, unspecified will leave the version as is but not known.
  */
-export function readInfoFileSync(
+export function readInfoFileSync<
+   TVersion extends InferBeatmapVersion<'info'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'info'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'info', TVersion>,
+>(
    path?: LooseAutocomplete<'Info.dat' | 'info.dat'>,
-   version?: number | null,
-   options?: IReadOptions<IWrapInfo>,
-): IWrapInfo;
-export function readInfoFileSync(
+   version?: TVersion | null,
+   options?: IReadOptions<'info', TVersion, TWrapper, TSerial>,
+): TWrapper;
+export function readInfoFileSync<
+   TVersion extends InferBeatmapVersion<'info'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'info'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'info', TVersion>,
+>(
    path?: LooseAutocomplete<'Info.dat' | 'info.dat'>,
-   options?: IReadOptions<IWrapInfo>,
-): IWrapInfo;
-export function readInfoFileSync(
+   options?: IReadOptions<'info', TVersion, TWrapper, TSerial>,
+): TWrapper;
+export function readInfoFileSync<
+   TVersion extends InferBeatmapVersion<'info'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'info'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'info', TVersion>,
+>(
    path: LooseAutocomplete<'Info.dat' | 'info.dat'> = 'Info.dat',
-   version?: number | null | IReadOptions<IWrapInfo>,
-   options?: IReadOptions<IWrapInfo>,
-): IWrapInfo {
+   version?: TVersion | null | IReadOptions<'info', TVersion, TWrapper, TSerial>,
+   options?: IReadOptions<'info', TVersion, TWrapper, TSerial>,
+): TWrapper {
    logger.tInfo(tag('readInfoFileSync'), 'Sync reading info file');
-   return handleReadSync('info', path, version, options);
+   return handleReadSync<'info', TVersion, TWrapper, TSerial>('info', path, version, options);
 }

--- a/src/read/lightshow.ts
+++ b/src/read/lightshow.ts
@@ -1,8 +1,13 @@
-import type { GenericLightshowFilename } from '../types/beatmap/shared/filename.ts';
+// deno-lint-ignore-file no-explicit-any
 import { logger } from '../logger.ts';
-import type { LooseAutocomplete } from '../types/utils.ts';
-import type { IWrapBeatmap } from '../types/beatmap/wrapper/beatmap.ts';
+import type { GenericLightshowFilename } from '../types/beatmap/shared/filename.ts';
+import type {
+   InferBeatmapAttribute,
+   InferBeatmapSerial,
+   InferBeatmapVersion,
+} from '../types/beatmap/shared/infer.ts';
 import type { IReadOptions } from '../types/bsmap/reader.ts';
+import type { LooseAutocomplete } from '../types/utils.ts';
 import { handleRead, handleReadSync, tag } from './_main.ts';
 
 /**
@@ -13,22 +18,34 @@ import { handleRead, handleReadSync, tag } from './_main.ts';
  *
  * Mismatched beatmap version will be automatically converted, unspecified will leave the version as is but not known.
  */
-export function readLightshowFile(
+export function readLightshowFile<
+   TVersion extends InferBeatmapVersion<'lightshow'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'lightshow'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'lightshow', TVersion>,
+>(
    path: LooseAutocomplete<GenericLightshowFilename>,
-   version?: number | null,
-   options?: IReadOptions<IWrapBeatmap>,
-): Promise<IWrapBeatmap>;
-export function readLightshowFile(
+   version?: TVersion | null,
+   options?: IReadOptions<'lightshow', TVersion, TWrapper, TSerial>,
+): Promise<TWrapper>;
+export function readLightshowFile<
+   TVersion extends InferBeatmapVersion<'lightshow'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'lightshow'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'lightshow', TVersion>,
+>(
    path: LooseAutocomplete<GenericLightshowFilename>,
-   options?: IReadOptions<IWrapBeatmap>,
-): Promise<IWrapBeatmap>;
-export function readLightshowFile(
+   options?: IReadOptions<'lightshow', TVersion, TWrapper, TSerial>,
+): Promise<TWrapper>;
+export function readLightshowFile<
+   TVersion extends InferBeatmapVersion<'lightshow'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'lightshow'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'lightshow', TVersion>,
+>(
    path: LooseAutocomplete<GenericLightshowFilename>,
-   version?: number | null | IReadOptions<IWrapBeatmap>,
-   options?: IReadOptions<IWrapBeatmap>,
-): Promise<IWrapBeatmap> {
+   version?: TVersion | null | IReadOptions<'lightshow', TVersion, TWrapper, TSerial>,
+   options?: IReadOptions<'lightshow', TVersion, TWrapper, TSerial>,
+): Promise<TWrapper> {
    logger.tInfo(tag('readLightshowFile'), 'Async reading lightshow file');
-   return handleRead('lightshow', path, version, options);
+   return handleRead<'lightshow', TVersion, TWrapper, TSerial>('lightshow', path, version, options);
 }
 
 /**
@@ -40,20 +57,37 @@ export function readLightshowFile(
  *
  * Mismatched beatmap version will be automatically converted, unspecified will leave the version as is but not known.
  */
-export function readLightshowFileSync(
+export function readLightshowFileSync<
+   TVersion extends InferBeatmapVersion<'lightshow'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'lightshow'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'lightshow', TVersion>,
+>(
    path: LooseAutocomplete<GenericLightshowFilename>,
-   version?: number | null,
-   options?: IReadOptions<IWrapBeatmap>,
-): IWrapBeatmap;
-export function readLightshowFileSync(
+   version?: TVersion | null,
+   options?: IReadOptions<'lightshow', TVersion, TWrapper, TSerial>,
+): TWrapper;
+export function readLightshowFileSync<
+   TVersion extends InferBeatmapVersion<'lightshow'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'lightshow'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'lightshow', TVersion>,
+>(
    path: LooseAutocomplete<GenericLightshowFilename>,
-   options?: IReadOptions<IWrapBeatmap>,
-): IWrapBeatmap;
-export function readLightshowFileSync(
+   options?: IReadOptions<'lightshow', TVersion, TWrapper, TSerial>,
+): TWrapper;
+export function readLightshowFileSync<
+   TVersion extends InferBeatmapVersion<'lightshow'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'lightshow'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'lightshow', TVersion>,
+>(
    path: LooseAutocomplete<GenericLightshowFilename>,
-   version?: number | null | IReadOptions<IWrapBeatmap>,
-   options?: IReadOptions<IWrapBeatmap>,
-): IWrapBeatmap {
+   version?: TVersion | null | IReadOptions<'lightshow', TVersion, TWrapper, TSerial>,
+   options?: IReadOptions<'lightshow', TVersion, TWrapper, TSerial>,
+): TWrapper {
    logger.tInfo(tag('readLightshowFileSync'), 'Sync reading lightshow file');
-   return handleReadSync('lightshow', path, version, options);
+   return handleReadSync<'lightshow', TVersion, TWrapper, TSerial>(
+      'lightshow',
+      path,
+      version,
+      options,
+   );
 }

--- a/src/shims/_json.ts
+++ b/src/shims/_json.ts
@@ -18,7 +18,7 @@ export function readJSONFileSync(path: string): Record<string, any> {
 
 export function writeJSONFile(
    path: string,
-   json: Record<string, unknown>,
+   json: Record<string, any>,
    format?: number,
 ): Promise<void> {
    logger.tInfo(tag('writeJSONFile'), `Async writing JSON file to ${path}`);
@@ -27,7 +27,7 @@ export function writeJSONFile(
 
 export function writeJSONFileSync(
    path: string,
-   json: Record<string, unknown>,
+   json: Record<string, any>,
    format?: number,
 ): void {
    logger.tInfo(tag('writeJSONFileSync'), `Sync writing JSON file to ${path}`);

--- a/src/types/beatmap/options/loader.ts
+++ b/src/types/beatmap/options/loader.ts
@@ -1,7 +1,19 @@
 // deno-lint-ignore-file no-explicit-any no-explicit-any
+import type { MirrorFn } from '../shared/functions.ts';
+import type {
+   InferBeatmapAttribute,
+   InferBeatmapSerial,
+   InferBeatmapVersion,
+} from '../shared/infer.ts';
+import type { BeatmapFileType } from '../shared/schema.ts';
 import type { ISchemaCheckOptions } from './schema.ts';
 
-export interface ILoadOptions<T extends Record<string, any> = Record<string, any>> {
+export interface ILoadOptions<
+   TFileType extends BeatmapFileType,
+   TVersion extends InferBeatmapVersion<TFileType>,
+   TWrapper = Record<string, any>,
+   TSerial = Record<string, any>,
+> {
    /**
     * Force version conversion if loaded difficulty version is mismatched.
     *
@@ -23,11 +35,17 @@ export interface ILoadOptions<T extends Record<string, any> = Record<string, any
     *
     * @default []
     */
-   preprocess?: ((data: Record<string, any>) => Record<string, any>)[];
+   preprocess?: [
+      ((data: TSerial, version?: TVersion | null) => InferBeatmapSerial<TFileType, TVersion>),
+      ...MirrorFn<InferBeatmapSerial<TFileType, TVersion>>[],
+   ];
    /**
-    * Perform any postprocessing after object class has been instantiated.
+    * Perform any postprocessing after object attribute has been instantiated.
     *
     * @default []
     */
-   postprocess?: ((data: T) => T)[];
+   postprocess?: [
+      ...MirrorFn<InferBeatmapAttribute<TFileType>>[],
+      ((data: InferBeatmapAttribute<TFileType>, version?: TVersion | null) => TWrapper),
+   ];
 }

--- a/src/types/beatmap/options/saver.ts
+++ b/src/types/beatmap/options/saver.ts
@@ -1,10 +1,20 @@
 // deno-lint-ignore-file no-explicit-any
+import type { MirrorFn } from '../shared/functions.ts';
+import type {
+   InferBeatmapAttribute,
+   InferBeatmapSerial,
+   InferBeatmapVersion,
+} from '../shared/infer.ts';
+import type { BeatmapFileType } from '../shared/schema.ts';
 import type { ICompatibilityOptions } from './compatibility.ts';
-import type { ISchemaCheckOptions } from './schema.ts';
 import type { IOptimizeOptions } from './optimize.ts';
+import type { ISchemaCheckOptions } from './schema.ts';
 
 export interface ISaveOptions<
-   T extends Record<string, any> = Record<string, any>,
+   TFileType extends BeatmapFileType,
+   TVersion extends InferBeatmapVersion<TFileType>,
+   TWrapper = Record<string, any>,
+   TSerial = Record<string, any>,
 > {
    /**
     * Prettify format JSON.
@@ -35,13 +45,19 @@ export interface ISaveOptions<
     *
     * @default []
     */
-   preprocess?: ((data: T) => T)[];
+   preprocess?: [
+      ((data: TWrapper, version?: TVersion | null) => InferBeatmapAttribute<TFileType>),
+      ...MirrorFn<InferBeatmapAttribute<TFileType>>[],
+   ];
    /**
     * Perform any postprocessing after transformed into JSON.
     *
     * @default []
     */
-   postprocess?: ((data: Record<string, any>) => Record<string, any>)[];
+   postprocess?: [
+      ...MirrorFn<InferBeatmapSerial<TFileType, TVersion>>[],
+      ((data: InferBeatmapSerial<TFileType, TVersion>, version?: TVersion | null) => TSerial),
+   ];
 }
 
 export interface ISaveValidate {

--- a/src/types/beatmap/shared/infer.ts
+++ b/src/types/beatmap/shared/infer.ts
@@ -1,0 +1,35 @@
+// deno-lint-ignore-file no-explicit-any
+import type { v1, v2, v3, v4 } from '../mod.ts';
+import type { IWrapAudioDataAttribute } from '../wrapper/audioData.ts';
+import type { IWrapBeatmapAttribute } from '../wrapper/beatmap.ts';
+import type { IWrapInfoAttribute } from '../wrapper/info.ts';
+import type { BeatmapFileType } from './schema.ts';
+
+export type InferBeatmapVersion<
+   TFileType extends BeatmapFileType,
+> = TFileType extends 'info' ? 1 | 2 | 4
+   : TFileType extends 'audioData' ? 2 | 4
+   : TFileType extends 'difficulty' ? 1 | 2 | 3 | 4
+   : TFileType extends 'lightshow' ? 3 | 4
+   : number;
+
+export type InferBeatmapAttribute<
+   TFileType extends BeatmapFileType,
+> = TFileType extends 'info' ? IWrapInfoAttribute
+   : TFileType extends 'audioData' ? IWrapAudioDataAttribute
+   : TFileType extends 'difficulty' | 'lightshow' ? IWrapBeatmapAttribute
+   : Record<string, any>;
+
+type InfoSerialMap = [never, v1.IInfo, v2.IInfo, never, v4.IInfo];
+type AudioDataSerialMap = [never, never, v2.IBPMInfo, never, v4.IAudio];
+type DifficultySerialMap = [never, v1.IDifficulty, v2.IDifficulty, v3.IDifficulty, v4.IDifficulty];
+type LightshowSerialMap = [never, never, never, v3.ILightshow, v4.ILightshow];
+
+export type InferBeatmapSerial<
+   TFileType extends BeatmapFileType,
+   TVersion extends InferBeatmapVersion<TFileType> = InferBeatmapVersion<TFileType>,
+> = TFileType extends 'info' ? InfoSerialMap[TVersion]
+   : TFileType extends 'audioData' ? AudioDataSerialMap[TVersion]
+   : TFileType extends 'difficulty' ? DifficultySerialMap[TVersion]
+   : TFileType extends 'lightshow' ? LightshowSerialMap[TVersion]
+   : Record<string, any>;

--- a/src/types/beatmap/shared/mod.ts
+++ b/src/types/beatmap/shared/mod.ts
@@ -1,4 +1,5 @@
 export * from './custom/mod.ts';
+
 export * from './characteristic.ts';
 export * from './cloneable.ts';
 export * from './colorScheme.ts';
@@ -7,6 +8,7 @@ export * from './difficulty.ts';
 export * from './environment.ts';
 export * from './filename.ts';
 export * from './functions.ts';
+export * from './infer.ts';
 export * from './modCheck.ts';
 export * from './schema.ts';
 export * from './timeProcessor.ts';

--- a/src/types/beatmap/shared/schema.ts
+++ b/src/types/beatmap/shared/schema.ts
@@ -1,5 +1,4 @@
 // deno-lint-ignore-file no-explicit-any
-import type { DeepPartial } from '../../utils.ts';
 import type { Version } from './version.ts';
 
 interface ISchemaDeclarationBase {
@@ -41,9 +40,17 @@ export type BeatmapFileType = 'info' | 'audioData' | 'difficulty' | 'lightshow';
  * Schema container for serialization.
  */
 export interface ISchemaContainer<
-   TWrap = { [key: string]: any },
+   TWrapper = { [key: string]: any },
    TSerial = { [key: string]: any },
+   TSerializationOptions = { [key: string]: any },
+   TDeserializationOptions = TSerializationOptions,
 > {
-   serialize: (data: TWrap) => TSerial;
-   deserialize: (data?: DeepPartial<TSerial>) => DeepPartial<TWrap>;
+   serialize: (
+      data: TWrapper,
+      options?: Partial<TSerializationOptions>,
+   ) => TSerial;
+   deserialize: (
+      data: TSerial,
+      options?: Partial<TDeserializationOptions>,
+   ) => TWrapper;
 }

--- a/src/types/beatmap/shared/schema.ts
+++ b/src/types/beatmap/shared/schema.ts
@@ -1,4 +1,5 @@
 // deno-lint-ignore-file no-explicit-any
+import type { DeepPartial } from '../../utils.ts';
 import type { Version } from './version.ts';
 
 interface ISchemaDeclarationBase {
@@ -43,14 +44,14 @@ export interface ISchemaContainer<
    TWrapper = { [key: string]: any },
    TSerial = { [key: string]: any },
    TSerializationOptions = { [key: string]: any },
-   TDeserializationOptions = TSerializationOptions,
+   TDeserializationOptions = { [key: string]: any },
 > {
    serialize: (
       data: TWrapper,
-      options?: Partial<TSerializationOptions>,
+      options?: DeepPartial<TSerializationOptions>,
    ) => TSerial;
    deserialize: (
       data: TSerial,
-      options?: Partial<TDeserializationOptions>,
+      options?: DeepPartial<TDeserializationOptions>,
    ) => TWrapper;
 }

--- a/src/types/beatmap/wrapper/baseFile.ts
+++ b/src/types/beatmap/wrapper/baseFile.ts
@@ -1,5 +1,5 @@
 import type { LooseAutocomplete } from '../../utils.ts';
-import type { IWrapBaseItem } from './baseItem.ts';
+import type { IWrapBaseItem, IWrapBaseItemAttribute } from './baseItem.ts';
 
 /**
  * Wrapper attribute for beatmap base file.
@@ -25,6 +25,10 @@ export interface IWrapBaseFile<T extends string = ''> extends IWrapBaseFileAttri
    setFilename(filename: this['filename']): this;
    setVersion(version: this['version']): this;
 }
+
+export type IWrapBeatmapFileAttribute<T extends string = ''> =
+   & IWrapBaseFileAttribute<T>
+   & IWrapBaseItemAttribute;
 
 /**
  * Wrapper for beatmap base file.

--- a/src/types/beatmap/wrapper/beatmap.ts
+++ b/src/types/beatmap/wrapper/beatmap.ts
@@ -1,3 +1,4 @@
+// deno-lint-ignore-file no-explicit-any
 import type { DeepPartial, LooseAutocomplete } from '../../utils.ts';
 import type { ICustomDataBase } from '../shared/custom/customData.ts';
 import type { GenericBeatmapFilename, GenericLightshowFilename } from '../shared/filename.ts';
@@ -53,15 +54,24 @@ export interface IWrapBeatmapAttribute
 /** Wrapper attribute for subset of beatmap data. */
 export type IWrapBeatmapAttributeSubset<
    TKey extends keyof IWrapDifficultyAttribute | keyof IWrapLightshowAttribute,
+   TPick extends
+      | keyof IWrapDifficultyAttribute[Extract<keyof IWrapDifficultyAttribute, TKey>]
+      | keyof IWrapLightshowAttribute[Extract<keyof IWrapLightshowAttribute, TKey>] = any,
 > =
    & {
       [key in TKey extends keyof IWrapDifficultyAttribute ? 'difficulty' : never]: {
-         [K in Extract<keyof IWrapDifficultyAttribute, TKey>]: IWrapDifficultyAttribute[K];
+         [K in Extract<keyof IWrapDifficultyAttribute, TKey>]: Pick<
+            Extract<IWrapDifficultyAttribute[K], unknown[]>[number],
+            Extract<keyof Extract<IWrapDifficultyAttribute[K], unknown[]>[number], TPick>
+         >[];
       };
    }
    & {
       [key in TKey extends keyof IWrapLightshowAttribute ? 'lightshow' : never]: {
-         [K in Extract<keyof IWrapLightshowAttribute, TKey>]: IWrapLightshowAttribute[K];
+         [K in Extract<keyof IWrapLightshowAttribute, TKey>]: Pick<
+            Extract<IWrapLightshowAttribute[K], unknown[]>[number],
+            Extract<keyof Extract<IWrapLightshowAttribute[K], unknown[]>[number], TPick>
+         >[];
       };
    };
 

--- a/src/types/beatmap/wrapper/beatmap.ts
+++ b/src/types/beatmap/wrapper/beatmap.ts
@@ -1,13 +1,18 @@
-import type { IWrapBPMEvent, IWrapBPMEventAttribute } from './bpmEvent.ts';
-import type { IWrapRotationEvent, IWrapRotationEventAttribute } from './rotationEvent.ts';
-import type { IWrapColorNote, IWrapColorNoteAttribute } from './colorNote.ts';
-import type { IWrapBombNote, IWrapBombNoteAttribute } from './bombNote.ts';
-import type { IWrapObstacle, IWrapObstacleAttribute } from './obstacle.ts';
+import type { DeepPartial, LooseAutocomplete } from '../../utils.ts';
+import type { ICustomDataBase } from '../shared/custom/customData.ts';
+import type { GenericBeatmapFilename, GenericLightshowFilename } from '../shared/filename.ts';
 import type { IWrapArc, IWrapArcAttribute } from './arc.ts';
-import type { IWrapChain, IWrapChainAttribute } from './chain.ts';
-import type { IWrapWaypoint, IWrapWaypointAttribute } from './waypoint.ts';
+import type { IWrapBaseFileAttribute, IWrapBeatmapFile } from './baseFile.ts';
+import type { IWrapBaseItemAttribute } from './baseItem.ts';
 import type { IWrapBasicEvent, IWrapBasicEventAttribute } from './basicEvent.ts';
+import type { IWrapBasicEventTypesWithKeywords } from './basicEventTypesWithKeywords.ts';
+import type { IWrapBombNote, IWrapBombNoteAttribute } from './bombNote.ts';
+import type { IWrapBPMEvent, IWrapBPMEventAttribute } from './bpmEvent.ts';
+import type { IWrapChain, IWrapChainAttribute } from './chain.ts';
 import type { IWrapColorBoostEvent, IWrapColorBoostEventAttribute } from './colorBoostEvent.ts';
+import type { IWrapColorNote, IWrapColorNoteAttribute } from './colorNote.ts';
+import type { IWrapDifficulty, IWrapDifficultyAttribute } from './difficulty.ts';
+import type { IWrapFxEventBoxGroup, IWrapFxEventBoxGroupAttribute } from './fxEventBoxGroup.ts';
 import type {
    IWrapLightColorEventBoxGroup,
    IWrapLightColorEventBoxGroupAttribute,
@@ -16,20 +21,15 @@ import type {
    IWrapLightRotationEventBoxGroup,
    IWrapLightRotationEventBoxGroupAttribute,
 } from './lightRotationEventBoxGroup.ts';
+import type { IWrapLightshow, IWrapLightshowAttribute } from './lightshow.ts';
 import type {
    IWrapLightTranslationEventBoxGroup,
    IWrapLightTranslationEventBoxGroupAttribute,
 } from './lightTranslationEventBoxGroup.ts';
-import type { IWrapBasicEventTypesWithKeywords } from './basicEventTypesWithKeywords.ts';
-import type { DeepPartial, LooseAutocomplete } from '../../utils.ts';
-import type { IWrapFxEventBoxGroup, IWrapFxEventBoxGroupAttribute } from './fxEventBoxGroup.ts';
-import type { IWrapDifficulty, IWrapDifficultyAttribute } from './difficulty.ts';
-import type { IWrapLightshow, IWrapLightshowAttribute } from './lightshow.ts';
-import type { IWrapBaseFileAttribute, IWrapBeatmapFile } from './baseFile.ts';
-import type { GenericBeatmapFilename, GenericLightshowFilename } from '../shared/filename.ts';
-import type { IWrapBaseItemAttribute } from './baseItem.ts';
-import type { ICustomDataBase } from '../shared/custom/customData.ts';
 import type { IWrapNJSEvent } from './njsEvent.ts';
+import type { IWrapObstacle, IWrapObstacleAttribute } from './obstacle.ts';
+import type { IWrapRotationEvent, IWrapRotationEventAttribute } from './rotationEvent.ts';
+import type { IWrapWaypoint, IWrapWaypointAttribute } from './waypoint.ts';
 
 /**
  * Wrapper attribute for beatmap data.
@@ -49,6 +49,21 @@ export interface IWrapBeatmapAttribute
     */
    customData: ICustomDataBase;
 }
+
+/** Wrapper attribute for subset of beatmap data. */
+export type IWrapBeatmapAttributeSubset<
+   TKey extends keyof IWrapDifficultyAttribute | keyof IWrapLightshowAttribute,
+> =
+   & {
+      [key in TKey extends keyof IWrapDifficultyAttribute ? 'difficulty' : never]: {
+         [K in Extract<keyof IWrapDifficultyAttribute, TKey>]: IWrapDifficultyAttribute[K];
+      };
+   }
+   & {
+      [key in TKey extends keyof IWrapLightshowAttribute ? 'lightshow' : never]: {
+         [K in Extract<keyof IWrapLightshowAttribute, TKey>]: IWrapLightshowAttribute[K];
+      };
+   };
 
 /**
  * Wrapper for beatmap data.

--- a/src/types/bsmap/fromInfo.ts
+++ b/src/types/bsmap/fromInfo.ts
@@ -1,7 +1,9 @@
-import type { IWrapBeatmap } from '../beatmap/wrapper/beatmap.ts';
-import type { IWrapInfoBeatmapAttribute } from '../beatmap/wrapper/info.ts';
+// deno-lint-ignore-file no-explicit-any
+import type { InferBeatmapAttribute } from '../beatmap/shared/infer.ts';
 
-export interface IBeatmapInfoData {
-   info: IWrapInfoBeatmapAttribute;
-   beatmap: IWrapBeatmap;
+export interface IBeatmapInfoData<
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'difficulty'>,
+> {
+   info: Pick<InferBeatmapAttribute<'info'>, 'difficulties'>['difficulties'][number];
+   beatmap: TWrapper;
 }

--- a/src/types/bsmap/reader.ts
+++ b/src/types/bsmap/reader.ts
@@ -1,8 +1,14 @@
 // deno-lint-ignore-file no-explicit-any
 import type { ILoadOptions } from '../beatmap/options/loader.ts';
+import type { InferBeatmapVersion } from '../beatmap/shared/infer.ts';
+import type { BeatmapFileType } from '../mod.ts';
 import type { IBaseOptions } from './_common.ts';
 
-export interface IReadOptions<T extends Record<string, any> = Record<string, any>>
-   extends IBaseOptions {
-   load?: ILoadOptions<T>;
+export interface IReadOptions<
+   TFileType extends BeatmapFileType,
+   TVersion extends InferBeatmapVersion<TFileType>,
+   TWrapper extends Record<string, any> = Record<string, any>,
+   TSerial extends Record<string, any> = Record<string, any>,
+> extends IBaseOptions {
+   load?: ILoadOptions<TFileType, TVersion, TWrapper, TSerial>;
 }

--- a/src/types/bsmap/writer.ts
+++ b/src/types/bsmap/writer.ts
@@ -1,9 +1,15 @@
 // deno-lint-ignore-file no-explicit-any
 import type { ISaveOptions } from '../beatmap/options/saver.ts';
+import type { InferBeatmapVersion } from '../beatmap/shared/infer.ts';
+import type { BeatmapFileType } from '../mod.ts';
 import type { IBaseOptions } from './_common.ts';
 
-export interface IWriteOptions<T extends Record<string, any> = Record<string, any>>
-   extends IBaseOptions {
+export interface IWriteOptions<
+   TFileType extends BeatmapFileType,
+   TVersion extends InferBeatmapVersion<TFileType>,
+   TWrapper extends Record<string, any> = Record<string, any>,
+   TSerial extends Record<string, any> = Record<string, any>,
+> extends IBaseOptions {
    filename?: string;
    /**
     * Prettify format JSON.
@@ -11,5 +17,5 @@ export interface IWriteOptions<T extends Record<string, any> = Record<string, an
     * @default 0
     */
    format?: number;
-   save?: ISaveOptions<T>;
+   save?: ISaveOptions<TFileType, TVersion, TWrapper, TSerial>;
 }

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -26,9 +26,11 @@ export type DeepWritable<T> = {
 /**
  * Make all nested properties in T optional.
  */
-export type DeepPartial<T> = {
-   [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
-};
+export type DeepPartial<T> = T extends Function ? T
+   : T extends Array<infer Member> ? Array<DeepPartial<Member>>
+   : T extends (infer X extends string | number) & {} ? X
+   : T extends object ? { [Key in NonNullable<keyof T>]?: DeepPartial<T[Key]> }
+   : T;
 
 /**
  * Make all properties in T optional except those in Ignore.

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -1,5 +1,4 @@
-import type { Writable } from '../types/utils.ts';
-import type { DeepWritable } from '../types/utils.ts';
+import type { DeepWritable, Writable } from '../types/utils.ts';
 
 /**
  * Shuffle array in-place.
@@ -96,4 +95,12 @@ export function hexToDec(hex: string): number {
 export function decToHex(val: number): string {
    const hex = val.toString(16);
    return hex;
+}
+
+/** Move to the next item in an iterable object programatically. */
+export function cycle<T extends string | number | symbol>(iter: Iterable<T>, current: T, step = 1) {
+   const arr = Object.values(iter);
+   const index = arr.indexOf(current);
+   if (!(current in arr)) return current;
+   return arr[(index + arr.length + step) % arr.length];
 }

--- a/src/utils/vector.ts
+++ b/src/utils/vector.ts
@@ -1,3 +1,4 @@
+import { EPSILON } from '../../tests/constants.ts';
 import type {
    Vector2,
    Vector2Object,
@@ -6,7 +7,7 @@ import type {
    Vector4,
    Vector4Object,
 } from '../types/vector.ts';
-import { lerp } from './math.ts';
+import { lerp, nearEqual } from './math.ts';
 
 type VectorObject = Partial<Vector2Object> | Partial<Vector3Object> | Partial<Vector4Object>;
 
@@ -25,159 +26,106 @@ export function isVector4(obj: unknown): obj is Vector4 {
    return Array.isArray(obj) && obj.length === 4 && obj.every((n) => typeof n === 'number');
 }
 
-export function vectorAdd<T extends Vector2 | Vector3 | Vector4 | number[] | undefined>(
+type VectorArgument = Vector2 | Vector3 | Vector4 | number[];
+function vectorImpl<TArgs extends any[]>(
+   operation: (v: number, value: number, ...args: TArgs) => number,
+) {
+   return function <
+      T extends VectorArgument,
+      TValue extends number | VectorArgument | VectorObject,
+   >(
+      vec?: T,
+      value?: TValue,
+      ...args: TArgs
+   ) {
+      if (!vec) return vec;
+      if (typeof value === 'number') return vec.map((v) => operation(v, value, ...args)) as T;
+      vec = [...vec];
+      if (value) {
+         if (Array.isArray(value)) {
+            for (let i = 0; i < vec.length; i++) {
+               if (typeof value[i] === 'number') {
+                  vec[i] = operation(vec[i], value[i], ...args);
+               }
+            }
+         } else {
+            switch (vec.length) {
+               case 4: {
+                  vec[3] = operation(vec[3], (value as Vector4Object).w ?? 1, ...args);
+               }
+               /* falls through */
+               case 3: {
+                  vec[2] = operation(vec[2], (value as Vector4Object).z ?? 1, ...args);
+               }
+               /* falls through */
+               case 2: {
+                  vec[1] = operation(vec[1], (value as Vector4Object).y ?? 1, ...args);
+                  vec[0] = operation(vec[0], (value as Vector4Object).x ?? 1, ...args);
+               }
+            }
+         }
+      }
+      return vec;
+   };
+}
+
+export function vectorAdd<T extends VectorArgument | undefined>(
    vec: T,
    value?: number | number[],
 ): T;
 export function vectorAdd(vec?: Vector2, value?: VectorObject): Vector2;
 export function vectorAdd(vec?: Vector3, value?: VectorObject): Vector3;
 export function vectorAdd(vec?: Vector4, value?: VectorObject): Vector4;
-export function vectorAdd<T extends Vector2 | Vector3 | Vector4 | number[]>(
+export function vectorAdd<T extends VectorArgument>(
    vec?: T,
    value?: number | T | VectorObject,
 ): T | undefined {
-   if (!vec) return vec;
-   if (typeof value === 'number') return vec.map((v) => v + value) as T;
-   vec = [...vec];
-   if (value) {
-      if (Array.isArray(value)) {
-         for (let i = 0; i < vec.length; i++) {
-            if (typeof value[i] === 'number') {
-               vec[i] += value[i];
-            }
-         }
-      } else {
-         switch (vec.length) {
-            case 4:
-               vec[3] = vec[3] + ((value as Vector4Object).w ?? 0);
-            /* falls through */
-            case 3:
-               vec[2] = vec[2] + ((value as Vector3Object).z ?? 0);
-            /* falls through */
-            case 2:
-               vec[1] = vec[1] + (value.y ?? 0);
-               vec[0] = vec[0] + (value.x ?? 0);
-         }
-      }
-   }
-   return vec;
+   return vectorImpl((x, n) => x + n)(vec, value);
 }
 
-export function vectorSub<T extends Vector2 | Vector3 | Vector4 | number[] | undefined>(
+export function vectorSub<T extends VectorArgument | undefined>(
    vec: T,
    value?: number | number[],
 ): T;
 export function vectorSub(vec?: Vector2, value?: VectorObject): Vector2;
 export function vectorSub(vec?: Vector3, value?: VectorObject): Vector3;
 export function vectorSub(vec?: Vector4, value?: VectorObject): Vector4;
-export function vectorSub<T extends Vector2 | Vector3 | Vector4 | number[]>(
+export function vectorSub<T extends VectorArgument>(
    vec?: T,
    value?: number | T | VectorObject,
 ): T | undefined {
-   if (!vec) return vec;
-   if (typeof value === 'number') return vec.map((v) => v - value) as T;
-   vec = [...vec];
-   if (value) {
-      if (Array.isArray(value)) {
-         for (let i = 0; i < vec.length; i++) {
-            if (typeof value[i] === 'number') {
-               vec[i] -= value[i];
-            }
-         }
-      } else {
-         switch (vec.length) {
-            case 4:
-               vec[3] = vec[3] - ((value as Vector4Object).w ?? 0);
-            /* falls through */
-            case 3:
-               vec[2] = vec[2] - ((value as Vector3Object).z ?? 0);
-            /* falls through */
-            case 2:
-               vec[1] = vec[1] - (value.y ?? 0);
-               vec[0] = vec[0] - (value.x ?? 0);
-         }
-      }
-   }
-   return vec;
+   return vectorImpl((x, n) => x - n)(vec, value);
 }
 
-export function vectorMul<T extends Vector2 | Vector3 | Vector4 | number[] | undefined>(
+export function vectorMul<T extends VectorArgument | undefined>(
    vec: T,
    value?: number | number[],
 ): T;
 export function vectorMul(vec?: Vector2, value?: VectorObject): Vector2;
 export function vectorMul(vec?: Vector3, value?: VectorObject): Vector3;
 export function vectorMul(vec?: Vector4, value?: VectorObject): Vector4;
-export function vectorMul<T extends Vector2 | Vector3 | Vector4 | number[]>(
+export function vectorMul<T extends VectorArgument>(
    vec?: T,
    value?: number | T | VectorObject,
 ): T | undefined {
-   if (!vec) return vec;
-   if (typeof value === 'number') return vec.map((v) => v * value) as T;
-   vec = [...vec];
-   if (value) {
-      if (Array.isArray(value)) {
-         for (let i = 0; i < vec.length; i++) {
-            if (typeof value[i] === 'number') {
-               vec[i] *= value[i];
-            }
-         }
-      } else {
-         switch (vec.length) {
-            case 4:
-               vec[3] = vec[3] * ((value as Vector4Object).w ?? 1);
-            /* falls through */
-            case 3:
-               vec[2] = vec[2] * ((value as Vector3Object).z ?? 1);
-            /* falls through */
-            case 2:
-               vec[1] = vec[1] * (value.y ?? 1);
-               vec[0] = vec[0] * (value.x ?? 1);
-         }
-      }
-   }
-   return vec;
+   return vectorImpl((x, n) => x * n)(vec, value);
 }
 
-export function vectorDiv<T extends Vector2 | Vector3 | Vector4 | number[] | undefined>(
+export function vectorDiv<T extends VectorArgument | undefined>(
    vec: T,
    value?: number | number[],
 ): T;
 export function vectorDiv(vec?: Vector2, value?: VectorObject): Vector2;
 export function vectorDiv(vec?: Vector3, value?: VectorObject): Vector3;
 export function vectorDiv(vec?: Vector4, value?: VectorObject): Vector4;
-export function vectorDiv<T extends Vector2 | Vector3 | Vector4 | number[]>(
+export function vectorDiv<T extends VectorArgument>(
    vec?: T,
    value?: number | T | VectorObject,
 ): T | undefined {
-   if (!vec) return vec;
-   if (typeof value === 'number') return vec.map((v) => v / value) as T;
-   vec = [...vec];
-   if (value) {
-      if (Array.isArray(value)) {
-         for (let i = 0; i < vec.length; i++) {
-            if (typeof value[i] === 'number') {
-               vec[i] /= value[i];
-            }
-         }
-      } else {
-         switch (vec.length) {
-            case 4:
-               vec[3] = vec[3] / ((value as Vector4Object).w ?? 1);
-            /* falls through */
-            case 3:
-               vec[2] = vec[2] / ((value as Vector3Object).z ?? 1);
-            /* falls through */
-            case 2:
-               vec[1] = vec[1] / (value.y ?? 1);
-               vec[0] = vec[0] / (value.x ?? 1);
-         }
-      }
-   }
-   return vec;
+   return vectorImpl((x, n) => x / n)(vec, value);
 }
 
-export function lerpVector<T extends Vector2 | Vector3 | Vector4 | number[] | undefined>(
+export function lerpVector<T extends VectorArgument | undefined>(
    alpha: number,
    vec: T,
    value?: number[],
@@ -197,33 +145,55 @@ export function lerpVector(
    vec?: Vector4,
    value?: VectorObject,
 ): Vector4;
-export function lerpVector<T extends Vector2 | Vector3 | Vector4 | number[]>(
+export function lerpVector<T extends VectorArgument>(
    alpha: number,
    vec?: T,
    value?: T | VectorObject,
 ): T | undefined {
-   if (!vec) return vec;
-   vec = [...vec];
-   if (value) {
-      if (Array.isArray(value)) {
-         for (let i = 0; i < vec.length; i++) {
-            if (typeof value[i] === 'number') {
-               vec[i] = lerp(alpha, vec[i], value[i]);
-            }
-         }
-      } else {
-         switch (vec.length) {
-            case 4:
-               vec[3] = lerp(alpha, vec[3], (value as Vector4Object).w ?? vec[3]);
-            /* falls through */
-            case 3:
-               vec[2] = lerp(alpha, vec[2], (value as Vector3Object).z ?? vec[2]);
-            /* falls through */
-            case 2:
-               vec[1] = lerp(alpha, vec[1], value.y ?? vec[1]);
-               vec[0] = lerp(alpha, vec[0], value.x ?? vec[0]);
-         }
-      }
+   return vectorImpl<[number]>((x, n, alpha) => lerp(alpha, x, n))(vec, value, alpha);
+}
+
+export function vectorDistance<T extends VectorArgument>(v1: T, v2: T) {
+   const diff = vectorSub(v1, v2);
+   let acc = 0;
+   for (let i = 0; i < diff.length; i++) {
+      const x = diff[i] ** 2;
+      acc += x;
    }
-   return vec;
+   return Math.sqrt(acc);
+}
+
+export function vectorIsVertical<T extends VectorArgument>(v1: T, v2: T, epsilon = EPSILON) {
+   const [dX] = vectorSub(v1, v2);
+   return Math.abs(dX) <= epsilon;
+}
+export function vectorIsHorizontal<T extends VectorArgument>(v1: T, v2: T, epsilon = EPSILON) {
+   const [, dY] = vectorSub(v1, v2);
+   return Math.abs(dY) <= epsilon;
+}
+export function vectorIsDiagonal<T extends VectorArgument>(v1: T, v2: T, epsilon = EPSILON) {
+   const [dX, dY] = vectorSub(v1, v2);
+   return nearEqual(Math.abs(dX), Math.abs(dY), epsilon);
+}
+
+export function vectorIsInline<T extends VectorArgument>(v1: T, v2: T, lapping = 0.5) {
+   const distance = vectorDistance(v1, v2);
+   return distance <= lapping;
+}
+export function vectorIsAdjacent<T extends VectorArgument>(v1: T, v2: T, epsilon = EPSILON) {
+   const distance = vectorDistance(v1, v2);
+   return distance > (0.5 - epsilon) && distance < (1 + epsilon);
+}
+export function vectorIsWindow<T extends VectorArgument>(v1: T, v2: T, gap = 1.8) {
+   const distance = vectorDistance(v1, v2);
+   return distance > gap;
+}
+
+export function vectorIsSlantedWindow<T extends VectorArgument>(v1: T, v2: T, gap = 1.8) {
+   return (
+      vectorIsWindow(v1, v2, 1.8) &&
+      !vectorIsDiagonal(v1, v2, 0.001) &&
+      !vectorIsHorizontal(v1, v2, 0.001) &&
+      !vectorIsVertical(v1, v2, 0.001)
+   );
 }

--- a/src/utils/vector.ts
+++ b/src/utils/vector.ts
@@ -1,4 +1,4 @@
-import { EPSILON } from '../../tests/constants.ts';
+// deno-lint-ignore-file no-explicit-any
 import type {
    Vector2,
    Vector2Object,
@@ -163,15 +163,19 @@ export function vectorDistance<T extends VectorArgument>(v1: T, v2: T) {
    return Math.sqrt(acc);
 }
 
-export function vectorIsVertical<T extends VectorArgument>(v1: T, v2: T, epsilon = EPSILON) {
+export function vectorIsVertical<T extends VectorArgument>(v1: T, v2: T, epsilon = 0.001) {
    const [dX] = vectorSub(v1, v2);
    return Math.abs(dX) <= epsilon;
 }
-export function vectorIsHorizontal<T extends VectorArgument>(v1: T, v2: T, epsilon = EPSILON) {
+export function vectorIsHorizontal<T extends VectorArgument>(
+   v1: T,
+   v2: T,
+   epsilon = 0.001,
+) {
    const [, dY] = vectorSub(v1, v2);
    return Math.abs(dY) <= epsilon;
 }
-export function vectorIsDiagonal<T extends VectorArgument>(v1: T, v2: T, epsilon = EPSILON) {
+export function vectorIsDiagonal<T extends VectorArgument>(v1: T, v2: T, epsilon = 0.001) {
    const [dX, dY] = vectorSub(v1, v2);
    return nearEqual(Math.abs(dX), Math.abs(dY), epsilon);
 }
@@ -180,7 +184,7 @@ export function vectorIsInline<T extends VectorArgument>(v1: T, v2: T, lapping =
    const distance = vectorDistance(v1, v2);
    return distance <= lapping;
 }
-export function vectorIsAdjacent<T extends VectorArgument>(v1: T, v2: T, epsilon = EPSILON) {
+export function vectorIsAdjacent<T extends VectorArgument>(v1: T, v2: T, epsilon = 0.001) {
    const distance = vectorDistance(v1, v2);
    return distance > (0.5 - epsilon) && distance < (1 + epsilon);
 }
@@ -189,7 +193,7 @@ export function vectorIsWindow<T extends VectorArgument>(v1: T, v2: T, gap = 1.8
    return distance > gap;
 }
 
-export function vectorIsSlantedWindow<T extends VectorArgument>(v1: T, v2: T, gap = 1.8) {
+export function vectorIsSlantedWindow<T extends VectorArgument>(v1: T, v2: T) {
    return (
       vectorIsWindow(v1, v2, 1.8) &&
       !vectorIsDiagonal(v1, v2, 0.001) &&

--- a/src/utils/vector.ts
+++ b/src/utils/vector.ts
@@ -51,16 +51,16 @@ function vectorImpl<TArgs extends any[]>(
          } else {
             switch (vec.length) {
                case 4: {
-                  vec[3] = operation(vec[3], (value as Vector4Object).w ?? 1, ...args);
+                  vec[3] = operation(vec[3], (value as Vector4Object).w ?? 0, ...args);
                }
                /* falls through */
                case 3: {
-                  vec[2] = operation(vec[2], (value as Vector4Object).z ?? 1, ...args);
+                  vec[2] = operation(vec[2], (value as Vector4Object).z ?? 0, ...args);
                }
                /* falls through */
                case 2: {
-                  vec[1] = operation(vec[1], (value as Vector4Object).y ?? 1, ...args);
-                  vec[0] = operation(vec[0], (value as Vector4Object).x ?? 1, ...args);
+                  vec[1] = operation(vec[1], (value as Vector4Object).y ?? 0, ...args);
+                  vec[0] = operation(vec[0], (value as Vector4Object).x ?? 0, ...args);
                }
             }
          }
@@ -108,7 +108,7 @@ export function vectorMul<T extends VectorArgument>(
    vec?: T,
    value?: number | T | VectorObject,
 ): T | undefined {
-   return vectorImpl((x, n) => x * n)(vec, value);
+   return vectorImpl((x, n) => n ? x * n : x)(vec, value);
 }
 
 export function vectorDiv<T extends VectorArgument | undefined>(
@@ -122,7 +122,7 @@ export function vectorDiv<T extends VectorArgument>(
    vec?: T,
    value?: number | T | VectorObject,
 ): T | undefined {
-   return vectorImpl((x, n) => x / n)(vec, value);
+   return vectorImpl((x, n) => n ? x / n : x)(vec, value);
 }
 
 export function lerpVector<T extends VectorArgument | undefined>(

--- a/src/write/_main.ts
+++ b/src/write/_main.ts
@@ -1,18 +1,22 @@
 // deno-lint-ignore-file no-explicit-any
 import { saveBeatmap } from '../beatmap/saver/_main.ts';
-import { path } from '../shims/path.ts';
-import { writeJSONFile, writeJSONFileSync } from '../shims/_json.ts';
 import { globals } from '../globals.ts';
+import { writeJSONFile, writeJSONFileSync } from '../shims/_json.ts';
+import { path } from '../shims/path.ts';
+import type {
+   InferBeatmapAttribute,
+   InferBeatmapSerial,
+   InferBeatmapVersion,
+} from '../types/beatmap/shared/infer.ts';
 import type { BeatmapFileType } from '../types/beatmap/shared/schema.ts';
-import type { IWrapBeatmapFile } from '../types/beatmap/wrapper/baseFile.ts';
 import type { IWriteOptions } from '../types/bsmap/writer.ts';
 
-const defaultOptions: Required<IWriteOptions> = {
+const defaultOptions = {
    directory: '',
    filename: '',
    format: 0,
    save: {},
-};
+} as const;
 
 export function tag(name: string): string[] {
    return ['writer', name];
@@ -27,12 +31,20 @@ function getFileName(type: BeatmapFileType, data: Record<string, any>): string {
    }
 }
 
-export function handleWrite<T extends Record<string, any>>(
-   type: BeatmapFileType,
-   data: IWrapBeatmapFile,
-   version?: number | null | IWriteOptions<T>,
-   options: IWriteOptions<T> = {},
-): Promise<Record<string, any>> {
+export function handleWrite<
+   TFileType extends BeatmapFileType,
+   TVersion extends InferBeatmapVersion<TFileType>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<TFileType>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<
+      TFileType,
+      TVersion
+   >,
+>(
+   type: TFileType,
+   data: TWrapper,
+   version?: TVersion | null | IWriteOptions<TFileType, TVersion, TWrapper, TSerial>,
+   options: IWriteOptions<TFileType, TVersion, TWrapper, TSerial> = {},
+): Promise<TSerial> {
    const ver = typeof version === 'number' ? version : null;
    const opt = (typeof version !== 'number' ? version : options) ?? {};
    const json = saveBeatmap(type, data, ver, opt.save);
@@ -46,12 +58,20 @@ export function handleWrite<T extends Record<string, any>>(
    ).then(() => json);
 }
 
-export function handleWriteSync<T extends Record<string, any>>(
-   type: BeatmapFileType,
-   data: IWrapBeatmapFile,
-   version?: number | null | IWriteOptions<T>,
-   options: IWriteOptions<T> = {},
-): Record<string, any> {
+export function handleWriteSync<
+   TFileType extends BeatmapFileType,
+   TVersion extends InferBeatmapVersion<TFileType>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<TFileType>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<
+      TFileType,
+      TVersion
+   >,
+>(
+   type: TFileType,
+   data: TWrapper,
+   version?: TVersion | null | IWriteOptions<TFileType, TVersion, TWrapper, TSerial>,
+   options: IWriteOptions<TFileType, TVersion, TWrapper, TSerial> = {},
+): TSerial {
    const ver = typeof version === 'number' ? version : null;
    const opt = (typeof version !== 'number' ? version : options) ?? {};
    const json = saveBeatmap(type, data, ver, opt.save);

--- a/src/write/audioData.ts
+++ b/src/write/audioData.ts
@@ -1,6 +1,10 @@
 // deno-lint-ignore-file no-explicit-any
 import { logger } from '../logger.ts';
-import type { IWrapAudioData } from '../types/beatmap/wrapper/audioData.ts';
+import type {
+   InferBeatmapAttribute,
+   InferBeatmapSerial,
+   InferBeatmapVersion,
+} from '../types/beatmap/shared/infer.ts';
 import type { IWriteOptions } from '../types/bsmap/writer.ts';
 import { handleWrite, handleWriteSync, tag } from './_main.ts';
 
@@ -10,22 +14,39 @@ import { handleWrite, handleWriteSync, tag } from './_main.ts';
  * await writeAudioDataFile(audio, 4);
  * ```
  */
-export function writeAudioDataFile(
-   data: IWrapAudioData,
-   version?: number | null,
-   options?: IWriteOptions<IWrapAudioData>,
-): Promise<Record<string, any>>;
-export function writeAudioDataFile(
-   data: IWrapAudioData,
-   options?: IWriteOptions<IWrapAudioData>,
-): Promise<Record<string, any>>;
-export function writeAudioDataFile(
-   data: IWrapAudioData,
-   version?: number | null | IWriteOptions<IWrapAudioData>,
-   options?: IWriteOptions<IWrapAudioData>,
-): Promise<Record<string, any>> {
+export function writeAudioDataFile<
+   TVersion extends InferBeatmapVersion<'audioData'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'audioData'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'audioData', TVersion>,
+>(
+   data: TWrapper,
+   version?: TVersion | null,
+   options?: IWriteOptions<'audioData', TVersion, TWrapper, TSerial>,
+): Promise<TSerial>;
+export function writeAudioDataFile<
+   TVersion extends InferBeatmapVersion<'audioData'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'audioData'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'audioData', TVersion>,
+>(
+   data: TWrapper,
+   options?: IWriteOptions<'audioData', TVersion, TWrapper, TSerial>,
+): Promise<TSerial>;
+export function writeAudioDataFile<
+   TVersion extends InferBeatmapVersion<'audioData'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'audioData'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'audioData', TVersion>,
+>(
+   data: TWrapper,
+   version?: TVersion | null | IWriteOptions<'audioData', TVersion, TWrapper, TSerial>,
+   options?: IWriteOptions<'audioData', TVersion, TWrapper, TSerial>,
+): Promise<TSerial> {
    logger.tInfo(tag('writeAudioDataFile'), 'Async writing audio data file');
-   return handleWrite('audioData', data, version, options);
+   return handleWrite<'audioData', TVersion, TWrapper, TSerial>(
+      'audioData',
+      data,
+      version,
+      options,
+   );
 }
 
 /**
@@ -34,20 +55,37 @@ export function writeAudioDataFile(
  * writeAudioDataFileSync(audio, 4);
  * ```
  */
-export function writeAudioDataFileSync(
-   data: IWrapAudioData,
-   version?: number | null,
-   options?: IWriteOptions<IWrapAudioData>,
-): Record<string, any>;
-export function writeAudioDataFileSync(
-   data: IWrapAudioData,
-   options?: IWriteOptions<IWrapAudioData>,
-): Record<string, any>;
-export function writeAudioDataFileSync(
-   data: IWrapAudioData,
-   version?: number | null | IWriteOptions<IWrapAudioData>,
-   options?: IWriteOptions<IWrapAudioData>,
-): Record<string, any> {
+export function writeAudioDataFileSync<
+   TVersion extends InferBeatmapVersion<'audioData'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'audioData'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'audioData', TVersion>,
+>(
+   data: TWrapper,
+   version?: TVersion | null,
+   options?: IWriteOptions<'audioData', TVersion, TWrapper, TSerial>,
+): TSerial;
+export function writeAudioDataFileSync<
+   TVersion extends InferBeatmapVersion<'audioData'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'audioData'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'audioData', TVersion>,
+>(
+   data: TWrapper,
+   options?: IWriteOptions<'audioData', TVersion, TWrapper, TSerial>,
+): TSerial;
+export function writeAudioDataFileSync<
+   TVersion extends InferBeatmapVersion<'audioData'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'audioData'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'audioData', TVersion>,
+>(
+   data: TWrapper,
+   version?: TVersion | null | IWriteOptions<'audioData', TVersion, TWrapper, TSerial>,
+   options?: IWriteOptions<'audioData', TVersion, TWrapper, TSerial>,
+): TSerial {
    logger.tInfo(tag('writeAudioDataFileSync'), 'Sync writing audio data file');
-   return handleWriteSync('audioData', data, version, options);
+   return handleWriteSync<'audioData', TVersion, TWrapper, TSerial>(
+      'audioData',
+      data,
+      version,
+      options,
+   );
 }

--- a/src/write/difficulty.ts
+++ b/src/write/difficulty.ts
@@ -1,6 +1,10 @@
 // deno-lint-ignore-file no-explicit-any
 import { logger } from '../logger.ts';
-import type { IWrapBeatmap } from '../types/beatmap/wrapper/beatmap.ts';
+import type {
+   InferBeatmapAttribute,
+   InferBeatmapSerial,
+   InferBeatmapVersion,
+} from '../types/beatmap/shared/infer.ts';
 import type { IWriteOptions } from '../types/mod.ts';
 import { handleWrite, handleWriteSync, tag } from './_main.ts';
 
@@ -10,22 +14,39 @@ import { handleWrite, handleWriteSync, tag } from './_main.ts';
  * await writeDifficultyFile(beatmap, 4);
  * ```
  */
-export function writeDifficultyFile(
-   data: IWrapBeatmap,
-   version?: number | null,
-   options?: IWriteOptions<IWrapBeatmap>,
-): Promise<Record<string, any>>;
-export function writeDifficultyFile(
-   data: IWrapBeatmap,
-   options?: IWriteOptions<IWrapBeatmap>,
-): Promise<Record<string, any>>;
-export function writeDifficultyFile(
-   data: IWrapBeatmap,
-   version?: number | null | IWriteOptions<IWrapBeatmap>,
-   options?: IWriteOptions<IWrapBeatmap>,
-): Promise<Record<string, any>> {
+export function writeDifficultyFile<
+   TVersion extends InferBeatmapVersion<'difficulty'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'difficulty'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'difficulty', TVersion>,
+>(
+   data: TWrapper,
+   version?: TVersion | null,
+   options?: IWriteOptions<'difficulty', TVersion, TWrapper, TSerial>,
+): Promise<TSerial>;
+export function writeDifficultyFile<
+   TVersion extends InferBeatmapVersion<'difficulty'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'difficulty'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'difficulty', TVersion>,
+>(
+   data: TWrapper,
+   options?: IWriteOptions<'difficulty', TVersion, TWrapper, TSerial>,
+): Promise<TSerial>;
+export function writeDifficultyFile<
+   TVersion extends InferBeatmapVersion<'difficulty'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'difficulty'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'difficulty', TVersion>,
+>(
+   data: TWrapper,
+   version?: TVersion | null | IWriteOptions<'difficulty', TVersion, TWrapper, TSerial>,
+   options?: IWriteOptions<'difficulty', TVersion, TWrapper, TSerial>,
+): Promise<TSerial> {
    logger.tInfo(tag('writeDifficultyFile'), 'Async writing difficulty file');
-   return handleWrite('difficulty', data, version, options);
+   return handleWrite<'difficulty', TVersion, TWrapper, TSerial>(
+      'difficulty',
+      data,
+      version,
+      options,
+   );
 }
 
 /**
@@ -34,20 +55,37 @@ export function writeDifficultyFile(
  * writeDifficultyFileSync(beatmap, 4);
  * ```
  */
-export function writeDifficultyFileSync(
-   data: IWrapBeatmap,
-   version?: number | null,
-   options?: IWriteOptions<IWrapBeatmap>,
-): Record<string, any>;
-export function writeDifficultyFileSync(
-   data: IWrapBeatmap,
-   options?: IWriteOptions<IWrapBeatmap>,
-): Record<string, any>;
-export function writeDifficultyFileSync(
-   data: IWrapBeatmap,
-   version?: number | null | IWriteOptions<IWrapBeatmap>,
-   options?: IWriteOptions<IWrapBeatmap>,
-): Record<string, any> {
+export function writeDifficultyFileSync<
+   TVersion extends InferBeatmapVersion<'difficulty'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'difficulty'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'difficulty', TVersion>,
+>(
+   data: TWrapper,
+   version?: TVersion | null,
+   options?: IWriteOptions<'difficulty', TVersion, TWrapper, TSerial>,
+): TSerial;
+export function writeDifficultyFileSync<
+   TVersion extends InferBeatmapVersion<'difficulty'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'difficulty'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'difficulty', TVersion>,
+>(
+   data: TWrapper,
+   options?: IWriteOptions<'difficulty', TVersion, TWrapper, TSerial>,
+): TSerial;
+export function writeDifficultyFileSync<
+   TVersion extends InferBeatmapVersion<'difficulty'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'difficulty'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'difficulty', TVersion>,
+>(
+   data: TWrapper,
+   version?: TVersion | null | IWriteOptions<'difficulty', TVersion, TWrapper, TSerial>,
+   options?: IWriteOptions<'difficulty', TVersion, TWrapper, TSerial>,
+): TSerial {
    logger.tInfo(tag('writeDifficultyFileSync'), 'Sync writing difficulty file');
-   return handleWriteSync('difficulty', data, version, options);
+   return handleWriteSync<'difficulty', TVersion, TWrapper, TSerial>(
+      'difficulty',
+      data,
+      version,
+      options,
+   );
 }

--- a/src/write/info.ts
+++ b/src/write/info.ts
@@ -1,6 +1,10 @@
 // deno-lint-ignore-file no-explicit-any
 import { logger } from '../logger.ts';
-import type { IWrapInfo } from '../types/beatmap/wrapper/info.ts';
+import type {
+   InferBeatmapAttribute,
+   InferBeatmapSerial,
+   InferBeatmapVersion,
+} from '../types/beatmap/shared/infer.ts';
 import type { IWriteOptions } from '../types/mod.ts';
 import { handleWrite, handleWriteSync, tag } from './_main.ts';
 
@@ -10,22 +14,34 @@ import { handleWrite, handleWriteSync, tag } from './_main.ts';
  * await writeInfoFile(info, 4);
  * ```
  */
-export function writeInfoFile(
-   data: IWrapInfo,
-   version?: number | null,
-   options?: IWriteOptions<IWrapInfo>,
-): Promise<Record<string, any>>;
-export function writeInfoFile(
-   data: IWrapInfo,
-   options?: IWriteOptions<IWrapInfo>,
-): Promise<Record<string, any>>;
-export function writeInfoFile(
-   data: IWrapInfo,
-   version?: number | null | IWriteOptions<IWrapInfo>,
-   options?: IWriteOptions<IWrapInfo>,
-): Promise<Record<string, any>> {
+export function writeInfoFile<
+   TVersion extends InferBeatmapVersion<'info'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'info'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'info', TVersion>,
+>(
+   data: TWrapper,
+   version?: TVersion | null,
+   options?: IWriteOptions<'info', TVersion, TWrapper, TSerial>,
+): Promise<TSerial>;
+export function writeInfoFile<
+   TVersion extends InferBeatmapVersion<'info'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'info'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'info', TVersion>,
+>(
+   data: TWrapper,
+   options?: IWriteOptions<'info', TVersion, TWrapper, TSerial>,
+): Promise<TSerial>;
+export function writeInfoFile<
+   TVersion extends InferBeatmapVersion<'info'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'info'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'info', TVersion>,
+>(
+   data: TWrapper,
+   version?: TVersion | null | IWriteOptions<'info', TVersion, TWrapper, TSerial>,
+   options?: IWriteOptions<'info', TVersion, TWrapper, TSerial>,
+): Promise<TSerial> {
    logger.tInfo(tag('writeInfoFile'), 'Async writing info file');
-   return handleWrite('info', data, version, options);
+   return handleWrite<'info', TVersion, TWrapper, TSerial>('info', data, version, options);
 }
 
 /**
@@ -34,20 +50,32 @@ export function writeInfoFile(
  * writeInfoFileSync(info, 4);
  * ```
  */
-export function writeInfoFileSync(
-   data: IWrapInfo,
-   version?: number | null,
-   options?: IWriteOptions<IWrapInfo>,
-): Record<string, any>;
-export function writeInfoFileSync(
-   data: IWrapInfo,
-   options?: IWriteOptions<IWrapInfo>,
-): Record<string, any>;
-export function writeInfoFileSync(
-   data: IWrapInfo,
-   version?: number | null | IWriteOptions<IWrapInfo>,
-   options?: IWriteOptions<IWrapInfo>,
-): Record<string, any> {
+export function writeInfoFileSync<
+   TVersion extends InferBeatmapVersion<'info'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'info'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'info', TVersion>,
+>(
+   data: TWrapper,
+   version?: TVersion | null,
+   options?: IWriteOptions<'info', TVersion, TWrapper, TSerial>,
+): TSerial;
+export function writeInfoFileSync<
+   TVersion extends InferBeatmapVersion<'info'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'info'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'info', TVersion>,
+>(
+   data: TWrapper,
+   options?: IWriteOptions<'info', TVersion, TWrapper, TSerial>,
+): TSerial;
+export function writeInfoFileSync<
+   TVersion extends InferBeatmapVersion<'info'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'info'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'info', TVersion>,
+>(
+   data: TWrapper,
+   version?: TVersion | null | IWriteOptions<'info', TVersion, TWrapper, TSerial>,
+   options?: IWriteOptions<'info', TVersion, TWrapper, TSerial>,
+): TSerial {
    logger.tInfo(tag('writeInfoFileSync'), 'Sync writing info file');
-   return handleWriteSync('info', data, version, options);
+   return handleWriteSync<'info', TVersion, TWrapper, TSerial>('info', data, version, options);
 }

--- a/src/write/lightshow.ts
+++ b/src/write/lightshow.ts
@@ -1,6 +1,10 @@
 // deno-lint-ignore-file no-explicit-any
 import { logger } from '../logger.ts';
-import type { IWrapBeatmap } from '../types/beatmap/wrapper/beatmap.ts';
+import type {
+   InferBeatmapAttribute,
+   InferBeatmapSerial,
+   InferBeatmapVersion,
+} from '../types/beatmap/shared/infer.ts';
 import type { IWriteOptions } from '../types/mod.ts';
 import { handleWrite, handleWriteSync, tag } from './_main.ts';
 
@@ -10,22 +14,39 @@ import { handleWrite, handleWriteSync, tag } from './_main.ts';
  * await writeLightshowFile(beatmap, 4);
  * ```
  */
-export function writeLightshowFile(
-   data: IWrapBeatmap,
-   version?: number | null,
-   options?: IWriteOptions<IWrapBeatmap>,
-): Promise<Record<string, any>>;
-export function writeLightshowFile(
-   data: IWrapBeatmap,
-   options?: IWriteOptions<IWrapBeatmap>,
-): Promise<Record<string, any>>;
-export function writeLightshowFile(
-   data: IWrapBeatmap,
-   version?: number | null | IWriteOptions<IWrapBeatmap>,
-   options?: IWriteOptions<IWrapBeatmap>,
-): Promise<Record<string, any>> {
+export function writeLightshowFile<
+   TVersion extends InferBeatmapVersion<'lightshow'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'lightshow'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'lightshow', TVersion>,
+>(
+   data: TWrapper,
+   version?: TVersion | null,
+   options?: IWriteOptions<'lightshow', TVersion, TWrapper, TSerial>,
+): Promise<TSerial>;
+export function writeLightshowFile<
+   TVersion extends InferBeatmapVersion<'lightshow'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'lightshow'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'lightshow', TVersion>,
+>(
+   data: TWrapper,
+   options?: IWriteOptions<'lightshow', TVersion, TWrapper, TSerial>,
+): Promise<TSerial>;
+export function writeLightshowFile<
+   TVersion extends InferBeatmapVersion<'lightshow'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'lightshow'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'lightshow', TVersion>,
+>(
+   data: TWrapper,
+   version?: TVersion | null | IWriteOptions<'lightshow', TVersion, TWrapper, TSerial>,
+   options?: IWriteOptions<'lightshow', TVersion, TWrapper, TSerial>,
+): Promise<TSerial> {
    logger.tInfo(tag('writeLightshowFile'), 'Async writing lightshow file');
-   return handleWrite('lightshow', data, version, options);
+   return handleWrite<'lightshow', TVersion, TWrapper, TSerial>(
+      'lightshow',
+      data,
+      version,
+      options,
+   );
 }
 
 /**
@@ -34,20 +55,37 @@ export function writeLightshowFile(
  * writeLightshowFileSync(beatmap, 4);
  * ```
  */
-export function writeLightshowFileSync(
-   data: IWrapBeatmap,
-   version?: number | null,
-   options?: IWriteOptions<IWrapBeatmap>,
-): Record<string, any>;
-export function writeLightshowFileSync(
-   data: IWrapBeatmap,
-   options?: IWriteOptions<IWrapBeatmap>,
-): Record<string, any>;
-export function writeLightshowFileSync(
-   data: IWrapBeatmap,
-   version?: number | null | IWriteOptions<IWrapBeatmap>,
-   options?: IWriteOptions<IWrapBeatmap>,
-): Record<string, any> {
+export function writeLightshowFileSync<
+   TVersion extends InferBeatmapVersion<'lightshow'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'lightshow'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'lightshow', TVersion>,
+>(
+   data: TWrapper,
+   version?: TVersion | null,
+   options?: IWriteOptions<'lightshow', TVersion, TWrapper, TSerial>,
+): TSerial;
+export function writeLightshowFileSync<
+   TVersion extends InferBeatmapVersion<'lightshow'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'lightshow'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'lightshow', TVersion>,
+>(
+   data: TWrapper,
+   options?: IWriteOptions<'lightshow', TVersion, TWrapper, TSerial>,
+): TSerial;
+export function writeLightshowFileSync<
+   TVersion extends InferBeatmapVersion<'lightshow'>,
+   TWrapper extends Record<string, any> = InferBeatmapAttribute<'lightshow'>,
+   TSerial extends Record<string, any> = InferBeatmapSerial<'lightshow', TVersion>,
+>(
+   data: TWrapper,
+   version?: TVersion | null | IWriteOptions<'lightshow', TVersion, TWrapper, TSerial>,
+   options?: IWriteOptions<'lightshow', TVersion, TWrapper, TSerial>,
+): TSerial {
    logger.tInfo(tag('writeLightshowFileSync'), 'Sync writing lightshow file');
-   return handleWriteSync('lightshow', data, version, options);
+   return handleWriteSync<'lightshow', TVersion, TWrapper, TSerial>(
+      'lightshow',
+      data,
+      version,
+      options,
+   );
 }

--- a/tests/beatmap/arc.test.ts
+++ b/tests/beatmap/arc.test.ts
@@ -1,5 +1,5 @@
-import { Arc, assertEquals, v2, v3, v4 } from '../deps.ts';
 import { assertObjectMatch } from '../assert.ts';
+import { Arc, assertEquals, v2, v3, v4 } from '../deps.ts';
 
 const schemaList = [
    [v4.arc, 'V4 Arc'],
@@ -96,7 +96,8 @@ for (const tup of schemaList) {
    const nameTag = tup[1];
    const schema = tup[0];
    Deno.test(`${nameTag} from JSON instantiation`, () => {
-      let obj = new BaseClass(schema.deserialize());
+      // deno-lint-ignore no-explicit-any
+      let obj = new BaseClass(schema.deserialize({} as any));
       assertObjectMatch(
          obj,
          defaultValue,
@@ -106,7 +107,7 @@ for (const tup of schemaList) {
       switch (schema) {
          case v4.arc:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v4.arc).deserialize({
                   object: {
                      ai: 0,
                      hb: 2.5,
@@ -125,7 +126,7 @@ for (const tup of schemaList) {
             break;
          case v3.arc:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v3.arc).deserialize({
                   b: 2.5,
                   c: 1,
                   x: 2,
@@ -144,7 +145,7 @@ for (const tup of schemaList) {
             break;
          case v2.arc:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v2.arc).deserialize({
                   _colorType: 1,
                   _headTime: 2.5,
                   _headLineIndex: 2,
@@ -187,7 +188,7 @@ for (const tup of schemaList) {
       switch (schema) {
          case v4.arc:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v4.arc).deserialize({
                   object: {
                      hb: 2.5,
                      tb: 3,
@@ -200,7 +201,7 @@ for (const tup of schemaList) {
             break;
          case v3.arc:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v3.arc).deserialize({
                   b: 2.5,
                   c: 1,
                   mu: 0.5,
@@ -211,7 +212,7 @@ for (const tup of schemaList) {
             break;
          case v2.arc:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v2.arc).deserialize({
                   _colorType: 1,
                   _headTime: 2.5,
                   _headControlPointLengthMultiplier: 0.5,

--- a/tests/beatmap/basicEvent.test.ts
+++ b/tests/beatmap/basicEvent.test.ts
@@ -1,5 +1,5 @@
-import { assertEquals, BasicEvent, v1, v2, v3, v4 } from '../deps.ts';
 import { assertObjectMatch } from '../assert.ts';
+import { assertEquals, BasicEvent, v1, v2, v3, v4 } from '../deps.ts';
 
 const schemaList = [
    [v4.basicEvent, 'V4 Basic Event'],
@@ -69,7 +69,8 @@ for (const tup of schemaList) {
    const nameTag = tup[1];
    const schema = tup[0];
    Deno.test(`${nameTag} from JSON instantiation`, () => {
-      let obj = new BaseClass(schema.deserialize());
+      // deno-lint-ignore no-explicit-any
+      let obj = new BaseClass(schema.deserialize({} as any));
       assertObjectMatch(
          obj,
          { ...defaultValue, floatValue: schema === v1.basicEvent ? 1 : 0 },
@@ -79,11 +80,8 @@ for (const tup of schemaList) {
       switch (schema) {
          case v4.basicEvent:
             obj = new BaseClass(
-               schema.deserialize({
-                  object: {
-                     b: 1,
-                     i: 0,
-                  },
+               (schema as typeof v4.basicEvent).deserialize({
+                  object: { b: 1, i: 0 },
                   data: {
                      t: 4,
                      i: 2,
@@ -95,7 +93,7 @@ for (const tup of schemaList) {
             break;
          case v3.basicEvent:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v3.basicEvent).deserialize({
                   b: 1,
                   et: 4,
                   i: 2,
@@ -106,7 +104,7 @@ for (const tup of schemaList) {
             break;
          case v2.basicEvent:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v2.basicEvent).deserialize({
                   _time: 1,
                   _type: 4,
                   _value: 2,
@@ -117,7 +115,11 @@ for (const tup of schemaList) {
             break;
          case v1.basicEvent:
             obj = new BaseClass(
-               schema.deserialize({ _time: 1, _type: 4, _value: 2 }),
+               (schema as typeof v1.basicEvent).deserialize({
+                  _time: 1,
+                  _type: 4,
+                  _value: 2,
+               }),
             );
             break;
       }
@@ -136,7 +138,7 @@ for (const tup of schemaList) {
       switch (schema) {
          case v4.basicEvent:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v4.basicEvent).deserialize({
                   object: {
                      b: 1,
                   },
@@ -148,7 +150,7 @@ for (const tup of schemaList) {
             break;
          case v3.basicEvent:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v3.basicEvent).deserialize({
                   b: 1,
                   et: 4,
                }),
@@ -156,14 +158,20 @@ for (const tup of schemaList) {
             break;
          case v2.basicEvent:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v2.basicEvent).deserialize({
                   _time: 1,
                   _type: 4,
                }),
             );
             break;
          case v1.basicEvent:
-            obj = new BaseClass(schema.deserialize({ _time: 1, _type: 4 }));
+            obj = new BaseClass(
+               // @ts-expect-error awaiting updated type definitions from outgoing pull request
+               (schema as typeof v1.basicEvent).deserialize({
+                  _time: 1,
+                  _type: 4,
+               }),
+            );
             break;
       }
       assertObjectMatch(

--- a/tests/beatmap/basicEventTypesForKeywords.test.ts
+++ b/tests/beatmap/basicEventTypesForKeywords.test.ts
@@ -1,5 +1,5 @@
-import { assertEquals, BasicEventTypesForKeywords, v2, v3 } from '../deps.ts';
 import { assertObjectMatch } from '../assert.ts';
+import { assertEquals, BasicEventTypesForKeywords, v2, v3 } from '../deps.ts';
 
 const schemaList = [
    [v3.basicEventTypesForKeywords, 'V3 Basic Event Types For Keywords'],
@@ -43,7 +43,8 @@ for (const tup of schemaList) {
    const nameTag = tup[1];
    const schema = tup[0];
    Deno.test(`${nameTag} from JSON instantiation`, () => {
-      let obj = new BaseClass(schema.deserialize());
+      // deno-lint-ignore no-explicit-any
+      let obj = new BaseClass(schema.deserialize({} as any));
       assertObjectMatch(
          obj,
          defaultValue,
@@ -52,11 +53,19 @@ for (const tup of schemaList) {
 
       switch (schema) {
          case v3.basicEventTypesForKeywords:
-            obj = new BaseClass(schema.deserialize({ k: 'test', e: [1, 2] }));
+            obj = new BaseClass(
+               (schema as typeof v3.basicEventTypesForKeywords).deserialize({
+                  k: 'test',
+                  e: [1, 2],
+               }),
+            );
             break;
          case v2.basicEventTypesForKeywords:
             obj = new BaseClass(
-               schema.deserialize({ _keyword: 'test', _specialEvents: [1, 2] }),
+               (schema as typeof v2.basicEventTypesForKeywords).deserialize({
+                  _keyword: 'test',
+                  _specialEvents: [1, 2],
+               }),
             );
             break;
       }
@@ -68,11 +77,15 @@ for (const tup of schemaList) {
 
       switch (schema) {
          case v3.basicEventTypesForKeywords:
-            obj = new BaseClass(schema.deserialize({ e: [1, 2] }));
+            obj = new BaseClass(
+               (schema as typeof v3.basicEventTypesForKeywords).deserialize({
+                  e: [1, 2],
+               }),
+            );
             break;
          case v2.basicEventTypesForKeywords:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v2.basicEventTypesForKeywords).deserialize({
                   _specialEvents: [1, 2],
                }),
             );

--- a/tests/beatmap/bombNote.test.ts
+++ b/tests/beatmap/bombNote.test.ts
@@ -1,5 +1,5 @@
-import { assertEquals, BombNote, v1, v2, v3, v4 } from '../deps.ts';
 import { assertObjectMatch } from '../assert.ts';
+import { assertEquals, BombNote, v1, v2, v3, v4 } from '../deps.ts';
 
 const schemaList = [
    [v4.bombNote, 'V4 Bomb Note'],
@@ -57,7 +57,8 @@ for (const tup of schemaList) {
    const nameTag = tup[1];
    const schema = tup[0];
    Deno.test(`${nameTag} from JSON instantiation`, () => {
-      let obj = new BaseClass(schema.deserialize());
+      // deno-lint-ignore no-explicit-any
+      let obj = new BaseClass(schema.deserialize({} as any));
       assertObjectMatch(
          obj,
          defaultValue,
@@ -67,7 +68,7 @@ for (const tup of schemaList) {
       switch (schema) {
          case v4.bombNote:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v4.bombNote).deserialize({
                   object: { b: 1, i: 0, r: 15 },
                   data: { x: 3, y: 4, customData: { test: true } },
                }),
@@ -75,7 +76,7 @@ for (const tup of schemaList) {
             break;
          case v3.bombNote:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v3.bombNote).deserialize({
                   b: 1,
                   x: 3,
                   y: 4,
@@ -84,13 +85,23 @@ for (const tup of schemaList) {
             );
             break;
          case v2.bombNote:
-         case v1.bombNote:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v2.bombNote).deserialize({
                   _time: 1,
                   _lineIndex: 3,
                   _lineLayer: 4,
                   _customData: { test: true },
+               }),
+            );
+            break;
+         case v1.bombNote:
+            obj = new BaseClass(
+               (schema as typeof v1.bombNote).deserialize({
+                  _time: 1,
+                  _lineIndex: 3,
+                  _lineLayer: 4,
+                  _type: 3,
+                  _cutDirection: 0,
                }),
             );
             break;
@@ -110,24 +121,36 @@ for (const tup of schemaList) {
       switch (schema) {
          case v4.bombNote:
             obj = new BaseClass(
-               schema.deserialize({ object: { b: 1 }, data: { x: 3 } }),
+               (schema as typeof v4.bombNote).deserialize({
+                  object: {
+                     b: 1,
+                  },
+                  data: {
+                     x: 3,
+                  },
+               }),
             );
             break;
          case v3.bombNote:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v3.bombNote).deserialize({
                   b: 1,
                   x: 3,
                }),
             );
             break;
          case v2.bombNote:
-         case v1.bombNote:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v2.bombNote).deserialize({
                   _time: 1,
                   _lineIndex: 3,
                }),
+            );
+            break;
+         case v1.bombNote:
+            obj = new BaseClass(
+               // @ts-expect-error awaiting updated type definitions from outgoing pull request
+               (schema as typeof v1.bombNote).deserialize({ _time: 1, _lineIndex: 3 }),
             );
             break;
       }

--- a/tests/beatmap/bpmEvent.test.ts
+++ b/tests/beatmap/bpmEvent.test.ts
@@ -1,5 +1,5 @@
-import { assertEquals, BPMEvent, v1, v2, v3 } from '../deps.ts';
 import { assertObjectMatch } from '../assert.ts';
+import { assertEquals, BPMEvent, v1, v2, v3 } from '../deps.ts';
 
 const schemaList = [
    [v3.bpmEvent, 'V3 BPM Event'],
@@ -51,7 +51,8 @@ for (const tup of schemaList) {
    const nameTag = tup[1];
    const schema = tup[0];
    Deno.test(`${nameTag} from JSON instantiation`, () => {
-      let obj = new BaseClass(schema.deserialize());
+      // deno-lint-ignore no-explicit-any
+      let obj = new BaseClass(schema.deserialize({} as any));
       assertObjectMatch(
          obj,
          defaultValue,
@@ -61,12 +62,16 @@ for (const tup of schemaList) {
       switch (schema) {
          case v3.bpmEvent:
             obj = new BaseClass(
-               schema.deserialize({ b: 1, m: 120, customData: { test: true } }),
+               (schema as typeof v3.bpmEvent).deserialize({
+                  b: 1,
+                  m: 120,
+                  customData: { test: true },
+               }),
             );
             break;
          case v2.bpmEvent:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v2.bpmEvent).deserialize({
                   _time: 1,
                   _floatValue: 120,
                   _customData: { test: true },
@@ -74,7 +79,13 @@ for (const tup of schemaList) {
             );
             break;
          case v1.bpmEvent:
-            obj = new BaseClass(schema.deserialize({ _time: 1, _value: 120 }));
+            obj = new BaseClass(
+               (schema as typeof v1.bpmEvent).deserialize({
+                  _time: 1,
+                  _type: 100,
+                  _value: 120,
+               }),
+            );
             break;
       }
       assertObjectMatch(
@@ -85,13 +96,26 @@ for (const tup of schemaList) {
 
       switch (schema) {
          case v3.bpmEvent:
-            obj = new BaseClass(schema.deserialize({ m: 120 }));
+            obj = new BaseClass(
+               (schema as typeof v3.bpmEvent).deserialize({
+                  m: 120,
+               }),
+            );
             break;
          case v2.bpmEvent:
-            obj = new BaseClass(schema.deserialize({ _floatValue: 120 }));
+            obj = new BaseClass(
+               (schema as typeof v2.bpmEvent).deserialize({
+                  _floatValue: 120,
+               }),
+            );
             break;
          case v1.bpmEvent:
-            obj = new BaseClass(schema.deserialize({ _value: 120 }));
+            obj = new BaseClass(
+               // @ts-expect-error awaiting updated type definitions from outgoing pull request
+               (schema as typeof v1.bpmEvent).deserialize({
+                  _value: 120,
+               }),
+            );
             break;
       }
       assertObjectMatch(

--- a/tests/beatmap/chain.test.ts
+++ b/tests/beatmap/chain.test.ts
@@ -1,5 +1,5 @@
-import { assertEquals, Chain, v3, v4 } from '../deps.ts';
 import { assertObjectMatch } from '../assert.ts';
+import { assertEquals, Chain, v3, v4 } from '../deps.ts';
 
 const schemaList = [
    [v4.chain, 'V4 Chain'],
@@ -93,7 +93,8 @@ for (const tup of schemaList) {
    const nameTag = tup[1];
    const schema = tup[0];
    Deno.test(`${nameTag} from JSON instantiation`, () => {
-      let obj = new BaseClass(schema.deserialize());
+      // deno-lint-ignore no-explicit-any
+      let obj = new BaseClass(schema.deserialize({} as any));
       assertObjectMatch(
          obj,
          defaultValue,
@@ -103,7 +104,7 @@ for (const tup of schemaList) {
       switch (schema) {
          case v4.chain:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v4.chain).deserialize({
                   object: {
                      hb: 1,
                      hr: 15,
@@ -133,7 +134,7 @@ for (const tup of schemaList) {
             break;
          case v3.chain:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v3.chain).deserialize({
                   b: 1,
                   c: 1,
                   x: 2,
@@ -172,7 +173,7 @@ for (const tup of schemaList) {
       switch (schema) {
          case v4.chain:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v4.chain).deserialize({
                   object: {
                      tb: 2,
                   },
@@ -191,7 +192,7 @@ for (const tup of schemaList) {
             break;
          case v3.chain:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v3.chain).deserialize({
                   x: 2,
                   y: 3,
                   tb: 2,

--- a/tests/beatmap/colorBoostEvent.test.ts
+++ b/tests/beatmap/colorBoostEvent.test.ts
@@ -1,5 +1,5 @@
-import { assertEquals, ColorBoostEvent, v1, v2, v3, v4 } from '../deps.ts';
 import { assertObjectMatch } from '../assert.ts';
+import { assertEquals, ColorBoostEvent, v1, v2, v3, v4 } from '../deps.ts';
 
 const schemaList = [
    [v4.colorBoostEvent, 'V4 Color Boost Event'],
@@ -52,7 +52,8 @@ for (const tup of schemaList) {
    const nameTag = tup[1];
    const schema = tup[0];
    Deno.test(`${nameTag} from JSON instantiation`, () => {
-      let obj = new BaseClass(schema.deserialize());
+      // deno-lint-ignore no-explicit-any
+      let obj = new BaseClass(schema.deserialize({} as any));
       assertObjectMatch(
          obj,
          defaultValue,
@@ -62,20 +63,29 @@ for (const tup of schemaList) {
       switch (schema) {
          case v4.colorBoostEvent:
             obj = new BaseClass(
-               schema.deserialize({
-                  object: { b: 1 },
-                  data: { b: 1, customData: { test: true } },
+               (schema as typeof v4.colorBoostEvent).deserialize({
+                  object: {
+                     b: 1,
+                  },
+                  data: {
+                     b: 1,
+                     customData: { test: true },
+                  },
                }),
             );
             break;
          case v3.colorBoostEvent:
             obj = new BaseClass(
-               schema.deserialize({ b: 1, o: true, customData: { test: true } }),
+               (schema as typeof v3.colorBoostEvent).deserialize({
+                  b: 1,
+                  o: true,
+                  customData: { test: true },
+               }),
             );
             break;
          case v2.colorBoostEvent:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v2.colorBoostEvent).deserialize({
                   _time: 1,
                   _type: 5,
                   _value: 1,
@@ -86,7 +96,11 @@ for (const tup of schemaList) {
             break;
          case v1.colorBoostEvent:
             obj = new BaseClass(
-               schema.deserialize({ _time: 1, _type: 5, _value: 1 }),
+               (schema as typeof v1.colorBoostEvent).deserialize({
+                  _time: 1,
+                  _type: 5,
+                  _value: 1,
+               }),
             );
             break;
       }
@@ -102,16 +116,34 @@ for (const tup of schemaList) {
 
       switch (schema) {
          case v4.colorBoostEvent:
-            obj = new BaseClass(schema.deserialize({ object: { b: 1 } }));
+            obj = new BaseClass(
+               (schema as typeof v4.colorBoostEvent).deserialize({
+                  object: {
+                     b: 1,
+                  },
+                  data: {},
+               }),
+            );
             break;
          case v3.colorBoostEvent:
-            obj = new BaseClass(schema.deserialize({ b: 1 }));
+            obj = new BaseClass(
+               (schema as typeof v3.colorBoostEvent).deserialize({
+                  b: 1,
+               }),
+            );
             break;
          case v2.colorBoostEvent:
-            obj = new BaseClass(schema.deserialize({ _time: 1 }));
+            obj = new BaseClass((schema as typeof v2.colorBoostEvent).deserialize({
+               _time: 1,
+            }));
             break;
          case v1.colorBoostEvent:
-            obj = new BaseClass(schema.deserialize({ _time: 1 }));
+            obj = new BaseClass(
+               // @ts-expect-error awaiting updated type definitions from outgoing pull request
+               (schema as typeof v1.colorBoostEvent).deserialize({
+                  _time: 1,
+               }),
+            );
             break;
       }
       assertObjectMatch(

--- a/tests/beatmap/colorNote.test.ts
+++ b/tests/beatmap/colorNote.test.ts
@@ -1,5 +1,5 @@
-import { assertEquals, ColorNote, v1, v2, v3, v4 } from '../deps.ts';
 import { assertObjectMatch } from '../assert.ts';
+import { assertEquals, ColorNote, v1, v2, v3, v4 } from '../deps.ts';
 
 const schemaList = [
    [v4.colorNote, 'V4 Color Note'],
@@ -74,7 +74,8 @@ for (const tup of schemaList) {
    const nameTag = tup[1];
    const schema = tup[0];
    Deno.test(`${nameTag} from JSON instantiation`, () => {
-      let obj = new BaseClass(schema.deserialize());
+      // deno-lint-ignore no-explicit-any
+      let obj = new BaseClass(schema.deserialize({} as any));
       assertObjectMatch(
          obj,
          defaultValue,
@@ -84,7 +85,7 @@ for (const tup of schemaList) {
       switch (schema) {
          case v4.colorNote:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v4.colorNote).deserialize({
                   object: {
                      b: 1,
                      i: 0,
@@ -103,7 +104,7 @@ for (const tup of schemaList) {
             break;
          case v3.colorNote:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v3.colorNote).deserialize({
                   b: 1,
                   c: 1,
                   x: 2,
@@ -116,7 +117,7 @@ for (const tup of schemaList) {
             break;
          case v2.colorNote:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v2.colorNote).deserialize({
                   _time: 1,
                   _lineIndex: 2,
                   _lineLayer: 3,
@@ -128,7 +129,7 @@ for (const tup of schemaList) {
             break;
          case v1.colorNote:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v1.colorNote).deserialize({
                   _time: 1,
                   _lineIndex: 2,
                   _lineLayer: 3,
@@ -160,7 +161,7 @@ for (const tup of schemaList) {
       switch (schema) {
          case v4.colorNote:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v4.colorNote).deserialize({
                   object: {
                      b: 1,
                   },
@@ -173,7 +174,7 @@ for (const tup of schemaList) {
             break;
          case v3.colorNote:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v3.colorNote).deserialize({
                   b: 1,
                   x: 2,
                   d: 2,
@@ -182,7 +183,7 @@ for (const tup of schemaList) {
             break;
          case v2.colorNote:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v2.colorNote).deserialize({
                   _time: 1,
                   _lineIndex: 2,
                   _cutDirection: 2,
@@ -191,7 +192,8 @@ for (const tup of schemaList) {
             break;
          case v1.colorNote:
             obj = new BaseClass(
-               schema.deserialize({
+               // @ts-expect-error awaiting updated type definitions from outgoing pull request
+               (schema as typeof v1.colorNote).deserialize({
                   _time: 1,
                   _lineIndex: 2,
                   _cutDirection: 2,

--- a/tests/beatmap/fxEventBoxGroup.test.ts
+++ b/tests/beatmap/fxEventBoxGroup.test.ts
@@ -1,5 +1,5 @@
-import { assertEquals, FxEventBoxGroup, types, v3, v4 } from '../deps.ts';
 import { assertObjectMatch } from '../assert.ts';
+import { assertEquals, FxEventBoxGroup, types, v3, v4 } from '../deps.ts';
 
 const schemaList = [
    [v4.fxEventBoxGroup, 'V4 Fx Event Event Box Group'],
@@ -178,7 +178,8 @@ for (const tup of schemaList) {
    const nameTag = tup[1];
    const schema = tup[0];
    Deno.test(`${nameTag} from JSON instantiation`, () => {
-      let obj = new BaseClass(schema.deserialize());
+      // deno-lint-ignore no-explicit-any
+      let obj = new BaseClass(schema.deserialize({} as any));
       assertObjectMatch(
          obj,
          defaultValue,
@@ -247,6 +248,7 @@ for (const tup of schemaList) {
                (schema as typeof v3.fxEventBoxGroup).deserialize({
                   object: {
                      b: 1,
+                     t: 1,
                      g: 2,
                      e: [],
                   },
@@ -349,6 +351,7 @@ for (const tup of schemaList) {
                         eventData: [
                            {
                               data: { v: 420 },
+                              time: 0,
                            },
                         ],
                         filterData: {
@@ -367,6 +370,7 @@ for (const tup of schemaList) {
                (schema as typeof v3.fxEventBoxGroup).deserialize({
                   object: {
                      b: 1,
+                     t: 1,
                      e: [],
                   },
                   boxData: [

--- a/tests/beatmap/indexFilter.test.ts
+++ b/tests/beatmap/indexFilter.test.ts
@@ -1,5 +1,5 @@
-import { assertEquals, IndexFilter, v3, v4 } from '../deps.ts';
 import { assertObjectMatch } from '../assert.ts';
+import { assertEquals, IndexFilter, v3, v4 } from '../deps.ts';
 
 const schemaList = [
    [v4.indexFilter, 'V4 Index Filter'],
@@ -76,7 +76,8 @@ for (const tup of schemaList) {
    const nameTag = tup[1];
    const schema = tup[0];
    Deno.test(`${nameTag} from JSON instantiation`, () => {
-      let obj = new BaseClass(schema.deserialize());
+      // deno-lint-ignore no-explicit-any
+      let obj = new BaseClass(schema.deserialize({} as any));
       assertObjectMatch(
          obj,
          defaultValue,
@@ -85,19 +86,36 @@ for (const tup of schemaList) {
 
       switch (schema) {
          case v4.indexFilter:
+            obj = new BaseClass(
+               (schema as typeof v4.indexFilter).deserialize({
+                  f: 2,
+                  p: 1,
+                  t: 2,
+                  r: 1,
+                  c: 4,
+                  n: 2,
+                  s: 12345,
+                  l: 1,
+                  d: 3,
+                  customData: { test: true },
+               }),
+            );
+            break;
          case v3.indexFilter:
-            obj = new BaseClass(schema.deserialize({
-               f: 2,
-               p: 1,
-               t: 2,
-               r: 1,
-               c: 4,
-               n: 2,
-               s: 12345,
-               l: 1,
-               d: 3,
-               customData: { test: true },
-            }));
+            obj = new BaseClass(
+               (schema as typeof v3.indexFilter).deserialize({
+                  f: 2,
+                  p: 1,
+                  t: 2,
+                  r: 1,
+                  c: 4,
+                  n: 2,
+                  s: 12345,
+                  l: 1,
+                  d: 3,
+                  customData: { test: true },
+               }),
+            );
             break;
       }
       assertObjectMatch(
@@ -119,12 +137,22 @@ for (const tup of schemaList) {
 
       switch (schema) {
          case v4.indexFilter:
+            obj = new BaseClass(
+               (schema as typeof v4.indexFilter).deserialize({
+                  f: 2,
+                  p: 1,
+                  n: 2,
+               }),
+            );
+            break;
          case v3.indexFilter:
-            obj = new BaseClass(schema.deserialize({
-               f: 2,
-               p: 1,
-               n: 2,
-            }));
+            obj = new BaseClass(
+               (schema as typeof v3.indexFilter).deserialize({
+                  f: 2,
+                  p: 1,
+                  n: 2,
+               }),
+            );
             break;
       }
       assertObjectMatch(

--- a/tests/beatmap/lightColorEventBoxGroup.test.ts
+++ b/tests/beatmap/lightColorEventBoxGroup.test.ts
@@ -1,5 +1,5 @@
-import { assertEquals, LightColorEventBoxGroup, types, v3, v4 } from '../deps.ts';
 import { assertObjectMatch } from '../assert.ts';
+import { assertEquals, LightColorEventBoxGroup, types, v3, v4 } from '../deps.ts';
 
 const schemaList = [
    [v4.lightColorEventBoxGroup, 'V4 Light Color Event Box Group'],
@@ -191,7 +191,8 @@ for (const tup of schemaList) {
    const nameTag = tup[1];
    const schema = tup[0];
    Deno.test(`${nameTag} from JSON instantiation`, () => {
-      let obj = new BaseClass(schema.deserialize());
+      // deno-lint-ignore no-explicit-any
+      let obj = new BaseClass(schema.deserialize({} as any));
       assertObjectMatch(
          obj,
          defaultValue,
@@ -201,7 +202,7 @@ for (const tup of schemaList) {
       switch (schema) {
          case v4.lightColorEventBoxGroup:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v4.lightColorEventBoxGroup).deserialize({
                   object: {
                      t: types.EventBoxType.COLOR,
                      b: 1,
@@ -262,7 +263,7 @@ for (const tup of schemaList) {
             break;
          case v3.lightColorEventBoxGroup:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v3.lightColorEventBoxGroup).deserialize({
                   b: 1,
                   g: 2,
                   e: [
@@ -353,7 +354,7 @@ for (const tup of schemaList) {
       switch (schema) {
          case v4.lightColorEventBoxGroup:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v4.lightColorEventBoxGroup).deserialize({
                   object: {
                      t: types.EventBoxType.COLOR,
                      b: 1,
@@ -389,7 +390,7 @@ for (const tup of schemaList) {
             break;
          case v3.lightColorEventBoxGroup:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v3.lightColorEventBoxGroup).deserialize({
                   b: 1,
                   e: [
                      {

--- a/tests/beatmap/lightRotationEventBoxGroup.test.ts
+++ b/tests/beatmap/lightRotationEventBoxGroup.test.ts
@@ -1,5 +1,5 @@
-import { assertEquals, LightRotationEventBoxGroup, types, v3, v4 } from '../deps.ts';
 import { assertObjectMatch } from '../assert.ts';
+import { assertEquals, LightRotationEventBoxGroup, types, v3, v4 } from '../deps.ts';
 
 const schemaList = [
    [v4.lightRotationEventBoxGroup, 'V4 Light Rotation Event Box Group'],
@@ -192,7 +192,8 @@ for (const tup of schemaList) {
    const nameTag = tup[1];
    const schema = tup[0];
    Deno.test(`${nameTag} from JSON instantiation`, () => {
-      let obj = new BaseClass(schema.deserialize());
+      // deno-lint-ignore no-explicit-any
+      let obj = new BaseClass(schema.deserialize({} as any));
       assertObjectMatch(
          obj,
          defaultValue,
@@ -202,9 +203,9 @@ for (const tup of schemaList) {
       switch (schema) {
          case v4.lightRotationEventBoxGroup:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v4.lightRotationEventBoxGroup).deserialize({
                   object: {
-                     t: types.EventBoxType.COLOR,
+                     t: types.EventBoxType.ROTATION,
                      b: 1,
                      g: 2,
                      e: [
@@ -262,7 +263,7 @@ for (const tup of schemaList) {
             break;
          case v3.lightRotationEventBoxGroup:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v3.lightRotationEventBoxGroup).deserialize({
                   b: 1,
                   g: 2,
                   e: [
@@ -354,9 +355,9 @@ for (const tup of schemaList) {
       switch (schema) {
          case v4.lightRotationEventBoxGroup:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v4.lightRotationEventBoxGroup).deserialize({
                   object: {
-                     t: types.EventBoxType.COLOR,
+                     t: types.EventBoxType.ROTATION,
                      b: 1,
                   },
                   boxData: [
@@ -388,7 +389,7 @@ for (const tup of schemaList) {
             break;
          case v3.lightRotationEventBoxGroup:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v3.lightRotationEventBoxGroup).deserialize({
                   b: 1,
                   e: [
                      {

--- a/tests/beatmap/lightTranslationEventBoxGroup.test.ts
+++ b/tests/beatmap/lightTranslationEventBoxGroup.test.ts
@@ -1,5 +1,5 @@
-import { assertEquals, LightTranslationEventBoxGroup, types, v3, v4 } from '../deps.ts';
 import { assertObjectMatch } from '../assert.ts';
+import { assertEquals, LightTranslationEventBoxGroup, types, v3, v4 } from '../deps.ts';
 
 const schemaList = [
    [v4.lightTranslationEventBoxGroup, 'V4 Light Translation Event Box Group'],
@@ -185,7 +185,8 @@ for (const tup of schemaList) {
    const nameTag = tup[1];
    const schema = tup[0];
    Deno.test(`${nameTag} from JSON instantiation`, () => {
-      let obj = new BaseClass(schema.deserialize());
+      // deno-lint-ignore no-explicit-any
+      let obj = new BaseClass(schema.deserialize({} as any));
       assertObjectMatch(
          obj,
          defaultValue,
@@ -195,8 +196,9 @@ for (const tup of schemaList) {
       switch (schema) {
          case v4.lightTranslationEventBoxGroup:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v4.lightTranslationEventBoxGroup).deserialize({
                   object: {
+                     t: types.EventBoxType.TRANSLATION,
                      b: 1,
                      g: 2,
                      e: [
@@ -252,7 +254,7 @@ for (const tup of schemaList) {
             break;
          case v3.lightTranslationEventBoxGroup:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v3.lightTranslationEventBoxGroup).deserialize({
                   b: 1,
                   g: 2,
                   e: [
@@ -339,8 +341,9 @@ for (const tup of schemaList) {
       switch (schema) {
          case v4.lightTranslationEventBoxGroup:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v4.lightTranslationEventBoxGroup).deserialize({
                   object: {
+                     t: types.EventBoxType.TRANSLATION,
                      b: 1,
                   },
                   boxData: [
@@ -373,7 +376,7 @@ for (const tup of schemaList) {
             break;
          case v3.lightTranslationEventBoxGroup:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v3.lightTranslationEventBoxGroup).deserialize({
                   b: 1,
                   e: [
                      {

--- a/tests/beatmap/obstacle.test.ts
+++ b/tests/beatmap/obstacle.test.ts
@@ -1,5 +1,5 @@
-import { assertEquals, Obstacle, v1, v2, v3, v4 } from '../deps.ts';
 import { assertObjectMatch } from '../assert.ts';
+import { assertEquals, Obstacle, v1, v2, v3, v4 } from '../deps.ts';
 
 const schemaList = [
    [v4.obstacle, 'V4 Obstacle'],
@@ -79,7 +79,8 @@ for (const tup of schemaList) {
    const nameTag = tup[1];
    const schema = tup[0];
    Deno.test(`${nameTag} from JSON instantiation`, () => {
-      let obj = new BaseClass(schema.deserialize());
+      // deno-lint-ignore no-explicit-any
+      let obj = new BaseClass(schema.deserialize({} as any));
       assertObjectMatch(
          obj,
          {
@@ -92,7 +93,7 @@ for (const tup of schemaList) {
       switch (schema) {
          case v4.obstacle:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v4.obstacle).deserialize({
                   object: { b: 1, i: 0, r: 15 },
                   data: {
                      x: 2,
@@ -107,7 +108,7 @@ for (const tup of schemaList) {
             break;
          case v3.obstacle:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v3.obstacle).deserialize({
                   b: 1,
                   x: 2,
                   y: 2,
@@ -120,7 +121,7 @@ for (const tup of schemaList) {
             break;
          case v2.obstacle:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v2.obstacle).deserialize({
                   _time: 1,
                   _lineIndex: 2,
                   _type: 1,
@@ -132,7 +133,7 @@ for (const tup of schemaList) {
             break;
          case v1.obstacle:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v1.obstacle).deserialize({
                   _time: 1,
                   _lineIndex: 2,
                   _type: 1,
@@ -160,12 +161,17 @@ for (const tup of schemaList) {
       switch (schema) {
          case v4.obstacle:
             obj = new BaseClass(
-               schema.deserialize({ object: { b: 1 }, data: { w: 2 } }),
+               (schema as typeof v4.obstacle).deserialize({
+                  object: { b: 1 },
+                  data: {
+                     w: 2,
+                  },
+               }),
             );
             break;
          case v3.obstacle:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v3.obstacle).deserialize({
                   b: 1,
                   w: 2,
                }),
@@ -173,7 +179,7 @@ for (const tup of schemaList) {
             break;
          case v2.obstacle:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v2.obstacle).deserialize({
                   _time: 1,
                   _width: 2,
                }),
@@ -181,7 +187,8 @@ for (const tup of schemaList) {
             break;
          case v1.obstacle:
             obj = new BaseClass(
-               schema.deserialize({
+               // @ts-expect-error awaiting updated type definitions from outgoing pull request
+               (schema as typeof v1.obstacle).deserialize({
                   _time: 1,
                   _width: 2,
                }),

--- a/tests/beatmap/rotationEvent.test.ts
+++ b/tests/beatmap/rotationEvent.test.ts
@@ -1,5 +1,5 @@
-import { assertEquals, RotationEvent, v1, v2, v3, v4 } from '../deps.ts';
 import { assertObjectMatch } from '../assert.ts';
+import { assertEquals, RotationEvent, v1, v2, v3, v4 } from '../deps.ts';
 
 const schemaList = [
    [v4.rotationEvent, 'V4 Rotation Event'],
@@ -62,7 +62,8 @@ for (const tup of schemaList) {
    const nameTag = tup[1];
    const schema = tup[0];
    Deno.test(`${nameTag} from JSON instantiation`, () => {
-      let obj = new BaseClass(schema.deserialize());
+      // deno-lint-ignore no-explicit-any
+      let obj = new BaseClass(schema.deserialize({} as any));
       assertObjectMatch(
          obj,
          {
@@ -75,15 +76,19 @@ for (const tup of schemaList) {
       switch (schema) {
          case v4.rotationEvent:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v4.rotationEvent).deserialize({
                   object: { b: 1 },
-                  data: { e: 1, r: 15, customData: { test: true } },
+                  data: {
+                     e: 1,
+                     r: 15,
+                     customData: { test: true },
+                  },
                }),
             );
             break;
          case v3.rotationEvent:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v3.rotationEvent).deserialize({
                   b: 1,
                   e: 1,
                   r: 15,
@@ -93,7 +98,7 @@ for (const tup of schemaList) {
             break;
          case v2.rotationEvent:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v2.rotationEvent).deserialize({
                   _time: 1,
                   _type: 15,
                   _value: 4,
@@ -103,7 +108,7 @@ for (const tup of schemaList) {
             break;
          case v1.rotationEvent:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v1.rotationEvent).deserialize({
                   _time: 1,
                   _type: 15,
                   _value: 4,
@@ -125,28 +130,30 @@ for (const tup of schemaList) {
       switch (schema) {
          case v4.rotationEvent:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v4.rotationEvent).deserialize({
+                  object: {},
                   data: { r: 15 },
                }),
             );
             break;
          case v3.rotationEvent:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v3.rotationEvent).deserialize({
                   r: 15,
                }),
             );
             break;
          case v2.rotationEvent:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v2.rotationEvent).deserialize({
                   _value: 4,
                }),
             );
             break;
          case v1.rotationEvent:
             obj = new BaseClass(
-               schema.deserialize({
+               // @ts-expect-error awaiting updated type definitions from outgoing pull request
+               (schema as typeof v1.rotationEvent).deserialize({
                   _value: 4,
                }),
             );

--- a/tests/beatmap/waypoint.test.ts
+++ b/tests/beatmap/waypoint.test.ts
@@ -1,5 +1,5 @@
-import { assertEquals, v2, v3, v4, Waypoint } from '../deps.ts';
 import { assertObjectMatch } from '../assert.ts';
+import { assertEquals, v2, v3, v4, Waypoint } from '../deps.ts';
 
 const schemaList = [
    [v4.waypoint, 'V4 Waypoint'],
@@ -68,7 +68,8 @@ for (const tup of schemaList) {
    const nameTag = tup[1];
    const schema = tup[0];
    Deno.test(`${nameTag} from JSON instantiation`, () => {
-      let obj = new BaseClass(schema.deserialize());
+      // deno-lint-ignore no-explicit-any
+      let obj = new BaseClass(schema.deserialize({} as any));
       assertObjectMatch(
          obj,
          defaultValue,
@@ -78,15 +79,20 @@ for (const tup of schemaList) {
       switch (schema) {
          case v4.waypoint:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v4.waypoint).deserialize({
                   object: { b: 2.5, i: 0, r: 15 },
-                  data: { x: 2, y: 1, d: 3, customData: { test: true } },
+                  data: {
+                     x: 2,
+                     y: 1,
+                     d: 3,
+                     customData: { test: true },
+                  },
                }),
             );
             break;
          case v3.waypoint:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v3.waypoint).deserialize({
                   b: 2.5,
                   x: 2,
                   y: 1,
@@ -97,7 +103,7 @@ for (const tup of schemaList) {
             break;
          case v2.waypoint:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v2.waypoint).deserialize({
                   _time: 2.5,
                   _lineIndex: 2,
                   _lineLayer: 1,
@@ -122,11 +128,16 @@ for (const tup of schemaList) {
 
       switch (schema) {
          case v4.waypoint:
-            obj = new BaseClass(schema.deserialize({ data: { y: 1, d: 3 } }));
+            obj = new BaseClass(
+               (schema as typeof v4.waypoint).deserialize({
+                  object: {},
+                  data: { y: 1, d: 3 },
+               }),
+            );
             break;
          case v3.waypoint:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v3.waypoint).deserialize({
                   y: 1,
                   d: 3,
                }),
@@ -134,7 +145,7 @@ for (const tup of schemaList) {
             break;
          case v2.waypoint:
             obj = new BaseClass(
-               schema.deserialize({
+               (schema as typeof v2.waypoint).deserialize({
                   _lineLayer: 1,
                   _offsetDirection: 3,
                }),

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -2,8 +2,8 @@ import type { v2 } from '../src/types/mod.ts';
 import { assertObjectMatch } from './assert.ts';
 import {
    assertEquals,
-   Beatmap,
-   ColorNote,
+   createBeatmap,
+   createColorNote,
    loadDifficulty,
    readDifficultyFile,
    readDifficultyFileSync,
@@ -167,9 +167,9 @@ Deno.test('using custom wrappers', () => {
    const difficulty = saveDifficulty(beatmap, {
       preprocess: [
          (x) => {
-            return Beatmap.createOne({
+            return createBeatmap({
                version: x.version,
-               difficulty: { colorNotes: x.foo.map((x) => ColorNote.createOne({ time: x.t })) },
+               difficulty: { colorNotes: x.foo.map((x) => createColorNote({ time: x.t })) },
             });
          },
       ],


### PR DESCRIPTION
this pr makes lots of internal changes to remove the hard dependency on the wrapper class implementations for various functions, primarily for beatmap helpers and loader/saver functions. this enables them to be more usable in situations where the wrapper classes are not compatible or viable with certain architectures, such as browser storage and redux state (which in the case of the latter, strips all non-serializable objects out of the state models and expects update logic to be performed without side effects).

most of the changes here boil down to type updates and new abstractions for wrapper class methods and common logic, but i'll summarize the points of interest below to give you a better idea of what to expect when reviewing the changes, since the PR looks a lot bigger than what the overall impact of these changes should be in hindsight.

also the changes here shouldn't conflict with any of the outgoing changes in #3, so feel free to suggest any changes and/or merge this when ready.

## Overview

- all helper methods for wrapper class objects have been broken off into new standalone functions (see `src/beatmap/helpers/core/mod.ts`)
- each wrapper object type now provides a pure functional constructor that strictly returns serializable attributes (akin to class constructor or static `createOne` methods *without references to the classes*). in theory, this should allow bundlers to more effectively tree-shake the classes out of the bundle entirely when they are not being used.
- many functions now take in *only the necessary attributes* needed for their logic to pass. this removes the need to explicitly reimplement *all* wrapper class properties (including functions) to use these helpers outside of the context of the classes or via standalone calls.
- types for schema containers are now defined as-is, since defaulting to partial types can be slightly misleading for certain wrapper/serial types that don't support optionaliaztion.
- all schema containers now support a new `options` parameter that can be used to pass in polyfills or flags for configurable controls over serialization behavior.
- loader/saver functions now have improved inference for wrapper and serial types. generics for these functions along with reader/writer have also been made consistent for a better mental model and control flow for generic types: 
  `<TFileType, TVersion, TWrapper, TSerial>`.
- for loader/saver functions, the first preprocessor and last postprocessor will allow you to transform the input/output types for loader/saver functions (see e2e test for a basic example of this behavior in action). not really intended for most use cases, but will be a nice escape hatch for situations like mine that use custom wrapper types for beatmapper and would otherwise create a lot more work for proper integration 🙃

## Breaking Changes

- loader/saver/reader/writer functions no longer return a full wrapper class object, and will only return the subset of serializable attributes. this was a necessary trade-off since the goal was to move away from the class implementations and their respective side-effects, but it's not a huge loss imo since you can always re-wrap the return types with the appropriate constructor or add a postprocessor if you need/prefer the class form:
 
  ```ts
  // before:
  const beatmap = readDifficultyFileSync('ExpertPlusStandard.dat');
  beatmap.addColorNotes([]); // now errors: class methods are no longer included by default

  // after:
  const beatmap = Beatmap.createOne(readDifficultyFileSync('ExpertPlusStandard.dat'));
  beatmap.addColorNotes([]); // works as expected.
  ```
